### PR TITLE
esp-usb:  Add codespell pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,13 @@ repos:
     -   id: astyle_py
         args: ['--style=otbs', '--attach-namespaces', '--attach-classes', '--indent=spaces=4', '--convert-tabs', '--align-pointer=name', '--align-reference=name', '--keep-one-line-statements', '--pad-header', '--pad-oper']
 
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+    - id: codespell
+      types_or: [c, c++]
+      args: [-w, "--ignore-words=codespell-ignore-list"]
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/codespell-ignore-list
+++ b/codespell-ignore-list
@@ -1,0 +1,2 @@
+inout
+wheight

--- a/device/esp_tinyusb/include/tusb_tasks.h
+++ b/device/esp_tinyusb/include/tusb_tasks.h
@@ -20,8 +20,8 @@ extern "C" {
  * If you have more requirements for this task, you can create your own task which calls tud_task as the last step.
  *
  * @retval ESP_OK run tinyusb main task successfully
- * @retval ESP_FAIL run tinyusb main task failed of internal error or initialization withing the task failed when TINYUSB_INIT_IN_DEFAULT_TASK=y
- * @retval ESP_FAIL initialization withing the task failed if CONFIG_TINYUSB_INIT_IN_DEFAULT_TASK is enabled
+ * @retval ESP_FAIL run tinyusb main task failed of internal error or initialization within the task failed when TINYUSB_INIT_IN_DEFAULT_TASK=y
+ * @retval ESP_FAIL initialization within the task failed if CONFIG_TINYUSB_INIT_IN_DEFAULT_TASK is enabled
  * @retval ESP_ERR_INVALID_STATE tinyusb main task has been created before
  */
 esp_err_t tusb_run_task(void);
@@ -29,7 +29,7 @@ esp_err_t tusb_run_task(void);
 /**
  * @brief This helper function stops and destroys the task created by `tusb_run_task()`
  *
- * @retval ESP_OK stop and destory tinyusb main task successfully
+ * @retval ESP_OK stop and destroy tinyusb main task successfully
  * @retval ESP_ERR_INVALID_STATE tinyusb main task hasn't been created yet
  */
 esp_err_t tusb_stop_task(void);

--- a/device/esp_tinyusb/tusb_tasks.c
+++ b/device/esp_tinyusb/tusb_tasks.c
@@ -44,7 +44,7 @@ static void tusb_device_task(void *arg)
 
 esp_err_t tusb_run_task(void)
 {
-    // This function is not garanteed to be thread safe, if invoked multiple times without calling `tusb_stop_task`, will cause memory leak
+    // This function is not guaranteed to be thread safe, if invoked multiple times without calling `tusb_stop_task`, will cause memory leak
     // doing a sanity check anyway
     ESP_RETURN_ON_FALSE(!s_tusb_tskh, ESP_ERR_INVALID_STATE, TAG, "TinyUSB main task already started");
 

--- a/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
@@ -794,7 +794,7 @@ esp_err_t cdc_acm_host_open(uint16_t vid, uint16_t pid, uint8_t interface_idx, c
     cdc_dev->data_protocol = (cdc_data_protocol_t)cdc_dev->data.intf_desc->bInterfaceProtocol;
 
     // The following line is here for backward compatibility with v1.0.*
-    // where fixed size of IN buffer (equal to IN Maximum Packe Size) was used
+    // where fixed size of IN buffer (equal to IN Maximum Packet Size) was used
     const size_t in_buf_size = (dev_config->data_cb && (dev_config->in_buffer_size == 0)) ? USB_EP_DESC_GET_MPS(in_ep) : dev_config->in_buffer_size;
 
     // Allocate USB transfers, claim CDC interfaces and return CDC-ACM handle
@@ -1037,7 +1037,7 @@ static void in_xfer_cb(usb_transfer_t *transfer)
             uint8_t **ptr = (uint8_t **)(&(transfer->data_buffer));
             *ptr += transfer->actual_num_bytes;
 
-            // Calculate remaining space in the buffer. Attention: pointer arithmetics!
+            // Calculate remaining space in the buffer. Attention: pointer arithmetic!
             size_t space_left = transfer->data_buffer_size - (transfer->data_buffer - cdc_dev->data.in_data_buffer_base);
             uint16_t mps = cdc_dev->data.in_mps;
             transfer->num_bytes = (space_left / mps) * mps; // Round down to MPS for next transfer

--- a/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_acm_host.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_acm_host.h
@@ -85,7 +85,7 @@ typedef void (*cdc_acm_new_dev_callback_t)(usb_device_handle_t usb_dev);
  * @brief Data receive callback type
  *
  * @param[in] data     Pointer to received data
- * @param[in] data_len Lenght of received data in bytes
+ * @param[in] data_len Length of received data in bytes
  * @param[in] user_arg User's argument passed to open function
  * @return true        Received data was processed     -> Flush RX buffer
  * @return false       Received data was NOT processed -> Append new data to the buffer
@@ -95,7 +95,7 @@ typedef bool (*cdc_acm_data_callback_t)(const uint8_t *data, size_t data_len, vo
 /**
  * @brief Device event callback type
  *
- * @param[in] event    Event strucutre
+ * @param[in] event    Event structure
  * @param[in] user_arg User's argument passed to open function
  */
 typedef void (*cdc_acm_host_dev_callback_t)(const cdc_acm_host_dev_event_data_t *event, void *user_ctx);

--- a/host/class/cdc/usb_host_cdc_acm/test/test_cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/test/test_cdc_acm_host.c
@@ -389,7 +389,7 @@ TEST_CASE("error_handling", "[cdc_acm]")
     TEST_ASSERT_NOT_NULL(cdc_dev);
     TEST_ASSERT_EQUAL(ESP_ERR_NOT_SUPPORTED, cdc_acm_host_data_tx_blocking(cdc_dev, tx_buf, sizeof(tx_buf), 1000));
 
-    // Send unsupported CDC request (TinyUSB accepts SendBreak command, eventhough it doesn't support it)
+    // Send unsupported CDC request (TinyUSB accepts SendBreak command, even though it doesn't support it)
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_send_break(cdc_dev, 100));
 
     // Clean-up

--- a/host/class/hid/usb_host_hid/hid_host.c
+++ b/host/class/hid/usb_host_hid/hid_host.c
@@ -24,7 +24,7 @@ static portMUX_TYPE hid_lock = portMUX_INITIALIZER_UNLOCKED;
 #define HID_ENTER_CRITICAL()    portENTER_CRITICAL(&hid_lock)
 #define HID_EXIT_CRITICAL()     portEXIT_CRITICAL(&hid_lock)
 
-// HID verification macroses
+// HID verification macros
 #define HID_GOTO_ON_FALSE_CRITICAL(exp, err)    \
     do {                                        \
         if(!(exp)) {                            \
@@ -52,7 +52,7 @@ static portMUX_TYPE hid_lock = portMUX_INITIALIZER_UNLOCKED;
 
 #define HID_RETURN_ON_INVALID_ARG(exp) ESP_RETURN_ON_FALSE((exp) != NULL, ESP_ERR_INVALID_ARG, TAG, "Argument error")
 
-// USB Descriptor parsing helping macroses
+// USB Descriptor parsing helping macros
 #define GET_NEXT_INTERFACE_DESC(p, max_len, offs)                                                \
     ((const usb_intf_desc_t *)usb_parse_next_descriptor_of_type((const usb_standard_desc_t *)p,  \
                                                                 max_len,                         \
@@ -79,7 +79,7 @@ typedef struct hid_host_device {
     SemaphoreHandle_t ctrl_xfer_done;           /**< Control transfer semaphore */
     usb_transfer_t *ctrl_xfer;                  /**< Pointer to control transfer buffer */
     usb_device_handle_t dev_hdl;                /**< USB device handle */
-    uint8_t dev_addr;                           /**< USB devce address */
+    uint8_t dev_addr;                           /**< USB device address */
 } hid_device_t;
 
 /**
@@ -194,7 +194,7 @@ static hid_device_t *get_hid_device_by_handle(usb_device_handle_t usb_handle)
 }
 
 /**
- * @brief Return HID Device fron the transfer context
+ * @brief Return HID Device from the transfer context
  *
  * @param[in] xfer   USB transfer struct
  * @return hid_device_t Pointer to HID Device
@@ -539,7 +539,7 @@ static bool hid_host_device_init_attempt(uint8_t dev_addr)
 /**
  * @brief USB device was removed we need to shutdown HID Interface
  *
- * @param[in] hid_dev_handle    Handle of the HID devive to close
+ * @param[in] hid_dev_handle    Handle of the HID device to close
  * @return esp_err_t
  */
 static esp_err_t hid_host_interface_shutdown(hid_host_device_handle_t hid_dev_handle)
@@ -887,11 +887,11 @@ static esp_err_t hid_class_request_report_descriptor(hid_iface_t *iface)
 {
     HID_RETURN_ON_INVALID_ARG(iface);
 
-    // Get Report Descritpor is possible only in Ready or Active state
+    // Get Report Descriptor is possible only in Ready or Active state
     HID_RETURN_ON_FALSE((HID_INTERFACE_STATE_READY == iface->state) ||
                         (HID_INTERFACE_STATE_ACTIVE == iface->state),
                         ESP_ERR_INVALID_STATE,
-                        "Unable to request report decriptor. Interface is not ready");
+                        "Unable to request report descriptor. Interface is not ready");
 
     iface->report_desc = malloc(iface->report_desc_size);
     HID_RETURN_ON_FALSE(iface->report_desc,
@@ -1077,7 +1077,7 @@ esp_err_t hid_host_uninstall_device(hid_device_t *hid_device)
     HID_RETURN_ON_INVALID_ARG(hid_device);
 
     HID_RETURN_ON_ERROR( usb_host_transfer_free(hid_device->ctrl_xfer),
-                         "Unablet to free transfer buffer for EP0");
+                         "Unable to free transfer buffer for EP0");
     HID_RETURN_ON_ERROR( usb_host_device_close(s_hid_driver->client_handle,
                          hid_device->dev_hdl),
                          "Unable to close USB host");

--- a/host/class/hid/usb_host_hid/include/usb/hid_host.h
+++ b/host/class/hid/usb_host_hid/include/usb/hid_host.h
@@ -132,7 +132,7 @@ esp_err_t hid_host_uninstall(void);
 /**
  * @brief USB HID Host open a device with specific device parameters
  *
- * @param[in] iface_handle     Handle of the HID devive to open
+ * @param[in] iface_handle     Handle of the HID device to open
  * @param[in] config           Configuration structure HID device to open
  * @return esp_err_t
  */
@@ -142,7 +142,7 @@ esp_err_t hid_host_device_open(hid_host_device_handle_t hid_dev_handle,
 /**
  * @brief USB HID Host close device
  *
- * @param[in] hid_dev_handle   Handle of the HID devive to close
+ * @param[in] hid_dev_handle   Handle of the HID device to close
  * @return esp_err_t
  */
 esp_err_t hid_host_device_close(hid_host_device_handle_t hid_dev_handle);

--- a/host/class/hid/usb_host_hid/test/hid_mock_device.c
+++ b/host/class/hid/usb_host_hid/test/hid_mock_device.c
@@ -172,7 +172,7 @@ void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_
  * @brief HID Mock device start
  *
  * @param[in] iface_count   Interface count, when TUSB_IFACE_COUNT_ONE then there is two Interfaces, but equal (Protocol=None).
- * when TUSB_IFACE_COUNT_TWO then HID device mocked with two independed Interfaces (Protocol=BootKeyboard, Protocol=BootMouse).
+ * when TUSB_IFACE_COUNT_TWO then HID device mocked with two independent Interfaces (Protocol=BootKeyboard, Protocol=BootMouse).
  */
 void hid_mock_device(tusb_iface_count_t iface_count)
 {

--- a/host/class/hid/usb_host_hid/test/test_hid_basic.c
+++ b/host/class/hid/usb_host_hid/test/test_hid_basic.c
@@ -234,7 +234,7 @@ void hid_host_test_requests_callback(hid_host_device_handle_t hid_device_handle,
         wprintf(L"\t iSerialNumber: %S \n", hid_dev_info.iSerialNumber);
 
         if (dev_params.proto == HID_PROTOCOL_NONE) {
-            // If Protocol NONE, based on hid1_11.pdf, p.78, all ohter devices should support
+            // If Protocol NONE, based on hid1_11.pdf, p.78, all other devices should support
             rep_len = sizeof(tmp);
             // For testing with ESP32 we used ReportID = 0x01 (Keyboard ReportID)
             if (ESP_OK == hid_class_request_get_report(hid_device_handle,
@@ -616,7 +616,7 @@ TEST_CASE("class_specific_requests", "[hid_host]")
     test_setup_hid_task();
     // Install USB and HID driver with 'hid_host_test_device_callback_to_queue'
     test_hid_setup(hid_host_test_device_callback_to_queue, HID_TEST_EVENT_HANDLE_IN_DRIVER);
-    // All specific control requests will be verified during device connetion callback 'hid_host_test_requests_callback'
+    // All specific control requests will be verified during device connection callback 'hid_host_test_requests_callback'
     // Wait for test completed for 250 ms
     vTaskDelay(250);
     // Tear down test
@@ -632,7 +632,7 @@ TEST_CASE("class_specific_requests_with_external_polling", "[hid_host]")
     test_hid_setup(hid_host_test_device_callback_to_queue, HID_TEST_EVENT_HANDLE_EXTERNAL);
     // Create HID Driver events polling task
     test_setup_hid_polling_task();
-    // All specific control requests will be verified during device connetion callback 'hid_host_test_requests_callback'
+    // All specific control requests will be verified during device connection callback 'hid_host_test_requests_callback'
     // Wait for test completed for 250 ms
     vTaskDelay(250);
     // Tear down test

--- a/host/class/hid/usb_host_hid/test/test_hid_err_handling.c
+++ b/host/class/hid/usb_host_hid/test/test_hid_err_handling.c
@@ -187,7 +187,7 @@ static void test_uninstall_hid_driver_while_device_is_present(void)
     test_hid_setup(test_hid_host_event_callback_open, HID_TEST_EVENT_HANDLE_IN_DRIVER);
     // Wait for USB device appearing for 250 msec
     vTaskDelay(250);
-    // Uninstall HID Driver wile device is still connected and verify a result
+    // Uninstall HID Driver while device is still connected and verify a result
     printf("HID Driver uninstall attempt while HID Device is still present ...\n");
     TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, hid_host_uninstall());
     // Tear down test

--- a/host/class/msc/usb_host_msc/include/usb/msc_host.h
+++ b/host/class/msc/usb_host_msc/include/usb/msc_host.h
@@ -52,8 +52,8 @@ typedef void (*msc_host_event_cb_t)(const msc_host_event_t *event, void *arg);
 typedef struct {
     bool create_backround_task;     /**< When set to true, background task handling usb events is created.
                                          Otherwise user has to periodically call msc_host_handle_events function */
-    size_t task_priority;           /**< Task priority of crated background task */
-    size_t stack_size;              /**< Stack size of crated background task */
+    size_t task_priority;           /**< Task priority of created background task */
+    size_t stack_size;              /**< Stack size of created background task */
     BaseType_t core_id;             /**< Select core on which background task will run or tskNO_AFFINITY  */
     msc_host_event_cb_t callback;   /**< Callback invoked when MSC event occurs. Must not be NULL. */
     void *callback_arg;             /**< User provided argument passed to callback */

--- a/host/class/uvc/usb_host_uvc/include/libuvc_adapter.h
+++ b/host/class/uvc/usb_host_uvc/include/libuvc_adapter.h
@@ -55,7 +55,7 @@ esp_err_t libuvc_adapter_print_descriptors(uvc_device_handle_t *device);
  * - This function has to be called periodically, if configuration
  *   was provided with `create_background_task` set to `false`.
  *
- * @param[in]  timeout_ms  Timeout in miliseconds
+ * @param[in]  timeout_ms  Timeout in milliseconds
  * @return esp_err_t
  */
 esp_err_t libuvc_adapter_handle_events(uint32_t timeout_ms);

--- a/host/class/uvc/usb_host_uvc/private_include/libusb.h
+++ b/host/class/uvc/usb_host_uvc/private_include/libusb.h
@@ -270,7 +270,7 @@ inline void libusb_set_iso_packet_lengths(struct libusb_transfer *transfer, size
     }
 }
 
-int libusb_set_interface_alt_setting(libusb_device_handle *dev_handle, int32_t inferface, int32_t alt_settings);
+int libusb_set_interface_alt_setting(libusb_device_handle *dev_handle, int32_t interface, int32_t alt_settings);
 
 int libusb_get_ss_endpoint_companion_descriptor(struct libusb_context *ctx,
         const struct libusb_endpoint_descriptor *endpoint,

--- a/host/class/uvc/usb_host_uvc/src/descriptor.c
+++ b/host/class/uvc/usb_host_uvc/src/descriptor.c
@@ -377,7 +377,7 @@ typedef struct {
     uint8_t  bFormatIndex;
     uint8_t  bmCapabilities;
     uint16_t wWidth;
-    uint16_t wHeigh;
+    uint16_t wHeight;
     uint32_t dwMinBitRate;
     uint32_t dwMaxBitRate;
     uint32_t dwMaxVideoFrameBufSize;
@@ -643,7 +643,7 @@ static void print_vs_frame_mjpeg_desc(const uint8_t *buff)
     printf("\tbFormatIndex 0x%x\n", desc->bFormatIndex);
     printf("\tbmCapabilities 0x%x\n", desc->bmCapabilities);
     printf("\twWidth %u\n", desc->wWidth);
-    printf("\twHeigh %u\n", desc->wHeigh);
+    printf("\twHeigh %u\n", desc->wHeight);
     printf("\tdwMinBitRate %"PRIu32"\n", desc->dwMinBitRate);
     printf("\tdwMaxBitRate %"PRIu32"\n", desc->dwMaxBitRate);
     printf("\tdwMaxVideoFrameBufSize %"PRIu32"\n", desc->dwMaxVideoFrameBufSize);

--- a/host/class/uvc/usb_host_uvc/src/libusb_adapter.c
+++ b/host/class/uvc/usb_host_uvc/src/libusb_adapter.c
@@ -771,7 +771,7 @@ int libusb_release_interface(libusb_device_handle *dev_handle, int interface)
     return esp_to_libusb_error( usb_host_interface_release(s_uvc_driver->client, device->handle, interface) );
 }
 
-int libusb_set_interface_alt_setting(libusb_device_handle *dev_handle, int32_t inferface, int32_t alt_settings)
+int libusb_set_interface_alt_setting(libusb_device_handle *dev_handle, int32_t interface, int32_t alt_settings)
 {
     uvc_camera_t *device = (uvc_camera_t *)dev_handle;
     usb_host_client_handle_t client = s_uvc_driver->client;
@@ -780,12 +780,12 @@ int libusb_set_interface_alt_setting(libusb_device_handle *dev_handle, int32_t i
 
     // Setting alternate interface 0.0 is special case in UVC specs.
     // No interface is to be released, just send control transfer.
-    if (inferface != 0 || alt_settings != 0) {
-        RETURN_ON_ERROR_LIBUSB( usb_host_interface_release(client, device->handle, inferface) );
-        RETURN_ON_ERROR_LIBUSB( usb_host_interface_claim(client, device->handle, inferface, alt_settings) );
+    if (interface != 0 || alt_settings != 0) {
+        RETURN_ON_ERROR_LIBUSB( usb_host_interface_release(client, device->handle, interface) );
+        RETURN_ON_ERROR_LIBUSB( usb_host_interface_claim(client, device->handle, interface, alt_settings) );
     }
 
-    USB_SETUP_PACKET_INIT_SET_INTERFACE(&request, inferface, alt_settings);
+    USB_SETUP_PACKET_INIT_SET_INTERFACE(&request, interface, alt_settings);
     int result = control_transfer(dev_handle, &request, data, 2000);
     return result > 0 ? LIBUSB_SUCCESS : result;
 }
@@ -816,6 +816,6 @@ int8_t libusb_get_bus_number(libusb_device *device)
 
 int8_t libusb_get_device_address(libusb_device *device)
 {
-    // Device addres is stored directly in libusb_device
+    // Device address is stored directly in libusb_device
     return (uint8_t)(uint32_t)device;
 }


### PR DESCRIPTION
## Change description
- Added a codespell pre-commit hook (for `c` and `cpp` files only, with `codespell-ignore-list`)
- Applied codespell on all files (`c` and `cpp`)