### PR TITLE
UVC driver release 1.0.3

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -1,0 +1,18 @@
+## 1.0.3
+
+- Added support for ESP32-P4
+- Bumped libuvc version to relax frame format negotiation
+- Fixed crash on opening non-UVC devices
+
+## 1.0.2
+
+- Updated libuvc library to 0.0.7 https://github.com/libuvc/libuvc/tree/v0.0.7
+- Added Software BoM information
+
+## 1.0.1
+
+- Fixed compatibility with IDF v4.4
+
+## 1.0.0
+
+- Initial version

--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added support for ESP32-P4
 - Bumped libuvc version to relax frame format negotiation
 - Fixed crash on opening non-UVC devices
+- Added `libuvc_get_usb_device_info` function
 
 ## 1.0.2
 

--- a/host/class/uvc/usb_host_uvc/README.md
+++ b/host/class/uvc/usb_host_uvc/README.md
@@ -21,3 +21,4 @@ Following two supported formats are the most common (both encoded in MJPEG):
 ## Tested cameras
  * Logitech C980
  * CANYON CNE-CWC2
+ * Logitech C270

--- a/host/class/uvc/usb_host_uvc/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.2~1"
+version: "1.0.3"
 description: USB Host UVC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uvc/usb_host_uvc
 dependencies:

--- a/host/class/uvc/usb_host_uvc/include/libuvc_adapter.h
+++ b/host/class/uvc/usb_host_uvc/include/libuvc_adapter.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "esp_err.h"
+#include "usb/usb_types_stack.h"
+#include "libuvc/libuvc.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +61,14 @@ esp_err_t libuvc_adapter_print_descriptors(uvc_device_handle_t *device);
  * @return esp_err_t
  */
 esp_err_t libuvc_adapter_handle_events(uint32_t timeout_ms);
+
+/**
+ * @brief Get information about underlying USB device
+ *
+ * @param[in]  dev      UVC device handle obtained from uvc_find_device()
+ * @param[out] dev_info Pointer to structure where the information will be saved
+ */
+esp_err_t libuvc_get_usb_device_info(uvc_device_t *dev, usb_device_info_t *dev_info);
 
 #ifdef __cplusplus
 }

--- a/host/class/uvc/usb_host_uvc/src/descriptor.c
+++ b/host/class/uvc/usb_host_uvc/src/descriptor.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -190,8 +190,8 @@ int parse_configuration(libusb_config_descriptor_t *config, const uint8_t *buffe
             LIBUSB_GOTO_ON_FALSE(interface->altsetting);
 
             for (int ep = 0; ep < endpoints; ep++) {
-                ep_desc = usb_parse_endpoint_descriptor_by_index(ifc_desc, ep, config->wTotalLength, &offset);
-                ifc_desc = (const usb_intf_desc_t *)ep_desc;
+                int intf_offset = offset; // Current offset is interface offset in the configuration descriptor
+                ep_desc = usb_parse_endpoint_descriptor_by_index(ifc_desc, ep, config->wTotalLength, &intf_offset);
                 libusb_endpoint_descriptor_t *endpoint = &altsetting->endpoint[ep];
                 copy_endpoint_desc(endpoint, ep_desc);
                 LIBUSB_GOTO_ON_ERROR( add_extra_data(&extra, ep_desc) );

--- a/host/class/uvc/usb_host_uvc/src/libusb_adapter.c
+++ b/host/class/uvc/usb_host_uvc/src/libusb_adapter.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -189,6 +189,24 @@ esp_err_t libuvc_adapter_print_descriptors(uvc_device_handle_t *device)
     usb_print_config_descriptor(config_desc, print_usb_class_descriptors);
     print_string_descriptors(&dev_info);
 
+    return ESP_OK;
+}
+
+esp_err_t libuvc_get_usb_device_info(uvc_device_t *dev, usb_device_info_t *dev_info)
+{
+    uvc_error_t ret;
+    struct libusb_device_handle *usb_devh;
+
+    ret = libusb_open(dev->usb_dev, &usb_devh);
+    UVC_DEBUG("libusb_open() = %d", ret);
+    if (ret != UVC_SUCCESS) {
+        return ESP_FAIL;
+    }
+
+    uvc_camera_t *camera = (uvc_camera_t *)(usb_devh);
+    RETURN_ON_ERROR( usb_host_device_info(camera->handle, dev_info) );
+
+    libusb_close(usb_devh);
     return ESP_OK;
 }
 


### PR DESCRIPTION
- Added support for ESP32-P4
- Bumped libuvc version to relax frame format negotiation
- Fixed crash on opening non-UVC devices

Related
* libuvc PR https://github.com/libuvc/libuvc/pull/273
* Closes #19 