### PR TITLE
feat(esp_modem_usb_dte): add esp32p4 support & add cat.4 ec20 modem

### DIFF
--- a/host/class/cdc/esp_modem_usb_dte/CHANGELOG.md
+++ b/host/class/cdc/esp_modem_usb_dte/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## Unreleased
 
+## 1.2.0
+
 - Fixed C++ build error for `usb_host_config_t` backward compatibility
 - Added default configuration for SimCom SIM7070G, SIM7080 and SIMA7672E modems
+- Added default configuration for Quectel EC20
+- Added ESP32-P4 support
 
 ## 1.1.0
 

--- a/host/class/cdc/esp_modem_usb_dte/CMakeLists.txt
+++ b/host/class/cdc/esp_modem_usb_dte/CMakeLists.txt
@@ -1,5 +1,4 @@
 idf_component_register(SRCS "esp_modem_usb.cpp" "esp_modem_usb_api_target.cpp" "esp_modem_usb_c_api.cpp"
-                       REQUIRED_IDF_TARGETS esp32s2 esp32s3
                        PRIV_INCLUDE_DIRS "private_include"
                        INCLUDE_DIRS "include")
 

--- a/host/class/cdc/esp_modem_usb_dte/README.md
+++ b/host/class/cdc/esp_modem_usb_dte/README.md
@@ -49,6 +49,7 @@ Then, you can pass these constants to [ESP_MODEM_DEFAULT_USB_CONFIG](https://git
 
 ## List of tested modems
 The following modems were tested with this component, their configurations can be found in [esp_modem_usb_config.h](https://github.com/espressif/idf-extra-components/blob/master/usb/esp_modem_usb_dte/include/esp_modem_usb_config.h):
-* Quactel BG96
+* Quectel BG96
+* Quectel EC20
 * SimCom SIM7600E
 * SimCom A7670E

--- a/host/class/cdc/esp_modem_usb_dte/idf_component.yml
+++ b/host/class/cdc/esp_modem_usb_dte/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.1.0~1"
+version: "1.2.0"
 description: USB DTE plugin for esp_modem component
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/esp_modem_usb_dte
 
@@ -7,3 +7,8 @@ dependencies:
   idf: ">=4.4"
   usb_host_cdc_acm: "2.*"
   esp_modem: ">=0.1.28,<2.0.0"
+
+targets:
+  - esp32s2
+  - esp32s3
+  - esp32p4

--- a/host/class/cdc/esp_modem_usb_dte/include/esp_modem_usb_config.h
+++ b/host/class/cdc/esp_modem_usb_dte/include/esp_modem_usb_config.h
@@ -60,7 +60,7 @@ struct esp_modem_usb_term_config {
 #define ESP_MODEM_DEFAULT_USB_CONFIG(_vid, _pid, _intf) ESP_MODEM_DEFAULT_USB_CONFIG_DUAL(_vid, _pid, _intf, -1)
 
 /**
- * @brief Default configuration of Quactel BG96 modem
+ * @brief Default configuration of Quectel BG96 modem
  */
 #define ESP_MODEM_BG96_USB_CONFIG()    ESP_MODEM_DEFAULT_USB_CONFIG(0x2C7C, 0x0296, 2)
 
@@ -88,3 +88,8 @@ struct esp_modem_usb_term_config {
  * @brief Default configuration of SimCom SIMA7672E modem
  */
 #define ESP_MODEM_SIMA7672E_USB_CONFIG()   ESP_MODEM_DEFAULT_USB_CONFIG_DUAL(0x1E0E, 0x9011, 4, 5)
+
+/**
+ * @brief Default configuration of Quectel EC20 modem
+ */
+#define ESP_MODEM_EC20_USB_CONFIG()    ESP_MODEM_DEFAULT_USB_CONFIG(0x2C7C, 0x0125, 3)


### PR DESCRIPTION
As esp32p4 has been supported in [usb_host_cdc_acm](https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_cdc_acm), it should be the right time for us to support higher throughput Cat.4 Cellular module (DL 150 Mbps, UL 50 Mbps).

- [x] Support esp32p4 in esp_modem_usb_dte
- [x] Add Cat.4 module EC20
- [x] Add support in esp_modem example https://github.com/espressif/esp-protocols/pull/556
~~- [ ] Speed iperf test~~