### PR TITLE
Fix memory leak of the bvalid_sig test

### DIFF
--- a/device/esp_tinyusb/test_app/main/test_bvalid_sig.c
+++ b/device/esp_tinyusb/test_app/main/test_bvalid_sig.c
@@ -20,6 +20,7 @@
 #include "soc/gpio_sig_map.h"
 #include "unity.h"
 #include "tinyusb.h"
+#include "tusb_tasks.h"
 
 #define DEVICE_DETACH_TEST_ROUNDS       10
 #define DEVICE_DETACH_ROUND_DELAY_MS    1000
@@ -90,6 +91,8 @@ TEST_CASE("bvalid_signal", "[esp_tinyusb][usb_device]")
     TEST_ASSERT_EQUAL(dev_umounted, dev_mounted);
     TEST_ASSERT_EQUAL(DEVICE_DETACH_TEST_ROUNDS, dev_mounted);
 
-    tinyusb_driver_uninstall();
+    // Cleanup
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+    TEST_ASSERT_EQUAL(ESP_OK, tusb_stop_task());
 }
 #endif // SOC_USB_OTG_SUPPORTED


### PR DESCRIPTION
Even though the `test_bvalid_sig` is not running in CI yet, I discovered this issue when refactoring the test app. 
The test was failing due to memory leak.

The problem was, that the tusb task was still running, after the test was finished.

Before:
```
MALLOC_CAP_8BIT: Before 385196 bytes free, After 380676 bytes free (delta -4520)
./main/test_bvalid_sig.c:20:bvalid_signal:FAIL:Function [esp_tinyusb][usb_device].  memory leak
```

Fixed:
```
MALLOC_CAP_8BIT: Before 385196 bytes free, After 385144 bytes free (delta -52)
MALLOC_CAP_32BIT: Before 385196 bytes free, After 385144 bytes free (delta -52)
```
