### PR TITLE
feat(host_uac): support open device with known vid pid

### DIFF
--- a/host/class/uac/usb_host_uac/CHANGELOG.md
+++ b/host/class/uac/usb_host_uac/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog for USB Host UAC
+
+## 1.1.0
+
+### Improvements
+
+- Added add `uac_host_device_open_with_vid_pid` to open connected audio devices with known VID and PID
+- Print component version message `uac-host: Install Succeed, Version: 1.1.0` in `uac_host_install` function
+
 ## 1.0.0
 
 - Initial version

--- a/host/class/uac/usb_host_uac/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/CMakeLists.txt
@@ -1,3 +1,6 @@
 idf_component_register( SRCS "uac_descriptors.c" "uac_host.c"
                         INCLUDE_DIRS "include"
                         PRIV_REQUIRES usb esp_ringbuf)
+
+include(package_manager)
+cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/host/class/uac/usb_host_uac/Kconfig
+++ b/host/class/uac/usb_host_uac/Kconfig
@@ -4,6 +4,12 @@ menu "USB Host UAC"
         default n
         help
             Print UAC Configuration Descriptor to console.
+    config UAC_DEV_ADDR_LIST_MAX
+        int "Max USB Device Address List"
+        default 6
+        help
+            Max USB Device Address List to find the UAC device. If more devices are connected.
+            The driver will only use the first UAC_DEV_ADDR_LIST_MAX devices.
     config UAC_FREQ_NUM_MAX
         int "Max Number of Frequencies each Alt-interface supports"
         default 4

--- a/host/class/uac/usb_host_uac/idf_component.yml
+++ b/host/class/uac/usb_host_uac/idf_component.yml
@@ -1,9 +1,10 @@
 ## IDF Component Manager Manifest File
-version: "1.0.0"
+version: "1.1.0"
 description: USB Host UAC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uac/usb_host_uac
 dependencies:
   idf: ">=4.4"
+  cmake_utilities: "0.5.*"
 targets:
   - esp32s2
   - esp32s3

--- a/host/class/uac/usb_host_uac/include/usb/uac_host.h
+++ b/host/class/uac/usb_host_uac/include/usb/uac_host.h
@@ -197,8 +197,10 @@ esp_err_t uac_host_install(const uac_host_driver_config_t *config);
 esp_err_t uac_host_uninstall(void);
 
 /**
- * @brief Open a UAC logic device/interface
+ * @brief Open a UAC logic device/interface when new UAC device is connected
  *
+ * @note The config->addr and config->iface_num should be retrieved from the UAC driver event callback
+ *      after UAC_HOST_DRIVER_EVENT_RX_CONNECTED or UAC_HOST_DRIVER_EVENT_TX_CONNECTED event
  * @param[in] config            Pointer to UAC device configuration structure
  * @param[out] uac_dev_handle   Pointer to UAC device handle
  * @return esp_err_t
@@ -209,6 +211,27 @@ esp_err_t uac_host_uninstall(void);
  *  - ESP_ERR_NOT_SUPPORTED if the UAC version is not supported
  */
 esp_err_t uac_host_device_open(const uac_host_device_config_t *config, uac_host_device_handle_t *uac_dev_handle);
+
+/**
+ * @brief Open a UAC logic device/interface with specific VID, PID and interface number
+ *
+ * @note The config->addr is not used in this function, the VID, PID and config->iface_num should be provided by user.
+ *       If multiple hardware devices with the same VID and PID are connected through USB hub, the first one will be opened.
+ *
+ * @param[in] vid               Vendor ID
+ * @param[in] pid               Product ID
+ * @param[in] config            Pointer to UAC device configuration structure
+ * @param[out] uac_dev_handle   Pointer to UAC device handle
+ * @return esp_err_t
+ * - ESP_OK on success
+ * - ESP_ERR_INVALID_STATE if UAC driver is not installed
+ * - ESP_ERR_INVALID_ARG if the configuration is invalid
+ * - ESP_ERR_NO_MEM if memory allocation failed
+ * - ESP_ERR_NOT_SUPPORTED if the UAC version is not supported
+ * - ESP_ERR_NOT_FOUND if the device is not found
+ */
+esp_err_t uac_host_device_open_with_vid_pid(uint16_t vid, uint16_t pid, const uac_host_device_config_t *config,
+        uac_host_device_handle_t *uac_dev_handle);
 
 /**
  * @brief Close a UAC logic device/interface


### PR DESCRIPTION
## 1.1.0

### Improvements

- Added add `uac_host_device_open_with_vid_pid` to open connected audio devices with known VID and PID
- Print component version message `uac-host: Install Succeed, Version: 1.1.0` in `uac_host_install` function