### PR TITLE
esp_tinyusb: Removed MIN() definition if defined for cdc_acm

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,4 +1,10 @@
+## 1.4.4 (Unreleased)
+
+- CDC-ACM: Remove MIN() definition if already defined
+- MSC: Set EP size in configuration descriptor based on speed
+
 ## 1.4.3
+
 - esp_tinyusb: ESP32P4 HS only support
 
 ## 1.4.2

--- a/device/esp_tinyusb/tusb_cdc_acm.c
+++ b/device/esp_tinyusb/tusb_cdc_acm.c
@@ -15,7 +15,9 @@
 #include "cdc.h"
 #include "sdkconfig.h"
 
+#ifndef MIN
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#endif
 
 // CDC-ACM spinlock
 static portMUX_TYPE cdc_acm_lock = portMUX_INITIALIZER_UNLOCKED;

--- a/device/esp_tinyusb/usb_descriptors.c
+++ b/device/esp_tinyusb/usb_descriptors.c
@@ -182,7 +182,7 @@ uint8_t const descriptor_cfg_kconfig[] = {
 
 #if CFG_TUD_MSC
     // Interface number, string index, EP Out & EP In address, EP size
-    TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, STRID_MSC_INTERFACE, EPNUM_MSC, 0x80 | EPNUM_MSC, 64), // highspeed 512
+    TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, STRID_MSC_INTERFACE, EPNUM_MSC, 0x80 | EPNUM_MSC, TUD_OPT_HIGH_SPEED ? 512 : 64),
 #endif
 
 #if CFG_TUD_NCM


### PR DESCRIPTION
# esp_tinyusb v1.4.4

NOT A RELEASE 

## Change description
- Removed MIN() macro definition if already defined (CDC-ACM)
- Changed the EP size for MSC class in default configuration descriptor (for HS)
