### PR TITLE
CI: Add build and target run for IDF_v5.3

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
+        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "latest"]
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "latest"]
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "latest"]
         idf_target: ["esp32s2"]
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "usb_host"]
     container:


### PR DESCRIPTION
Closes [IDF-9867](https://jira.espressif.com:8443/browse/IDF-9867)

This MR adds IDF 5.3 to the CI build and target run