### PR TITLE
feat(cdc/modem): Add support to write big payloads in chunks (IEC-128)

### DIFF
--- a/host/class/cdc/esp_modem_usb_dte/CHANGELOG.md
+++ b/host/class/cdc/esp_modem_usb_dte/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.1
+
+- Added support to transmit larger payloads than the buffer_size of DTE
+
+### Known issues
+- ESP32-P4 cannot receive fragmented AT responses from a modem. Thus, some SimCom modems do not work with this version
+
 ## 1.2.0
 
 - Fixed C++ build error for `usb_host_config_t` backward compatibility

--- a/host/class/cdc/esp_modem_usb_dte/esp_modem_usb.cpp
+++ b/host/class/cdc/esp_modem_usb_dte/esp_modem_usb.cpp
@@ -47,7 +47,7 @@ static void usb_host_task(void *arg)
 namespace esp_modem {
 class UsbTerminal : public Terminal, private CdcAcmDevice {
 public:
-    explicit UsbTerminal(const esp_modem_dte_config *config, int term_idx)
+    explicit UsbTerminal(const esp_modem_dte_config *config, int term_idx): buffer_size(config->dte_buffer_size)
     {
         const struct esp_modem_usb_term_config *usb_config = (struct esp_modem_usb_term_config *)(config->extension_config);
 
@@ -117,8 +117,15 @@ public:
     int write(uint8_t *data, size_t len) override
     {
         ESP_LOG_BUFFER_HEXDUMP(TAG, data, len, ESP_LOG_DEBUG);
-        if (this->CdcAcmDevice::tx_blocking(data, len) != ESP_OK) {
-            return -1;
+        uint8_t *ptr = data;
+        size_t remain = len;
+        while (remain > 0) {
+            int batch = std::min(buffer_size, remain);
+            if (this->CdcAcmDevice::tx_blocking(ptr, batch) != ESP_OK) {
+                return -1;
+            }
+            remain -= batch;
+            ptr += batch;
         }
         return len;
     }
@@ -176,7 +183,8 @@ private:
         default:
             abort();
         }
-    };
+    }
+    size_t buffer_size;
 };
 TaskHandle_t UsbTerminal::usb_host_lib_task = nullptr;
 

--- a/host/class/cdc/esp_modem_usb_dte/idf_component.yml
+++ b/host/class/cdc/esp_modem_usb_dte/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.2.0"
+version: "1.2.1"
 description: USB DTE plugin for esp_modem component
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/esp_modem_usb_dte
 


### PR DESCRIPTION
usb host (CDC ACM) does not allow sending more data than the configured `out_xfer->data_buffer_size`.
Modem terminal, however, expects that we could send bigger chunks of data in both data and command mode (it's already supported in both inherent esp_modem terminals: UART, VFS)

* Closes https://github.com/espressif/esp-protocols/issues/589
* Alternative to https://github.com/espressif/esp-protocols/pull/593