### PR TITLE
fix(host/cdc_acm): Fix CTRL transfer size for devices with small MaxPacketSize0

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- Fixed Control transfer allocation size for too small EP0 Max Packet Size (https://github.com/espressif/esp-idf/issues/14345)
+
 ## 2.0.3
 
 - Added `cdc_acm_host_cdc_desc_get()` function that enables users to get CDC functional descriptors of the device


### PR DESCRIPTION
Some devices have MaxPacketSize0 = 8 which is not enough for some CDC specific CTRL requests

Closes https://github.com/espressif/esp-idf/issues/14345