### PR TITLE
fix(cdc_acm): Fix closing of already closed device

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Added `cdc_acm_host_cdc_desc_get()` function that enables users to get CDC functional descriptors of the device
+- Fixed closing of a CDC device from multiple threads
 
 ## 2.0.2
 

--- a/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_acm_host.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_acm_host.h
@@ -188,8 +188,10 @@ esp_err_t cdc_acm_host_open_vendor_specific(uint16_t vid, uint16_t pid, uint8_t 
  * @brief Close CDC device and release its resources
  *
  * @note All in-flight transfers will be prematurely canceled.
- * @param cdc_hdl CDC handle obtained from cdc_acm_host_open()
- * @return esp_err_t
+ * @param[in] cdc_hdl CDC handle obtained from cdc_acm_host_open()
+ * @return
+ *   - ESP_OK: Success - device closed
+ *   - ESP_ERR_INVALID_STATE: cdc_hdl is NULL or the CDC driver is not installed
  */
 esp_err_t cdc_acm_host_close(cdc_acm_dev_hdl_t cdc_hdl);
 


### PR DESCRIPTION
This bug was found out during esp-serial-flasher CDC operation.

In case the user does not track status of the CDC device and attempts to close the device from multiple places/threads the driver would crash

cc @DNedic