### PR TITLE
Add device speed to msc_host_get_device_info()

### DIFF
--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added support for ESP32-P4
 - Reverted zero-copy bulk transfers. Data are now copied to USB buffers with negligible effect on performance
+- Added device speed info to msc_host_get_device_info() to distinguish LS, FS, HS devices
 
 ## 1.1.1
 

--- a/host/class/msc/usb_host_msc/include/usb/msc_host.h
+++ b/host/class/msc/usb_host_msc/include/usb/msc_host.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include "esp_err.h"
 #include "freertos/FreeRTOS.h"
+#include "usb/usb_types_stack.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,6 +68,7 @@ typedef struct {
     uint32_t sector_size;
     uint16_t idProduct;
     uint16_t idVendor;
+    usb_speed_t port_speed;
     wchar_t iManufacturer[MSC_STR_DESC_SIZE];
     wchar_t iProduct[MSC_STR_DESC_SIZE];
     wchar_t iSerialNumber[MSC_STR_DESC_SIZE];

--- a/host/class/msc/usb_host_msc/src/msc_host.c
+++ b/host/class/msc/usb_host_msc/src/msc_host.c
@@ -570,6 +570,7 @@ esp_err_t msc_host_get_device_info(msc_host_device_handle_t device, msc_host_dev
     info->idVendor = desc->idVendor;
     info->sector_size = dev->disk.block_size;
     info->sector_count = dev->disk.block_count;
+    info->port_speed = dev_info.speed;
 
     copy_string_desc(info->iManufacturer, dev_info.str_desc_manufacturer);
     copy_string_desc(info->iProduct, dev_info.str_desc_product);


### PR DESCRIPTION
As a part of esp32p4 integration into the CI: 

- adding device speed parameter to `msc_host_get_device_info()` to be able to run `speed_test()` present in `pytest` for msc example in GL. 

- to distinguish devices with different usb speeds and evaluate read/write speed results correctly.