### PR TITLE
UVC deployment strategy (for discussion)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "host/usb_host_uvc/libuvc"]
 	path = host/class/uvc/usb_host_uvc/libuvc
-	url = ../../libuvc/libuvc.git
+	url = ../../espressif/libuvc.git

--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- CDC-ACM: Fixed memory leak at VFS unregister
+
 ## 1.4.4
 
 - esp_tinyusb: Added HighSpeed and Qualifier device descriptors in tinyusb configuration


### PR DESCRIPTION
This PR changes our libuvc submodule from upstream https://github.com/libuvc/libuvc to Espressif's fork https://github.com/espressif/libuvc

Please note that this deployment strategy is different from TinyUSB, where we release TinyUSB as one component and TinyUSB additions as a second one. This approach brings a lot of maintenance effort, though. So, IMO, this simplified strategy is more suitable for UVC

Opinions welcome!