### PR TITLE
fix(host/cdc): Fix TX timeout reaction

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -1,7 +1,8 @@
-## [Unreleased]
+## 2.0.3
 
 - Added `cdc_acm_host_cdc_desc_get()` function that enables users to get CDC functional descriptors of the device
 - Fixed closing of a CDC device from multiple threads
+- Fixed reaction on TX transfer timeout (https://github.com/espressif/esp-protocols/issues/514)
 
 ## 2.0.2
 

--- a/host/class/cdc/usb_host_cdc_acm/idf_component.yml
+++ b/host/class/cdc/usb_host_cdc_acm/idf_component.yml
@@ -1,6 +1,10 @@
 ## IDF Component Manager Manifest File
-version: "2.0.2~1"
+version: "2.0.3"
 description: USB Host CDC-ACM driver
+tags:
+  - usb
+  - usb_host
+  - cdc
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_cdc_acm
 dependencies:
   idf: ">=4.4"


### PR DESCRIPTION
After TX transfer timeout we reset the endpoint which causes all in-flight transfers to complete. The transfer finished callback gives a transfer finished semaphore which we must take, so we would not affect next TX transfers.

Test included

Closes https://github.com/espressif/esp-protocols/issues/514
Closes https://github.com/espressif/esp-usb/pull/40
Closes https://github.com/espressif/esp-idf/issues/13797