### PR TITLE
feat(cdc): fix GCC version variable name for CMake (IEC-151)

### DIFF
--- a/host/class/cdc/usb_host_vcp/CMakeLists.txt
+++ b/host/class/cdc/usb_host_vcp/CMakeLists.txt
@@ -6,6 +6,6 @@ set_target_properties(${COMPONENT_LIB} PROPERTIES
     CXX_STANDARD_REQUIRED ON
 )
 
-if (GCC_VERSION VERSION_LESS_EQUAL 13.2)  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116070
+if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 13.2)  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116070
     target_compile_options(${COMPONENT_LIB} PRIVATE -fconcepts)
 endif()

--- a/host/class/cdc/usb_host_vcp/idf_component.yml
+++ b/host/class/cdc/usb_host_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.0~3"
+version: "1.0.0~4"
 description: USB Host Virtual COM Port Service
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_vcp
 dependencies:


### PR DESCRIPTION
Related to https://github.com/espressif/esp-usb/pull/47

Sorry I set wrong gcc version variable for CMake in prior PR :(

@tore-espressif