### PR TITLE
usb_host_msc: Add P4 support

### DIFF
--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.2 Unreleased
+## 1.1.2
 
 - Added support for ESP32-P4
 - Reverted zero-copy bulk transfers. Data are now copied to USB buffers with negligible effect on performance

--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.2 Unreleased
 
+- Added support for ESP32-P4
 - Reverted zero-copy bulk transfers. Data are now copied to USB buffers with negligible effect on performance
 
 ## 1.1.1

--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2 Unreleased
+
+- Reverted zero-copy bulk transfers. Data are now copied to USB buffers with negligible effect on performance
+
 ## 1.1.1
 
 - Fix `msc_host_get_device_info` for devices without Serial Number string descriptor https://github.com/espressif/esp-idf/issues/12163

--- a/host/class/msc/usb_host_msc/CMakeLists.txt
+++ b/host/class/msc/usb_host_msc/CMakeLists.txt
@@ -8,7 +8,3 @@ idf_component_register( SRCS ${sources}
                         PRIV_INCLUDE_DIRS private_include include/esp_private
                         REQUIRES usb fatfs
                         PRIV_REQUIRES heap )
-
-# We access packeted USB string descriptor via pointers. The memory used for storing the descritptors
-# allows unaligned access, so this is not an issue
-target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-address-of-packed-member)

--- a/host/class/msc/usb_host_msc/idf_component.yml
+++ b/host/class/msc/usb_host_msc/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.1.1~1"
+version: "1.1.2"
 description: USB Host MSC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/msc/usb_host_msc
 dependencies:

--- a/host/class/msc/usb_host_msc/private_include/msc_common.h
+++ b/host/class/msc/usb_host_msc/private_include/msc_common.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -42,15 +42,9 @@ typedef struct msc_host_device {
 } msc_device_t;
 
 /**
- * @brief Trigger a BULK transfer to device: zero copy
+ * @brief Trigger a BULK transfer to device
  *
  * Data buffer ownership is transferred to the MSC driver and the application cannot access it before the transfer finishes.
- * This function is true zero-copy only if the passed data buffer is in DMA capable memory, as the USB Host uses DMA transfers.
- * If the buffer is NOT DMA capable, an intermediate DMA capable buffer is allocated and used for the transfer, resulting in memory coping.
- *
- * This function significantly improves performance with C Standard Library, which creates its own buffer for each opened file.
- * The STD lib buffer is then used for USB transfers too, which eliminates need of 2 large buffers and unnecessary copying of the data.
- * The user can set size of the buffer with setvbuf() function.
  *
  * @param[in]    device_handle MSC device handle
  * @param[inout] data          Data buffer. Direction depends on 'ep'.
@@ -58,7 +52,7 @@ typedef struct msc_host_device {
  * @param[in]    ep            Direction of the transfer
  * @return esp_err_t
  */
-esp_err_t msc_bulk_transfer_zcpy(msc_device_t *device_handle, uint8_t *data, size_t size, msc_endpoint_t ep);
+esp_err_t msc_bulk_transfer(msc_device_t *device_handle, uint8_t *data, size_t size, msc_endpoint_t ep);
 
 /**
  * @brief Trigger a CTRL transfer to device

--- a/host/class/msc/usb_host_msc/src/msc_host.c
+++ b/host/class/msc/usb_host_msc/src/msc_host.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -616,51 +616,38 @@ static usb_transfer_status_t wait_for_transfer_done(usb_transfer_t *xfer)
     return status;
 }
 
-esp_err_t msc_bulk_transfer_zcpy(msc_device_t *device, uint8_t *data, size_t size, msc_endpoint_t ep)
+esp_err_t msc_bulk_transfer(msc_device_t *device, uint8_t *data, size_t size, msc_endpoint_t ep)
 {
     esp_err_t ret = ESP_OK;
-    uint8_t *data_cpy = NULL; // Pointer to copy of data in DMA capable region
-    bool realloc_data = !esp_ptr_dma_capable(data); // Flag that the data must be moved to DMA capable region
-
-    // Data that is not in DMA capable memory must be copied to DMA capable memory
-    if (realloc_data) {
-        data_cpy = heap_caps_malloc(size, MALLOC_CAP_DMA);
-        ESP_RETURN_ON_FALSE(data_cpy != NULL, ESP_ERR_NO_MEM, TAG, "Could not allocate %d bytes in DMA capable memory", size);
-    }
-
     usb_transfer_t *xfer = device->xfer;
-    uint8_t *backup_buffer = xfer->data_buffer;
-    size_t backup_size = xfer->data_buffer_size;
+    size_t transfer_size = (ep == MSC_EP_IN) ? usb_round_up_to_mps(size, device->config.bulk_in_mps) : size;
+
+    if (xfer->data_buffer_size < transfer_size) {
+        // The allocated buffer is not large enough -> realloc
+        MSC_RETURN_ON_ERROR( usb_host_transfer_free(xfer) );
+        MSC_RETURN_ON_ERROR( usb_host_transfer_alloc(transfer_size, 0, &device->xfer) );
+        xfer = device->xfer;
+    }
 
     if (ep == MSC_EP_IN) {
         xfer->bEndpointAddress = device->config.bulk_in_ep;
-        xfer->num_bytes = usb_round_up_to_mps(size, device->config.bulk_in_mps);
     } else {
         xfer->bEndpointAddress = device->config.bulk_out_ep;
-        xfer->num_bytes = size;
-        if (realloc_data) {
-            memcpy(data_cpy, data, size);
-        }
+        memcpy(xfer->data_buffer, data, size);
     }
 
-    // Get pointers to start of data buffer and buffer size, so we can change it
-    uint8_t **ptr = (uint8_t **)(&(xfer->data_buffer));
-    size_t *siz = (size_t *)(&(xfer->data_buffer_size));
-
-    // Attention: Here we modify 'private' members data_buffer and data_buffer_size
-    *ptr = realloc_data ? data_cpy : data; // This is actually xfer->data_buffer
-    *siz = xfer->num_bytes; // This is actually xfer->data_buffer_size
+    xfer->num_bytes = transfer_size;
     xfer->device_handle = device->handle;
     xfer->callback = transfer_callback;
     xfer->timeout_ms = 5000;
     xfer->context = device;
 
-    MSC_GOTO_ON_ERROR( usb_host_transfer_submit(xfer) );
+    MSC_RETURN_ON_ERROR( usb_host_transfer_submit(xfer) );
     const usb_transfer_status_t status = wait_for_transfer_done(xfer);
     switch (status) {
     case USB_TRANSFER_STATUS_COMPLETED:
-        if (realloc_data && (ep == MSC_EP_IN)) {
-            memcpy(data, data_cpy, xfer->actual_num_bytes);
+        if (ep == MSC_EP_IN) {
+            memcpy(data, xfer->data_buffer, xfer->actual_num_bytes);
         }
         ret = ESP_OK;
         break;
@@ -670,12 +657,6 @@ esp_err_t msc_bulk_transfer_zcpy(msc_device_t *device, uint8_t *data, size_t siz
         ret = ESP_ERR_MSC_INTERNAL; break;
     }
 
-fail:
-    if (realloc_data) {
-        heap_caps_free(data_cpy);
-    }
-    *ptr = backup_buffer;
-    *siz = backup_size;
     return ret;
 }
 

--- a/host/class/msc/usb_host_msc/src/msc_host.c
+++ b/host/class/msc/usb_host_msc/src/msc_host.c
@@ -543,7 +543,9 @@ static void copy_string_desc(wchar_t *dest, const usb_str_desc_t *src)
     }
     if (src != NULL) {
         size_t len = MIN((src->bLength - USB_STANDARD_DESC_SIZE) / 2, MSC_STR_DESC_SIZE - 1);
-        wcsncpy(dest, src->wData, len);
+        for (int i = 0; i < len; i++) {
+            dest[i] = (wchar_t)src->wData[i];
+        }
         if (dest != NULL) { // This should be always true, we just check to avoid LoadProhibited exception
             dest[len] = 0;
         }

--- a/host/class/msc/usb_host_msc/src/msc_scsi_bot.c
+++ b/host/class/msc/usb_host_msc/src/msc_scsi_bot.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -246,21 +246,21 @@ esp_err_t bot_execute_command(msc_device_t *device, msc_cbw_t *cbw, void *data, 
     msc_endpoint_t ep = (cbw->flags & CWB_FLAG_DIRECTION_IN) ? MSC_EP_IN : MSC_EP_OUT;
 
     // 1. Command transport
-    MSC_RETURN_ON_ERROR( msc_bulk_transfer_zcpy(device, (uint8_t *)cbw, CBW_SIZE, MSC_EP_OUT) );
+    MSC_RETURN_ON_ERROR( msc_bulk_transfer(device, (uint8_t *)cbw, CBW_SIZE, MSC_EP_OUT) );
 
     // 2. Optional data transport
     if (data) {
-        MSC_RETURN_ON_ERROR( msc_bulk_transfer_zcpy(device, (uint8_t *)data, size, ep) );
+        MSC_RETURN_ON_ERROR( msc_bulk_transfer(device, (uint8_t *)data, size, ep) );
     }
 
     // 3. Status transport
-    esp_err_t err = msc_bulk_transfer_zcpy(device, (uint8_t *)&csw, sizeof(msc_csw_t), MSC_EP_IN);
+    esp_err_t err = msc_bulk_transfer(device, (uint8_t *)&csw, sizeof(msc_csw_t), MSC_EP_IN);
 
     // 3.1 Error recovery
     if (err == ESP_ERR_MSC_STALL) {
         // In case of the status transport failure, we can try reading the status again after clearing feature
         ESP_RETURN_ON_ERROR( clear_feature(device, device->config.bulk_in_ep), TAG, "Clear feature failed" );
-        err = msc_bulk_transfer_zcpy(device, (uint8_t *)&csw, sizeof(msc_csw_t), MSC_EP_IN);
+        err = msc_bulk_transfer(device, (uint8_t *)&csw, sizeof(msc_csw_t), MSC_EP_IN);
         if (ESP_OK != err) {
             // In case the repeated status transport failed we do reset recovery
             // We don't check the error code here, the command has already failed.


### PR DESCRIPTION
Fix MSC driver for P4

1. Correctly handle UTF-16 string descriptors
2. Revert zero-copy transfers. They cause issues with P4's L1 cache