### PR TITLE
fix(ci): Do not upgrade idf-component-manager

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install idf-component-manager idf-build-apps --upgrade
+          pip install idf-build-apps --upgrade
           export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
           export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
           export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"


### PR DESCRIPTION
Fix idf-component-manager build with IDF v4.4

Idf-component-manager v2.0.0 was released yesterday and it is not compatible with IDF v4.4