### PR TITLE
fix issue that out_xfer unintentionally returned by previous transmission (IEC-121)

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
@@ -1163,7 +1163,7 @@ esp_err_t cdc_acm_host_data_tx_blocking(cdc_acm_dev_hdl_t cdc_hdl, const uint8_t
     uint32_t start = xTaskGetTickCount();
     uint32_t timeout_ticks = pdMS_TO_TICKS(timeout_ms);
 
-    while(cdc_dev->data.out_xfer->actual_num_bytes < data_len) {
+    while (cdc_dev->data.out_xfer->actual_num_bytes < data_len) {
         int32_t timeout = timeout_ticks - (xTaskGetTickCount() - start);
         if (timeout > 0) {
             taken = xSemaphoreTake((SemaphoreHandle_t)cdc_dev->data.out_xfer->context, timeout);


### PR DESCRIPTION
for timeout or any reason the semaphore could left untaken before the new transmission start. it causing the transmission pick up the previous actual_num_bytes and return failure because of incorrect number of bytes transferred.