### PR TITLE
feat(cmock): Enable linux target build for HID, CDC-ACM and UVC hosts

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -6,6 +6,15 @@ host/class:
   enable:
     - if: SOC_USB_OTG_SUPPORTED == 1
 
+# Host tests
 host/class/cdc/usb_host_cdc_acm/host_test:
+  enable:
+    - if: IDF_TARGET in ["linux"] and (IDF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 4)
+
+host/class/hid/usb_host_hid/host_test:
+  enable:
+    - if: IDF_TARGET in ["linux"] and (IDF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 4)
+
+host/class/uvc/usb_host_uvc/host_test:
   enable:
     - if: IDF_TARGET in ["linux"] and (IDF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 4)

--- a/host/class/cdc/usb_host_cdc_acm/host_test/main/test_unit_public_api.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/main/test_unit_public_api.cpp
@@ -1,0 +1,77 @@
+
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <catch2/catch_test_macros.hpp>
+
+#include "usb/cdc_acm_host.h"
+
+extern "C" {
+#include "Mockusb_host.h"
+#include "Mockqueue.h"
+#include "Mocktask.h"
+#include "Mockidf_additions.h"
+#include "Mockportmacro.h"
+#include "Mockevent_groups.h"
+}
+
+SCENARIO("CDC-ACM Host install")
+{
+    // CDC-ACM Host driver config set to nullptr
+    GIVEN("NO CDC-ACM Host driver config, driver not installed") {
+        TaskHandle_t task_handle;
+        int sem;
+        int event_group;
+
+        // Call cdc_acm_host_install with cdc_acm_host_driver_config set to nullptr, fail to create EventGroup
+        SECTION("Fail to create EventGroup") {
+            // Create an EventGroup, return nullptr, so the EventGroup is not created successfully
+            xEventGroupCreate_ExpectAndReturn(nullptr);
+            // We should be calling xSemaphoreCreteMutex_ExpectAnyArgsAndRetrun instead of xQueueCreateMutex_ExpectAnyArgsAndReturn
+            // Because of missing Freertos Mocks
+            // Create a semaphore, return the semaphore handle (Queue Handle in this scenario), so the semaphore is created successfully
+            xQueueCreateMutex_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&sem));
+            // Create a task, return pdTRUE, so the task is created successfully
+            xTaskCreatePinnedToCore_ExpectAnyArgsAndReturn(pdTRUE);
+            // Return task handle by pointer
+            xTaskCreatePinnedToCore_ReturnThruPtr_pxCreatedTask(&task_handle);
+
+            // goto err: (xEventGroupCreate returned nullptr), delete the queue and the task
+            vQueueDelete_Expect(reinterpret_cast<QueueHandle_t>(&sem));
+            vTaskDelete_Expect(task_handle);
+
+            // Call the DUT function, expect ESP_ERR_NO_MEM
+            REQUIRE(ESP_ERR_NO_MEM == cdc_acm_host_install(nullptr));
+        }
+
+        // Call cdc_acm_host_install, expect to successfully install the CDC ACM host
+        SECTION("Successfully install CDC ACM Host") {
+            // Create an EventGroup, return event group handle, so the EventGroup is created successfully
+            xEventGroupCreate_ExpectAndReturn(reinterpret_cast<EventGroupHandle_t>(&event_group));
+            // We should be calling xSemaphoreCreteMutex_ExpectAnyArgsAndRetrun instead of xQueueCreateMutex_ExpectAnyArgsAndReturn
+            // Because of missing Freertos Mocks
+            // Create a semaphore, return the semaphore handle (Queue Handle in this scenario), so the semaphore is created successfully
+            xQueueCreateMutex_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&sem));
+            // Create a task, return pdTRUE, so the task is created successfully
+            vPortEnterCritical_Expect();
+            vPortExitCritical_Expect();
+            xTaskCreatePinnedToCore_ExpectAnyArgsAndReturn(pdTRUE);
+            // Return task handle by pointer
+            xTaskCreatePinnedToCore_ReturnThruPtr_pxCreatedTask(&task_handle);
+
+            // Call mocked function from USB Host
+            // return ESP_OK, so the client si registered successfully
+            usb_host_client_register_ExpectAnyArgsAndReturn(ESP_OK);
+
+            // Resume the task
+            vTaskResume_Expect(task_handle);
+
+            // Call the DUT Function, expect ESP_OK
+            REQUIRE(ESP_OK == cdc_acm_host_install(nullptr));
+        }
+    }
+}

--- a/host/class/hid/usb_host_hid/host_test/CMakeLists.txt
+++ b/host/class/hid/usb_host_hid/host_test/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+set(COMPONENTS main)
+
+list(APPEND EXTRA_COMPONENT_DIRS
+     "$ENV{IDF_PATH}/tools/mocks/usb/"
+     "$ENV{IDF_PATH}/tools/mocks/freertos/"
+    )
+
+project(host_test_usb_hid)

--- a/host/class/hid/usb_host_hid/host_test/README.md
+++ b/host/class/hid/usb_host_hid/host_test/README.md
@@ -3,8 +3,7 @@
 
 # Description
 
-This directory contains test code for `USB Host CDC-ACM` driver. Namely:
-* Descriptor parsing
+This directory contains test code for `USB Host HID` driver. Namely:
 * Simple public API call with mocked USB component to test Linux build and Cmock run for this class driver
 
 Tests are written using [Catch2](https://github.com/catchorg/Catch2) test framework, use CMock, so you must install Ruby on your machine to run them.
@@ -25,7 +24,7 @@ The build produces an executable in the build folder.
 Just run:
 
 ```
-./build/host_test_usb_cdc.elf
+./build/host_test_usb_hid.elf
 ```
 
 The test executable have some options provided by the test framework. 

--- a/host/class/hid/usb_host_hid/host_test/main/CMakeLists.txt
+++ b/host/class/hid/usb_host_hid/host_test/main/CMakeLists.txt
@@ -1,0 +1,8 @@
+idf_component_register(SRC_DIRS .
+                        REQUIRES cmock usb
+                        INCLUDE_DIRS .
+                        WHOLE_ARCHIVE)
+
+# Currently 'main' for IDF_TARGET=linux is defined in freertos component.
+# Since we are using a freertos mock here, need to let Catch2 provide 'main'.
+target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)

--- a/host/class/hid/usb_host_hid/host_test/main/idf_component.yml
+++ b/host/class/hid/usb_host_hid/host_test/main/idf_component.yml
@@ -1,0 +1,5 @@
+dependencies:
+  espressif/catch2: "^3.4.0"
+  usb_host_hid:
+    version: "*"
+    override_path: "../../"

--- a/host/class/hid/usb_host_hid/host_test/main/test_unit_public_api.cpp
+++ b/host/class/hid/usb_host_hid/host_test/main/test_unit_public_api.cpp
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <catch2/catch_test_macros.hpp>
+
+#include "usb/hid_host.h"
+#include "usb/hid.h"
+
+extern "C" {
+#include "Mockusb_host.h"
+#include "Mockqueue.h"
+#include "Mocktask.h"
+#include "Mockidf_additions.h"
+#include "Mockportmacro.h"
+}
+
+SCENARIO("HID Host install")
+{
+    hid_host_driver_config_t hid_host_driver_config = {
+        .create_background_task = true,
+        .task_priority = 5,
+        .stack_size = 4096,
+        .core_id = 0,
+        .callback = (reinterpret_cast<hid_host_driver_event_cb_t>(0xdeadbeef)),
+        .callback_arg = nullptr
+    };
+
+    // HID Host driver config set to nullptr
+    GIVEN("NO HID Host driver config, driver not already installed") {
+
+        // Call hid_host_install with hid_host_driver_config set to nullptr
+        SECTION("Config is nullptr") {
+            REQUIRE(ESP_ERR_INVALID_ARG == hid_host_install(nullptr));
+        }
+    }
+
+    // HID Host driver config set to config from HID Host example, but without callback
+    GIVEN("Minimal HID Host driver config, driver not already installed") {
+        hid_host_driver_config.callback = nullptr;
+
+        SECTION("Config error: no callback") {
+            // Call the DUT function, expect ESP_ERR_INVALID_ARG
+            REQUIRE(ESP_ERR_INVALID_ARG == hid_host_install(&hid_host_driver_config));
+        }
+
+        SECTION("Config error: stack size is 0") {
+            hid_host_driver_config.stack_size = 0;
+            // Call the DUT function, expect ESP_ERR_INVALID_ARG
+            REQUIRE(ESP_ERR_INVALID_ARG == hid_host_install(&hid_host_driver_config));
+        }
+
+        SECTION("Config error: task priority is 0") {
+            hid_host_driver_config.task_priority = 0;
+            // Call the DUT function, expect ESP_ERR_INVALID_ARG
+            REQUIRE(ESP_ERR_INVALID_ARG == hid_host_install(&hid_host_driver_config));
+        }
+    }
+
+    // HID Host driver config set to config from HID Host example
+    GIVEN("Full HID Host config, driver not already installed") {
+        int mtx;
+
+        // Install error: failed to create semaphore
+        SECTION("Install error: unable to create semaphore") {
+            // We must call xQueueGenericCreate_ExpectAnyArgsAndReturn instead of xSemaphoreCreateBinary_ExpectAnyArgsAndReturn
+            // Because of missing Freertos Mocks
+            // Create a semaphore, return nullptr, so the semaphore is not created successfully
+            xQueueGenericCreate_ExpectAnyArgsAndReturn(nullptr);
+
+            // Call the DUT function, expect ESP_ERR_NO_MEM
+            REQUIRE(ESP_ERR_NO_MEM == hid_host_install(&hid_host_driver_config));
+        }
+
+        // Unable to register client: Invalid state, goto fail
+        SECTION("Client register not successful: goto fail") {
+            // We must call xQueueGenericCreate_ExpectAnyArgsAndReturn instead of xSemaphoreCreateBinary_ExpectAnyArgsAndReturn
+            // Because of missing Freertos Mocks
+            // Create a semaphore, return the semaphore handle (Queue Handle in this scenario), so the semaphore is created successfully
+            xQueueGenericCreate_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&mtx));
+            // Register a client, return ESP_ERR_INVALID_STATE, so the client is not registered successfully
+            usb_host_client_register_ExpectAnyArgsAndReturn(ESP_ERR_INVALID_STATE);
+
+            // goto fail: delete the semaphore (Queue in this scenario)
+            vQueueDelete_Expect(reinterpret_cast<QueueHandle_t>(&mtx));
+
+            // Call the DUT function, expect ESP_ERR_INVALID_STATE
+            REQUIRE(ESP_ERR_INVALID_STATE == hid_host_install(&hid_host_driver_config));
+        }
+
+        SECTION("Client register successful: create background task fail") {
+            usb_host_client_handle_t client_handle;
+
+            // Create a semaphore, return the semaphore handle (Queue Handle in this scenario), so the semaphore is created successfully
+            xQueueGenericCreate_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&mtx));
+            // Register a client, return ESP_OK, so the client is registered successfully
+            usb_host_client_register_ExpectAnyArgsAndReturn(ESP_OK);
+            // Fill the pointer to the client_handle, which is used in goto fail, to deregister the client
+            usb_host_client_register_ReturnThruPtr_client_hdl_ret(&client_handle);
+
+            // Create a background task, return pdFALSE, so the task in not created successfully
+            vPortEnterCritical_Expect();
+            vPortExitCritical_Expect();
+            xTaskCreatePinnedToCore_ExpectAnyArgsAndReturn(pdFALSE);
+
+            // goto fail: delete the semaphore and deregister the client
+            // usb_host_client_deregister is not being checked for the return value !! Consider adding it to the host driver
+            usb_host_client_deregister_ExpectAndReturn(client_handle, ESP_OK);
+            // Delete the semaphore (Queue in this scenario)
+            vQueueDelete_Expect(reinterpret_cast<QueueHandle_t>(&mtx));
+
+            // Call the DUT function, expect ESP_ERR_NO_MEM
+            REQUIRE(ESP_ERR_NO_MEM == hid_host_install(&hid_host_driver_config));
+        }
+
+        // Call hid_host_install and expect successful installation
+        SECTION("Client register successful: hid_host_install successful") {
+            // Create semaphore, return semaphore handle (Queue Handle in this scenario), so the semaphore is created successfully
+            xQueueGenericCreate_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&mtx));
+            // return ESP_OK, so the client is registered successfully
+            usb_host_client_register_ExpectAnyArgsAndReturn(ESP_OK);
+
+            // Create a background task successfully by returning pdTRUE
+            vPortEnterCritical_Expect();
+            vPortExitCritical_Expect();
+            xTaskCreatePinnedToCore_ExpectAnyArgsAndReturn(pdTRUE);
+
+            // Call the DUT function, expect ESP_OK
+            REQUIRE(ESP_OK == hid_host_install(&hid_host_driver_config));
+        }
+    }
+
+    // HID Host driver config set to config from HID Host example
+    GIVEN("Full HID Host config, driver already installed") {
+
+        // Driver is already installed
+        SECTION("Install error: driver already installed") {
+            // Call the DUT function again to get the ESP_ERR_INVALID_STATE error
+            REQUIRE(ESP_ERR_INVALID_STATE == hid_host_install(&hid_host_driver_config));
+        }
+    }
+}

--- a/host/class/hid/usb_host_hid/host_test/sdkconfig.defaults
+++ b/host/class/hid/usb_host_hid/host_test/sdkconfig.defaults
@@ -1,0 +1,8 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) 5.4.0 Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="linux"
+CONFIG_COMPILER_CXX_EXCEPTIONS=y
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=12000
+CONFIG_FREERTOS_HZ=1000
+CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n

--- a/host/class/hid/usb_host_hid/idf_component.yml
+++ b/host/class/hid/usb_host_hid/idf_component.yml
@@ -4,7 +4,3 @@ description: USB Host HID driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/hid/usb_host_hid
 dependencies:
   idf: ">=4.4"
-targets:
-  - esp32s2
-  - esp32s3
-  - esp32p4

--- a/host/class/uvc/usb_host_uvc/host_test/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/host_test/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+set(COMPONENTS main)
+
+list(APPEND EXTRA_COMPONENT_DIRS
+     "$ENV{IDF_PATH}/tools/mocks/usb/"
+     "$ENV{IDF_PATH}/tools/mocks/freertos/"
+    )
+
+project(host_test_usb_uvc)

--- a/host/class/uvc/usb_host_uvc/host_test/README.md
+++ b/host/class/uvc/usb_host_uvc/host_test/README.md
@@ -3,8 +3,7 @@
 
 # Description
 
-This directory contains test code for `USB Host CDC-ACM` driver. Namely:
-* Descriptor parsing
+This directory contains test code for `USB Host UVC` driver. Namely:
 * Simple public API call with mocked USB component to test Linux build and Cmock run for this class driver
 
 Tests are written using [Catch2](https://github.com/catchorg/Catch2) test framework, use CMock, so you must install Ruby on your machine to run them.
@@ -25,7 +24,7 @@ The build produces an executable in the build folder.
 Just run:
 
 ```
-./build/host_test_usb_cdc.elf
+./build/host_test_usb_uvc.elf
 ```
 
 The test executable have some options provided by the test framework. 

--- a/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
@@ -1,0 +1,9 @@
+idf_component_register(SRC_DIRS .
+                        REQUIRES cmock usb
+                        INCLUDE_DIRS .
+                        PRIV_INCLUDE_DIRS "../../private_include"
+                        WHOLE_ARCHIVE)
+
+# Currently 'main' for IDF_TARGET=linux is defined in freertos component.
+# Since we are using a freertos mock here, need to let Catch2 provide 'main'.
+target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)

--- a/host/class/uvc/usb_host_uvc/host_test/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/host_test/main/idf_component.yml
@@ -1,0 +1,5 @@
+dependencies:
+  espressif/catch2: "^3.4.0"
+  usb_host_uvc:
+    version: "*"
+    override_path: "../../"

--- a/host/class/uvc/usb_host_uvc/host_test/main/test_unit_public_api.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/test_unit_public_api.cpp
@@ -1,0 +1,28 @@
+
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <catch2/catch_test_macros.hpp>
+
+#include "libuvc/libuvc.h"
+#include "libuvc_helper.h"
+#include "libuvc_adapter.h"
+
+extern "C" {
+#include "Mockusb_host.h"
+}
+
+SCENARIO("UVC Host Handle events")
+{
+    GIVEN("Libusb has not been initialized") {
+
+        // Call libuvc_adapter_handle_events and expect ESP_ERR_INVALID_STATE
+        SECTION("s_uvc_driver is NULL") {
+            REQUIRE(ESP_ERR_INVALID_STATE == libuvc_adapter_handle_events(0));
+        }
+    }
+}

--- a/host/class/uvc/usb_host_uvc/host_test/sdkconfig.defaults
+++ b/host/class/uvc/usb_host_uvc/host_test/sdkconfig.defaults
@@ -1,0 +1,8 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) 5.4.0 Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="linux"
+CONFIG_COMPILER_CXX_EXCEPTIONS=y
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=12000
+CONFIG_FREERTOS_HZ=1000
+CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n

--- a/host/class/uvc/usb_host_uvc/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/idf_component.yml
@@ -8,7 +8,3 @@ sbom:
   manifests:
     - path: sbom_libuvc.yml
       dest: libuvc
-targets:
-  - esp32s2
-  - esp32s3
-  - esp32p4

--- a/host/class/uvc/usb_host_uvc/include/libuvc_helper.h
+++ b/host/class/uvc/usb_host_uvc/include/libuvc_helper.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-inline static char *uvc_error_string(uvc_error_t error)
+inline static const char *uvc_error_string(uvc_error_t error)
 {
     switch (error) {
     case UVC_SUCCESS: return "UVC_SUCCESS";

--- a/host/class/uvc/usb_host_uvc/src/libusb_adapter.c
+++ b/host/class/uvc/usb_host_uvc/src/libusb_adapter.c
@@ -374,7 +374,7 @@ int32_t libusb_get_device_list(struct libusb_context *ctx, libusb_device ***list
     }
 
     for (size_t i = 0; i < actual_count; i++) {
-        dev_list[i] = (libusb_device *)(uint32_t)dev_addr_list[i];
+        dev_list[i] = (libusb_device *)(uintptr_t)dev_addr_list[i];
     }
     *list = (libusb_device **)dev_list;
     return actual_count;
@@ -453,7 +453,7 @@ static esp_err_t close_device(uvc_camera_t *device)
 
 int libusb_open(libusb_device *dev, libusb_device_handle **dev_handle)
 {
-    uint8_t device_addr = (uint8_t)(uint32_t)dev;
+    uint8_t device_addr = (uint8_t)(uintptr_t)dev;
     uvc_camera_t *device;
 
     RETURN_ON_ERROR_LIBUSB( open_device_if_closed(device_addr, &device) );
@@ -672,7 +672,7 @@ int libusb_control_transfer(libusb_device_handle *dev_handle,
 
 int libusb_get_device_descriptor(libusb_device *dev, struct libusb_device_descriptor *desc)
 {
-    uint8_t device_addr = (uint8_t)(uint32_t)dev;
+    uint8_t device_addr = (uint8_t)(uintptr_t)dev;
     const usb_device_desc_t *device_desc;
     uvc_camera_t *device;
 
@@ -705,7 +705,7 @@ int libusb_get_config_descriptor(libusb_device *dev,
                                  uint8_t config_index,
                                  struct libusb_config_descriptor **config)
 {
-    uint8_t device_addr = (uint8_t)(uint32_t)dev;
+    uint8_t device_addr = (uint8_t)(uintptr_t)dev;
     const usb_config_desc_t *config_desc;
     uvc_camera_t *device;
 
@@ -835,5 +835,5 @@ int8_t libusb_get_bus_number(libusb_device *device)
 int8_t libusb_get_device_address(libusb_device *device)
 {
     // Device address is stored directly in libusb_device
-    return (uint8_t)(uint32_t)device;
+    return (uint8_t)(uintptr_t)device;
 }


### PR DESCRIPTION
## Description
As a part of Linux host testing, we have created a mock of USB component in the esp-idf, which will be used for testing of Class drivers within this (esp-usb) repository using Cmock test cases. 
 
#### This MR adds Linux target build for:
 - HID Host
 - UVC Host

#### Already buildable Class drivers for linux:
 - CDC ACM Host

#### Not buildable Class drivers for linux:
 - MSC Host - `vfs` not buildable for linux
 - UAC Host - Ringbuffer support missing in Freerots Cmock
 - esp_tinyusb - `vfs` not buildable for linux

As discussed, rather than adding new supported target into the `idf_component.yml` file, (`linux` in this case, and other targets in future) the target list was removed from (those class drivers buildable for linux) and a target compatibility will be handled during build.

## Changes
 - HID Host linux build + simple cmock unit test
 - UVC Host linux build + simple cmock unit test
 - CDC ACM simple cmock unit test

## Related
 -  IDF-10351 - USB host testing: CMock on Linux

## Testing
 - For each class driver buildable on Linux a simple cmock host test has been added

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
