### PR TITLE
feat(cdc_acm): Add SimCom A7672 modem to descriptor tests

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/host_test/main/cdc_descriptors.hpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/main/cdc_descriptors.hpp
@@ -27,7 +27,7 @@
             - Qualcomm / Option SimTech, Incorporated (SIM7600E)
             - Qualcomm / Option SimTech SIM7000 (SIM7000E)
             - NOT TESTED: Qualcomm / Option SimTech SIM7080 (SIM7080G)
-            - NOT TESTED: Qualcomm / Option A76XX Series LTE Module (SIMA7672E)
+            - Qualcomm / Option A76XX Series LTE Module (SIMA7672E)
         - USB dongle:
             - NOT TESTED: Shenzhen Rapoo Technology Co., Ltd. Rapoo 2.4G Wireless Device
             - NOT TESTED: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)

--- a/host/class/cdc/usb_host_cdc_acm/host_test/main/test_parsing_modems.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/main/test_parsing_modems.cpp
@@ -200,3 +200,62 @@ SCENARIO("Modems descriptor parsing: 7000E", "[modem][7000E]")
         }
     }
 }
+
+SCENARIO("Modems descriptor parsing: A7672E", "[modem][A7672E]")
+{
+    GIVEN("SimCom A7672E FS") {
+        const usb_device_desc_t *dev_desc = (const usb_device_desc_t *)sima7672e_device_desc_fs_hs;
+        const usb_config_desc_t *cfg_desc = (const usb_config_desc_t *)sima7672e_config_desc_fs;
+
+        // Interface 0-1 belongs USB_CLASS_WIRELESS_CONTROLLER class, expect no CDC interface
+        SECTION("Interface 0") {
+            cdc_parsed_info_t parsed_result = {};
+            esp_err_t ret = cdc_parse_interface_descriptor(dev_desc, cfg_desc, 0, &parsed_result);
+            REQUIRE(ret == ESP_ERR_NOT_FOUND);
+        }
+
+        // Diagnostic interface
+        SECTION("Interface 2") {
+            cdc_parsed_info_t parsed_result = {};
+            esp_err_t ret = cdc_parse_interface_descriptor(dev_desc, cfg_desc, 2, &parsed_result);
+            REQUIRE_CDC_NONCOMPLIANT(ret, parsed_result);
+        }
+
+        // Interface 3: NMEA, Interface 4-5: AT
+        for (int interface = 3; interface <= 5; ++interface) {
+            SECTION("Interface " + std::to_string(interface)) {
+                cdc_parsed_info_t parsed_result = {};
+                esp_err_t ret = cdc_parse_interface_descriptor(dev_desc, cfg_desc, interface, &parsed_result);
+                REQUIRE_CDC_NONCOMPLIANT_WITH_NOTIFICATION(ret, parsed_result);
+            }
+        }
+    }
+
+    GIVEN("SimCom A7672E HS") {
+        const usb_device_desc_t *dev_desc = (const usb_device_desc_t *)sima7672e_device_desc_fs_hs;
+        const usb_config_desc_t *cfg_desc = (const usb_config_desc_t *)sima7672e_config_desc_hs;
+
+        // Interface 0-1 belongs USB_CLASS_WIRELESS_CONTROLLER class, expect no CDC interface
+        SECTION("Interface 0") {
+            cdc_parsed_info_t parsed_result = {};
+            esp_err_t ret = cdc_parse_interface_descriptor(dev_desc, cfg_desc, 0, &parsed_result);
+            REQUIRE(ret == ESP_ERR_NOT_FOUND);
+        }
+
+        // Diagnostic interface
+        SECTION("Interface 2") {
+            cdc_parsed_info_t parsed_result = {};
+            esp_err_t ret = cdc_parse_interface_descriptor(dev_desc, cfg_desc, 2, &parsed_result);
+            REQUIRE_CDC_NONCOMPLIANT(ret, parsed_result);
+        }
+
+        // Interface 3: NMEA, Interface 4-5: AT
+        for (int interface = 3; interface <= 5; ++interface) {
+            SECTION("Interface " + std::to_string(interface)) {
+                cdc_parsed_info_t parsed_result = {};
+                esp_err_t ret = cdc_parse_interface_descriptor(dev_desc, cfg_desc, interface, &parsed_result);
+                REQUIRE_CDC_NONCOMPLIANT_WITH_NOTIFICATION(ret, parsed_result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tests modem descriptor parsing from https://github.com/espressif/esp-usb/issues/76