### PR TITLE
CI: Add Clang tidy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_component.md
@@ -3,8 +3,9 @@
 - [ ] Component contains License
 - [ ] Component contains README.md
 - [ ] Component contains idf_component.yml file with `url` field defined
-- [ ] Component was added to [upload job](https://github.com/espressif/esp-usb/blob/master/.github/workflows/upload_component.yml#L18)
-- [ ] Component was added to build job
+- [ ] Component was added to [upload job](https://github.com/espressif/esp-usb/blob/master/.github/workflows/upload_component.yml#L34)
+- [ ] Component was added to [build job](https://github.com/espressif/esp-usb/blob/master/.idf_build_apps.toml#L2)
+- [ ] Component was added to [clang tidy job](https://github.com/espressif/esp-usb/blob/master/clang_tidy/CMakeLists.txt#L7)
 - [ ] _Optional:_ Component contains unit tests
 - [ ] CI passing
 

--- a/.github/filter_sarif.py
+++ b/.github/filter_sarif.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import copy
+import json
+import typing
+
+
+def process(in_file: typing.TextIO, out_file: typing.TextIO, include_prefix_list: typing.List[str]) -> None:
+    in_json = json.load(in_file)
+    if len(in_json['runs']) != 1:
+        raise NotImplementedError('Only 1 run is supported')
+    in_results = in_json['runs'][0]['results']
+    out_results = []
+    for result in in_results:
+        locations = result['locations']
+        if len(locations) != 1:
+            raise NotImplementedError('Only 1 location is supported')
+        artifact_location = locations[0]['physicalLocation']['artifactLocation']
+        uri = artifact_location['uri']
+        new_uri = None
+        for include_prefix in include_prefix_list:
+            if uri.startswith(include_prefix):
+                new_uri = uri.replace(include_prefix, '')
+                break
+        if not new_uri:
+            continue
+        new_result = copy.deepcopy(result)
+        new_result['locations'][0]['physicalLocation']['artifactLocation']['uri'] = new_uri
+        out_results.append(new_result)
+
+    out_json = copy.deepcopy(in_json)
+    out_json['runs'][0]['results'] = out_results
+    json.dump(out_json, out_file, indent=True)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o', '--output', type=argparse.FileType('w'), help='Output filtered SARIF file')
+    parser.add_argument('--include-prefix', required=True, action='append',
+                        help='File prefix for source code to include in analysis')
+    parser.add_argument('input_file', type=argparse.FileType('r'), help='Input SARIF file')
+    args = parser.parse_args()
+    process(args.input_file, args.output, args.include_prefix)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,59 @@
+name: Run clang-tidy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Run clang-tidy
+    runs-on: ubuntu-20.04
+    container: espressif/idf:latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Install libtinfo (esp-clang dependency)
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt update && apt-get install -y libtinfo5
+      - name: Install esp-clang
+        run: |
+          ${IDF_PATH}/tools/idf_tools.py --non-interactive install esp-clang
+      - name: Install clang-tidy-sarif
+        run: |
+          curl -sSL https://github.com/psastras/sarif-rs/releases/download/clang-tidy-sarif-v0.3.3/clang-tidy-sarif-x86_64-unknown-linux-gnu -o clang-tidy-sarif
+          chmod +x clang-tidy-sarif
+      - name: Install pyclang
+        run: |
+          . ${IDF_PATH}/export.sh
+          pip install pyclang~=0.2.0
+      - name: Run code analysis
+        shell: bash
+        env:
+          IDF_TOOLCHAIN: clang
+          IDF_TARGET: esp32s3
+        working-directory: clang_tidy
+        run: |
+          . ${IDF_PATH}/export.sh
+          idf.py reconfigure
+          idf.py clang-check --include-paths $GITHUB_WORKSPACE --exclude-paths $PWD --run-clang-tidy-py run-clang-tidy
+          cp warnings.txt ../
+      - name: Convert clang-tidy results into SARIF output
+        run: |
+          export PATH=$PWD:$PATH
+          ./clang-tidy-sarif -o results.sarif.raw warnings.txt
+          python3 $GITHUB_WORKSPACE/.github/filter_sarif.py -o results.sarif --include-prefix ${GITHUB_WORKSPACE}/ results.sarif.raw
+      - uses: actions/upload-artifact@v2
+        with:
+          path: |
+            warnings.txt
+            results.sarif
+            results.sarif.raw
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif
+          category: clang-tidy

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dependencies.lock
 **/managed_components/**
 .vscode/
 doxygen/
+warnings.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![Build and Run Test Application](https://github.com/espressif/esp-usb/actions/workflows/build_and_run_test_app.yml/badge.svg?branch=master)](https://github.com/espressif/esp-usb/actions/workflows/build_and_run_test_app.yml)
+[![Build and Run Test Application](https://github.com/espressif/esp-usb/actions/workflows/build_and_run_test_app_usb.yml/badge.svg?branch=master)](https://github.com/espressif/esp-usb/actions/workflows/build_and_run_test_app_usb.yml)
 [![Clang-Tidy](https://github.com/espressif/esp-usb/actions/workflows/clang-tidy.yml/badge.svg?branch=master)](https://github.com/espressif/esp-usb/security/code-scanning?query=is%3Aopen+branch%3Amaster)
 
 # Espressif ESP-USB

--- a/clang_tidy/CMakeLists.txt
+++ b/clang_tidy/CMakeLists.txt
@@ -1,0 +1,21 @@
+# The following lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+include($ENV{IDF_PATH}/tools/cmake/version.cmake)
+
+# Specify components that will be checked with Clang tidy
+set(EXTRA_COMPONENT_DIRS
+    ../device/esp_tinyusb
+    ../host/class/cdc/esp_modem_usb_dte
+    ../host/class/cdc/usb_host_cdc_acm
+    ../host/class/cdc/usb_host_ch34x_vcp
+    ../host/class/cdc/usb_host_cp210x_vcp
+    ../host/class/cdc/usb_host_ftdi_vcp
+    ../host/class/cdc/usb_host_vcp
+    ../host/class/hid/usb_host_hid
+    ../host/class/msc/usb_host_msc
+    ../host/class/uvc/usb_host_uvc
+)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(clang_check)

--- a/clang_tidy/README.md
+++ b/clang_tidy/README.md
@@ -1,0 +1,3 @@
+# ESP-USB Clang tidy
+
+This folder aims to store source files for Clang tidy CI job, which is run for this repository in the GitHub CI.


### PR DESCRIPTION
Adding Clang tidy related files.

We wanted to reuse Clang tidy CI job from `idf-extra-components`, where Clang tidy job was run from its main `test_app`.
Since we have split the main `test_app` into into several test apps in this respository an extensive Clang tidy job rework would be needed to run Clang tidy in all the test_apps. 

We decided to create a folder `clang_tidy`, from where Clang tidy is run. Doing so, nearly no modification is needed to be done in the Clang tidy CI job from `idf-extra-components`

`.github/filter_sarif.py` - copy from `idf-extra-components` (no modification)
`.github/workflows/clang-tidy.yml` - copy from `idf-extra-components` (line 41 added, line 38 modified folder name)

`clang_tidy` folder name and content of `clang_tidy/README.md` is opened for discussion.