### PR TITLE
esp_tinyusb: Adding bvalid_signal test

### DIFF
--- a/device/esp_tinyusb/test/CMakeLists.txt
+++ b/device/esp_tinyusb/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "test_esp_tinyusb.c"
+idf_component_register(SRCS "test_esp_tinyusb.c" "test_bvalid_sig.c"
                        INCLUDE_DIRS "."
                        REQUIRES unity esp_tinyusb
                        )

--- a/device/esp_tinyusb/test/test_bvalid_sig.c
+++ b/device/esp_tinyusb/test/test_bvalid_sig.c
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+
+#include <stdio.h>
+#include <string.h>
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "driver/gpio.h"
+#include "esp_rom_gpio.h"
+#include "soc/gpio_sig_map.h"
+#include "unity.h"
+#include "tinyusb.h"
+#include "class/msc/msc_device.h"
+
+#define DEVICE_DETACH_TEST_ROUNDS       10
+#define DEVICE_DETACH_ROUND_DELAY_MS    1000
+
+/* TinyUSB descriptors
+   ********************************************************************* */
+#define TUSB_DESC_TOTAL_LEN         (TUD_CONFIG_DESC_LEN)
+
+static unsigned int dev_mounted = 0;
+static unsigned int dev_umounted = 0;
+
+static uint8_t const test_configuration_descriptor[] = {
+    // Config number, interface count, string index, total length, attribute, power in mA
+    TUD_CONFIG_DESCRIPTOR(1, 0, 0, TUSB_DESC_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_SELF_POWERED | TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+};
+
+static const tusb_desc_device_t test_device_descriptor = {
+    .bLength = sizeof(test_device_descriptor),
+    .bDescriptorType = TUSB_DESC_DEVICE,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .idVendor = 0x303A, // This is Espressif VID. This needs to be changed according to Users / Customers
+    .idProduct = 0x4002,
+    .bcdDevice = 0x100,
+    .iManufacturer = 0x01,
+    .iProduct = 0x02,
+    .iSerialNumber = 0x03,
+    .bNumConfigurations = 0x01
+};
+
+// Invoked when device is mounted
+void tud_mount_cb(void)
+{
+    dev_mounted++;
+}
+
+// Invoked when device is unmounted
+void tud_umount_cb(void)
+{
+    dev_umounted++;
+}
+
+TEST_CASE("bvalid_signal", "[esp_tinyusb]")
+{
+    unsigned int rounds = DEVICE_DETACH_TEST_ROUNDS;
+
+    // Install TinyUSB driver
+    const tinyusb_config_t tusb_cfg = {
+        .external_phy = false,
+        .device_descriptor = &test_device_descriptor,
+        .configuration_descriptor = test_configuration_descriptor,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+
+    while (rounds--) {
+        // LOW to emulate disconnect USB device
+        esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ZERO_INPUT, USB_SRP_BVALID_IN_IDX, false);
+        vTaskDelay(pdMS_TO_TICKS(DEVICE_DETACH_ROUND_DELAY_MS));
+        // HIGH to emulate connect USB device
+        esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ONE_INPUT, USB_SRP_BVALID_IN_IDX, false);
+        vTaskDelay(pdMS_TO_TICKS(DEVICE_DETACH_ROUND_DELAY_MS));
+    }
+
+    // Verify
+    TEST_ASSERT_EQUAL(dev_umounted, dev_mounted);
+    TEST_ASSERT_EQUAL(DEVICE_DETACH_TEST_ROUNDS, dev_mounted);
+
+    tinyusb_driver_uninstall();
+}
+#endif // SOC_USB_OTG_SUPPORTED


### PR DESCRIPTION
# esp_tinyusb v1.4.4

NOT A RELEASE 

## Change description
- Added a usb_device test for `bvalid_signal` verification. 

## Details
USB Device events, such as attach (plug) and detach (unplug) are detected via `bvalid_signal`, which can be connected to any (*mostly) external PIN. (In the most common cases, this external PIN connected to VBUS USB via resistor divider to detect the VBUS power presence. For reference, check [Self-Powered Device](https://docs.espressif.com/projects/esp-idf/en/v5.1.1/esp32s2/api-reference/peripherals/usb_device.html))

When USB Device (self-powered) is attached to the USB Host, the VBUS becomes High. 
When USB Device (self-powered) is detached from the USB Host, the VBUS becomes Low. 
Both of attach and detach, trigger the dcd_dwc2 layer interrupt with `DCD_EVENT_UNPLUGGED` event. 

Current test implement the USB Device without any interface and connect the `bvalid_signal` to the High or Low signal source to emulate the VBUS presence/absence.
For smoke testing, 10 iterates is enough to see that logic is working. 
For load testing, please, change the parameter `DEVICE_DETACH_TEST_ROUNDS` in `test_bvalid_sig.c`.

### Important notice
Without changes in https://github.com/espressif/tinyusb/pull/19 the test doesn't work. 
