### PR TITLE
HID driver release 1.0.3

### DIFF
--- a/host/class/hid/usb_host_hid/CHANGELOG.md
+++ b/host/class/hid/usb_host_hid/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+- Fixed a bug with interface mismatch on EP IN transfer complete while several HID devices are present.
+- Fixed a bug during device freeing, while detaching one of several attached HID devices.
+
 ## 1.0.2
 
 - Added support for ESP32-P4

--- a/host/class/hid/usb_host_hid/idf_component.yml
+++ b/host/class/hid/usb_host_hid/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.2"
+version: "1.0.3"
 description: USB Host HID driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/hid/usb_host_hid
 dependencies:


### PR DESCRIPTION
# USB Host HID Class Driver v1.0.3 (Release)

## General description
- Initial support for external Hubs
 
## Changes
1. Fixed a bug with interface mismatch on EP IN transfer complete while several HID devices are present.
2. Fixed a bug during device freeing, while detaching one of several attached HID devices.

## Details
1. Wrong interface has been selected by EP number, while handling transfer complete callback for EP IN of HID Device. Fully removed logic of getting interface by EP number, instead keep the interface pointer in `xfer->context` field. 
2.  Wrong logic of releasing and freeing HID device object during device detaching. When several device were attached, the STAILQ was never empty, so the driver hanged infinitely.

