### PR TITLE
usb_host_hid v1.0.2: Support ESP32-P4

### DIFF
--- a/host/class/hid/usb_host_hid/CHANGELOG.md
+++ b/host/class/hid/usb_host_hid/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.2
-<! Unreleased >
+
+- Added support for ESP32-P4
 - Fixed device open procedure for HID devices with multiple non-sequential interfaces.
 
 ## 1.0.1

--- a/host/class/hid/usb_host_hid/CMakeLists.txt
+++ b/host/class/hid/usb_host_hid/CMakeLists.txt
@@ -1,7 +1,3 @@
 idf_component_register( SRCS "hid_host.c"
                         INCLUDE_DIRS "include"
 					    PRIV_REQUIRES usb )
-
-# We access packeted USB string descriptor via pointers. The memory used for storing the descritptors
-# allows unaligned access, so this is not an issue
-target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-address-of-packed-member)

--- a/host/class/hid/usb_host_hid/hid_host.c
+++ b/host/class/hid/usb_host_hid/hid_host.c
@@ -1013,11 +1013,9 @@ static esp_err_t hid_host_string_descriptor_copy(wchar_t *dest,
     }
     if (src != NULL) {
         size_t len = MIN((src->bLength - USB_STANDARD_DESC_SIZE) / 2, HID_STR_DESC_MAX_LENGTH - 1);
-        /*
-        * To pass the warning during compilation, there is a
-        * '-Wno-address-of-packed-member' flag added to this component
-        */
-        wcsncpy(dest, src->wData, len);
+        for (int i = 0; i < len; i++) {
+            dest[i] = (wchar_t) src->wData[i];
+        }
         // This should be always true, we just check to avoid LoadProhibited exception
         if (dest != NULL) {
             dest[len] = 0;

--- a/host/class/hid/usb_host_hid/idf_component.yml
+++ b/host/class/hid/usb_host_hid/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.1~1"
+version: "1.0.2"
 description: USB Host HID driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/hid/usb_host_hid
 dependencies:


### PR DESCRIPTION
# usb_host_hid v1.0.2

RELEASE


## Change description
- String descriptor copying procedure doesn't use `wcsncpy` anymore. Now, there is no difference on sizeof(wchar_t) on different platforms (riscv, xtensa).
- Removed the flag `-Wno-address-of-packed-member` which was necessary for `wcsncpy`. 