### PR TITLE
USB Host MSC: Add request sense feature

### DIFF
--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3 (unreleased)
+
+- Implemented request sense, to get sense data from USB device in case of an error
+
 ## 1.1.2
 
 - Added support for ESP32-P4


### PR DESCRIPTION
Closing IDF-9890

Added request sense feature for MCS driver.

After each  BOT command execution a `CSW` is checked for possible errors. If an error is present in the MSC device a `bCSWStatus` is returned to the Host as non zero. Ref: [USB Mass Storage Class – Bulk Only Transport](https://www.usb.org/sites/default/files/usbmassbulk_10.pdf) table 5.3. But a current MSC Host driver does not allow the user to find out what is causing the error.

This MR adds a feature to the MSC Host to issue a request sense to the MSC device each time, after checking `CSW` for errors. The request sense command returns specific error code. Ref: [USB Mass Storage Class – UFI Command Specification](https://www.usb.org/sites/default/files/usbmass-ufi10.pdf) Chapter 4.11 and Table 51