### PR TITLE
fix(usb_host_msc): Changed HID -> MSC in debug output

### DIFF
--- a/host/class/msc/usb_host_msc/src/msc_host.c
+++ b/host/class/msc/usb_host_msc/src/msc_host.c
@@ -345,10 +345,10 @@ esp_err_t msc_host_handle_events(uint32_t timeout)
  */
 static void event_handler_task(void *arg)
 {
-    ESP_LOGD(TAG, "USB HID handling start");
+    ESP_LOGD(TAG, "USB MSC handling start");
     while (msc_host_handle_events(portMAX_DELAY) == ESP_OK) {
     }
-    ESP_LOGD(TAG, "USB HID handling stop");
+    ESP_LOGD(TAG, "USB MSC handling stop");
     vTaskDelete(NULL);
 }
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Cleanup debug output in MSC class driver.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

* Closes IDF-9047

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
N/A
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
