### PR TITLE
feat(cdc): fix compilation with GCC14 (IEC-138)

### DIFF
--- a/host/class/cdc/usb_host_vcp/CMakeLists.txt
+++ b/host/class/cdc/usb_host_vcp/CMakeLists.txt
@@ -5,4 +5,7 @@ set_target_properties(${COMPONENT_LIB} PROPERTIES
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON
 )
-target_compile_options(${COMPONENT_LIB} PRIVATE -fconcepts)
+
+if (GCC_VERSION VERSION_LESS_EQUAL 13.2)  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116070
+    target_compile_options(${COMPONENT_LIB} PRIVATE -fconcepts)
+endif()

--- a/host/class/cdc/usb_host_vcp/idf_component.yml
+++ b/host/class/cdc/usb_host_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.0~2"
+version: "1.0.0~3"
 description: USB Host Virtual COM Port Service
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_vcp
 dependencies:


### PR DESCRIPTION
After upgrading to gcc14 i faced this issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116070

There is a solution to suppress the errors, but I don't know if you happy with these changes and why the default gnu++XX standard derived from idf could not be used...

P.s.: This change looks valid to me if take into account: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116071#c2
