### PR TITLE
ci(usb_host): Class drivers test apps run on esp32p4

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -49,8 +49,23 @@ jobs:
       fail-fast: false
       matrix:
         idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
-        idf_target: ["esp32s2"]
+        idf_target: ["esp32s2", "esp32p4"]
         runner_tag: ["usb_host", "usb_device"]
+        exclude:
+          # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
+          - idf_ver: "release-v5.0"
+            idf_target: "esp32p4"
+          - idf_ver: "release-v5.1"
+            idf_target: "esp32p4"
+          - idf_ver: "release-v5.2"
+            idf_target: "esp32p4"
+          - idf_ver: "release-v5.3" # TODO: enable IDF 5.3 once the docker image is updated
+            idf_target: "esp32p4"
+
+          # Exclude esp32p4 for all versions when using the usb_device runner
+          - idf_target: "esp32p4"   # TODO: esp32p4 usb_device runner not built yet
+            runner_tag: "usb_device"
+
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
     container:
       image: python:3.11-bookworm

--- a/host/class/cdc/usb_host_cdc_acm/test_app/README.md
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/README.md
@@ -9,4 +9,7 @@ It tests basic functionality of the driver like open/close/read/write operations
 
 ### Hardware Required
 
+This test requires two ESP32 development board with USB-OTG support. The development boards shall have interconnected USB peripherals,
+one acting as host running CDC-ACM host driver and another CDC-ACM device driver (tinyusb).
+
 This test expects that TinyUSB dual CDC device with VID = 0x303A and PID = 0x4002 is connected to the USB host.

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_app_main.c
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_app_main.c
@@ -7,17 +7,17 @@
 #include <stdio.h>
 #include <string.h>
 #include "unity.h"
-#include "esp_heap_caps.h"
+#include "unity_test_runner.h"
+#include "unity_test_utils_memory.h"
 
-static size_t before_free_8bit;
-static size_t before_free_32bit;
-
-#define TEST_MEMORY_LEAK_THRESHOLD (-530)
-static void check_leak(size_t before_free, size_t after_free, const char *type)
+void setUp(void)
 {
-    ssize_t delta = after_free - before_free;
-    printf("MALLOC_CAP_%s: Before %u bytes free, After %u bytes free (delta %d)\n", type, before_free, after_free, delta);
-    TEST_ASSERT_MESSAGE(delta >= TEST_MEMORY_LEAK_THRESHOLD, "memory leak");
+    unity_utils_record_free_mem();
+}
+
+void tearDown(void)
+{
+    unity_utils_evaluate_leaks();
 }
 
 void app_main(void)
@@ -35,23 +35,7 @@ void app_main(void)
     printf("|______/ /_______  / |______  /  |__|  \\___  >____  > |__|  \r\n");
     printf("                 \\/         \\/             \\/     \\/        \r\n");
 
-    UNITY_BEGIN();
+    unity_utils_setup_heap_record(80);
+    unity_utils_set_leak_level(530);
     unity_run_menu();
-    UNITY_END();
-}
-
-/* setUp runs before every test */
-void setUp(void)
-{
-    before_free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-    before_free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
-}
-
-/* tearDown runs after every test */
-void tearDown(void)
-{
-    size_t after_free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-    size_t after_free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
-    check_leak(before_free_8bit, after_free_8bit, "8BIT");
-    check_leak(before_free_32bit, after_free_32bit, "32BIT");
 }

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/usb_device.c
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/usb_device.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +8,6 @@
 #include "sdkconfig.h"
 #include "tinyusb.h"
 #include "tusb_cdc_acm.h"
-#include "esp_idf_version.h"
 
 static uint8_t buf[CONFIG_TINYUSB_CDC_RX_BUFSIZE + 1];
 static void tinyusb_cdc_rx_callback(int itf, cdcacm_event_t *event)
@@ -20,7 +19,6 @@ static void tinyusb_cdc_rx_callback(int itf, cdcacm_event_t *event)
     tinyusb_cdcacm_write_flush(itf, 0);
 }
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 static const tusb_desc_device_t cdc_device_descriptor = {
     .bLength = sizeof(cdc_device_descriptor),
     .bDescriptorType = TUSB_DESC_DEVICE,
@@ -39,22 +37,49 @@ static const tusb_desc_device_t cdc_device_descriptor = {
 };
 
 static const uint16_t cdc_desc_config_len = TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN;
-static const uint8_t cdc_desc_configuration[] = {
+static const uint8_t cdc_fs_desc_configuration[] = {
     TUD_CONFIG_DESCRIPTOR(1, 4, 0, cdc_desc_config_len, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
     TUD_CDC_DESCRIPTOR(0, 4, 0x81, 8, 0x02, 0x82, 64),
     TUD_CDC_DESCRIPTOR(2, 4, 0x83, 8, 0x04, 0x84, 64),
 };
-#endif
+
+#if (TUD_OPT_HIGH_SPEED)
+static const uint8_t cdc_hs_desc_configuration[] = {
+    TUD_CONFIG_DESCRIPTOR(1, 4, 0, cdc_desc_config_len, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CDC_DESCRIPTOR(0, 4, 0x81, 8, 0x02, 0x82, 512),
+    TUD_CDC_DESCRIPTOR(2, 4, 0x83, 8, 0x04, 0x84, 512),
+};
+
+static const tusb_desc_device_qualifier_t device_qualifier = {
+    .bLength = sizeof(tusb_desc_device_qualifier_t),
+    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .bNumConfigurations = 0x01,
+    .bReserved = 0
+};
+
+#endif // TUD_OPT_HIGH_SPEED
 
 void run_usb_dual_cdc_device(void)
 {
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
         .device_descriptor = &cdc_device_descriptor,
-        .configuration_descriptor = cdc_desc_configuration
-#endif
+        .string_descriptor = NULL,
+        .string_descriptor_count = 0,
+        .external_phy = false,
+#if (TUD_OPT_HIGH_SPEED)
+        .fs_configuration_descriptor = cdc_fs_desc_configuration,
+        .hs_configuration_descriptor = cdc_hs_desc_configuration,
+        .qualifier_descriptor = &device_qualifier,
+#else
+        .configuration_descriptor = cdc_fs_desc_configuration,
+#endif // TUD_OPT_HIGH_SPEED
     };
+
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
 
     tinyusb_config_cdcacm_t amc_cfg = {

--- a/host/class/cdc/usb_host_cdc_acm/test_app/pytest_usb_host_cdc.py
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/pytest_usb_host_cdc.py
@@ -14,14 +14,14 @@ from pytest_embedded_idf.dut import IdfDut
 @pytest.mark.parametrize('count', [
     2,
 ], indirect=True)
-def test_usb_host(dut: Tuple[IdfDut, IdfDut]) -> None:
+def test_usb_host_cdc(dut: Tuple[IdfDut, IdfDut]) -> None:
     device = dut[0]
     host = dut[1]
 
-    # 1.1 Prepare USB device for CDC test
+    # 1 Prepare USB device for CDC test
     device.expect_exact('Press ENTER to see the list of tests.')
     device.write('[cdc_acm_device]')
     device.expect_exact('USB initialization DONE')
 
-    # 1.2 Run CDC test
+    ## 2 Run CDC test
     host.run_all_single_board_cases(group='cdc_acm')

--- a/host/class/hid/usb_host_hid/test_app/README.md
+++ b/host/class/hid/usb_host_hid/test_app/README.md
@@ -1,4 +1,13 @@
-| Supported Targets | ESP32-S2 | ESP32-S3 |
-| ----------------- | -------- | -------- |
+| Supported Targets | ESP32-S2 | ESP32-S3 | ESP32-P4 |
+| ----------------- | -------- | -------- | -------- |
 
 # USB: HID Class test application
+
+## HID driver
+
+Basic functionality such as HID device install/uninstall, class specific requests as well as reaction to sudden disconnection and other error states.
+
+### Hardware Required
+
+This test requires two ESP32 development board with USB-OTG support. The development boards shall have interconnected USB peripherals,
+one acting as host running HID host driver and another HID device driver (tinyusb).

--- a/host/class/hid/usb_host_hid/test_app/main/hid_mock_device.c
+++ b/host/class/hid/usb_host_hid/test_app/main/hid_mock_device.c
@@ -1,19 +1,16 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdint.h>
-#include "sdkconfig.h"
 #include "tinyusb.h"
 #include "class/hid/hid_device.h"
-#include "esp_idf_version.h"
 #include "hid_mock_device.h"
 
 static tusb_iface_count_t tusb_iface_count = 0;
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 /************* TinyUSB descriptors ****************/
 #define TUSB_DESC_TOTAL_LEN      (TUD_CONFIG_DESC_LEN + CFG_TUD_HID * TUD_HID_DESC_LEN)
 
@@ -75,10 +72,28 @@ static const uint8_t *hid_configuration_descriptor_list[TUSB_IFACE_COUNT_MAX] = 
     hid_configuration_descriptor_one_iface,
     hid_configuration_descriptor_two_ifaces
 };
-#endif // // esp idf >= v5.0.0
+
+/**
+ * @brief Device qualifier
+ *
+ * This is a simple device qualifier for HS devices
+ */
+
+#if (TUD_OPT_HIGH_SPEED)
+static const tusb_desc_device_qualifier_t device_qualifier = {
+    .bLength = sizeof(tusb_desc_device_qualifier_t),
+    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .bNumConfigurations = 0x01,
+    .bReserved = 0
+};
+#endif // TUD_OPT_HIGH_SPEED
 /********* TinyUSB HID callbacks ***************/
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 // Invoked when received GET HID REPORT DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
 uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance)
@@ -95,12 +110,6 @@ uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance)
     }
     return NULL;
 }
-#endif // esp idf >= v5.0.0
-
-#if ((ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)) && (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)))
-#define HID_ITF_PROTOCOL_KEYBOARD HID_PROTOCOL_KEYBOARD
-#define HID_ITF_PROTOCOL_MOUSE    HID_PROTOCOL_MOUSE
-#endif // 4.4.0 <= esp idf < v5.0.0
 
 /**
  * @brief Get Keyboard report
@@ -177,7 +186,7 @@ void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_
 void hid_mock_device(tusb_iface_count_t iface_count)
 {
     if (iface_count > TUSB_IFACE_COUNT_MAX) {
-        printf("UHID mock device, wrong iface_count paramteter (%d)\n",
+        printf("HID mock device, wrong iface_count parameter (%d)\n",
                iface_count);
         return;
     }
@@ -186,15 +195,18 @@ void hid_mock_device(tusb_iface_count_t iface_count)
     tusb_iface_count = iface_count;
 
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
         .device_descriptor = NULL,
         .string_descriptor = hid_string_descriptor,
         .string_descriptor_count = sizeof(hid_string_descriptor) / sizeof(hid_string_descriptor[0]),
+        .external_phy = false,
+#if (TUD_OPT_HIGH_SPEED)
+        .fs_configuration_descriptor = hid_configuration_descriptor_list[tusb_iface_count],
+        .hs_configuration_descriptor = hid_configuration_descriptor_list[tusb_iface_count],
+        .qualifier_descriptor = &device_qualifier,
+#else
         .configuration_descriptor = hid_configuration_descriptor_list[tusb_iface_count],
-#endif // esp idf >= v5.0.0
+#endif // TUD_OPT_HIGH_SPEED
     };
-
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
 
     printf("HID mock device with %s has been started\n",

--- a/host/class/hid/usb_host_hid/test_app/main/test_app_main.c
+++ b/host/class/hid/usb_host_hid/test_app/main/test_app_main.c
@@ -7,17 +7,17 @@
 #include <stdio.h>
 #include <string.h>
 #include "unity.h"
-#include "esp_heap_caps.h"
+#include "unity_test_runner.h"
+#include "unity_test_utils_memory.h"
 
-static size_t before_free_8bit;
-static size_t before_free_32bit;
-
-#define TEST_MEMORY_LEAK_THRESHOLD (-530)
-static void check_leak(size_t before_free, size_t after_free, const char *type)
+void setUp(void)
 {
-    ssize_t delta = after_free - before_free;
-    printf("MALLOC_CAP_%s: Before %u bytes free, After %u bytes free (delta %d)\n", type, before_free, after_free, delta);
-    TEST_ASSERT_MESSAGE(delta >= TEST_MEMORY_LEAK_THRESHOLD, "memory leak");
+    unity_utils_record_free_mem();
+}
+
+void tearDown(void)
+{
+    unity_utils_evaluate_leaks();
 }
 
 void app_main(void)
@@ -35,23 +35,7 @@ void app_main(void)
     printf("|______/ /_______  / |______  /  |__|  \\___  >____  > |__|  \r\n");
     printf("                 \\/         \\/             \\/     \\/        \r\n");
 
-    UNITY_BEGIN();
+    unity_utils_setup_heap_record(80);
+    unity_utils_set_leak_level(530);
     unity_run_menu();
-    UNITY_END();
-}
-
-/* setUp runs before every test */
-void setUp(void)
-{
-    before_free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-    before_free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
-}
-
-/* tearDown runs after every test */
-void tearDown(void)
-{
-    size_t after_free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-    size_t after_free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
-    check_leak(before_free_8bit, after_free_8bit, "8BIT");
-    check_leak(before_free_32bit, after_free_32bit, "32BIT");
 }

--- a/host/class/hid/usb_host_hid/test_app/pytest_usb_host_hid.py
+++ b/host/class/hid/usb_host_hid/test_app/pytest_usb_host_hid.py
@@ -9,6 +9,7 @@ from pytest_embedded_idf.dut import IdfDut
 
 @pytest.mark.esp32s2
 @pytest.mark.esp32s3
+@pytest.mark.esp32p4
 @pytest.mark.usb_host
 @pytest.mark.parametrize('count', [
     2,
@@ -17,19 +18,19 @@ def test_usb_host_hid(dut: Tuple[IdfDut, IdfDut]) -> None:
     device = dut[0]
     host = dut[1]
 
-    # 3.1 Prepare USB device with one Interface for HID tests
+    # 1 Prepare USB device with one Interface for HID tests
     device.expect_exact('Press ENTER to see the list of tests.')
     device.write('[hid_device]')
     device.expect_exact('HID mock device with 1xInterface (Protocol=None) has been started')
 
-    # 3.2 Run HID tests
+    # 2 Run HID tests
     host.run_all_single_board_cases(group='hid_host')
 
-    # 3.3 Prepare USB device with two Interfaces for HID tests
+    # 3 Prepare USB device with two Interfaces for HID tests
     device.serial.hard_reset()
     device.expect_exact('Press ENTER to see the list of tests.')
     device.write('[hid_device2]')
     device.expect_exact('HID mock device with 2xInterfaces (Protocol=BootKeyboard, Protocol=BootMouse) has been started')
 
-    # 3.4 Run HID tests
+    # 4 Run HID tests
     host.run_all_single_board_cases(group='hid_host')

--- a/host/class/msc/usb_host_msc/test_app/README.md
+++ b/host/class/msc/usb_host_msc/test_app/README.md
@@ -1,7 +1,7 @@
-| Supported Targets | ESP32-S2 | ESP32-S3 |
-| ----------------- | -------- | -------- |
+| Supported Targets | ESP32-S2 | ESP32-S3 | ESP32-P4 |
+| ----------------- | -------- | -------- | -------- |
 
-# USB: CDC Class test application
+# USB: MSC Class test application
 
 ## MSC driver
 
@@ -10,5 +10,5 @@ raw access to MSC device and sudden disconnect is tested.
 
 ### Hardware Required
 
-This test requires two ESP32-S2/S3 boards with a interconnected USB peripherals,
+This test requires two ESP32 development board with USB-OTG support. The development boards shall have interconnected USB peripherals,
 one acting as host running MSC host driver and another MSC device driver (tinyusb).

--- a/host/class/msc/usb_host_msc/test_app/main/msc_device.c
+++ b/host/class/msc/usb_host_msc/test_app/main/msc_device.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,23 +7,20 @@
 
 #include "esp_log.h"
 #include "tinyusb.h"
-#include "esp_idf_version.h"
 #include "soc/soc_caps.h"
 #include "test_common.h"
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "esp_check.h"
 #include "driver/gpio.h"
 #include "tusb_msc_storage.h"
-#endif /* ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0) */
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED
+#if SOC_SDMMC_HOST_SUPPORTED
 #include "diskio_impl.h"
 #include "diskio_sdmmc.h"
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED */
+#endif /* SOC_SDMMC_HOST_SUPPORTED */
 
 #if SOC_USB_OTG_SUPPORTED
 
 /* sd-card configuration to be done by user */
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED
+#if SOC_SDMMC_HOST_SUPPORTED
 #define SDMMC_BUS_WIDTH 4 /* Select the bus width of SD or MMC interface (4 or 1).
                             Note that even if 1 line mode is used, D3 pin of the SD card must
                             have a pull-up resistor connected. Otherwise the card may enter
@@ -34,13 +31,12 @@
 #define PIN_D1          38 /* D1 GPIO number (applicable when width SDMMC_BUS_WIDTH is 4) */
 #define PIN_D2          33 /* D2 GPIO number (applicable when width SDMMC_BUS_WIDTH is 4) */
 #define PIN_D3          34 /* D3 GPIO number (applicable when width SDMMC_BUS_WIDTH is 4) */
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED */
+#endif /* SOC_SDMMC_HOST_SUPPORTED */
 
 static const char *TAG = "msc_example";
 
 /* TinyUSB descriptors
    ********************************************************************* */
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #define TUSB_DESC_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_MSC_DESC_LEN)
 
 enum {
@@ -53,13 +49,33 @@ enum {
     EDPT_MSC_IN   = 0x81,
 };
 
-static uint8_t const desc_configuration[] = {
+static uint8_t const msc_fs_desc_configuration[] = {
     // Config number, interface count, string index, total length, attribute, power in mA
     TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, TUSB_DESC_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
-
     // Interface number, string index, EP Out & EP In address, EP size
-    TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 0, EDPT_MSC_OUT, EDPT_MSC_IN, TUD_OPT_HIGH_SPEED ? 512 : 64),
+    TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 0, EDPT_MSC_OUT, EDPT_MSC_IN, 64),
 };
+
+#if (TUD_OPT_HIGH_SPEED)
+static const uint8_t msc_hs_desc_configuration[] = {
+    // Config number, interface count, string index, total length, attribute, power in mA
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, TUSB_DESC_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    // Interface number, string index, EP Out & EP In address, EP size
+    TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 0, EDPT_MSC_OUT, EDPT_MSC_IN, 512),
+};
+
+static const tusb_desc_device_qualifier_t device_qualifier = {
+    .bLength = sizeof(tusb_desc_device_qualifier_t),
+    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .bNumConfigurations = 0x01,
+    .bReserved = 0
+};
+#endif // TUD_OPT_HIGH_SPEED
 
 static tusb_desc_device_t descriptor_config = {
     .bLength = sizeof(descriptor_config),
@@ -86,10 +102,8 @@ static char const *string_desc_arr[] = {
     //"123456",                       // 3: Serials
     //"Test MSC",                  // 4. MSC
 };
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) */
 /*********************************************************************** TinyUSB descriptors*/
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #define VBUS_MONITORING_GPIO_NUM GPIO_NUM_4
 static void configure_vbus_monitoring(void)
 {
@@ -103,27 +117,31 @@ static void configure_vbus_monitoring(void)
     };
     ESP_ERROR_CHECK(gpio_config(&vbus_gpio_config));
 }
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) */
 
 static void storage_init(void)
 {
     ESP_LOGI(TAG, "USB MSC initialization");
+
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
         .device_descriptor = &descriptor_config,
-        .configuration_descriptor = desc_configuration,
         .string_descriptor = string_desc_arr,
         .string_descriptor_count = sizeof(string_desc_arr) / sizeof(string_desc_arr[0]),
+        .external_phy = false,
+#if (TUD_OPT_HIGH_SPEED)
+        .fs_configuration_descriptor = msc_fs_desc_configuration,
+        .hs_configuration_descriptor = msc_hs_desc_configuration,
+        .qualifier_descriptor = &device_qualifier,
+#else
+        .configuration_descriptor = msc_fs_desc_configuration,
+#endif // TUD_OPT_HIGH_SPEED
         .self_powered = true,
         .vbus_monitor_io = VBUS_MONITORING_GPIO_NUM
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) */
     };
+
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
     ESP_LOGI(TAG, "USB initialization DONE");
 }
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 static esp_err_t storage_init_spiflash(wl_handle_t *wl_handle)
 {
     ESP_LOGI(TAG, "Initializing wear levelling");
@@ -136,28 +154,26 @@ static esp_err_t storage_init_spiflash(wl_handle_t *wl_handle)
 
     return wl_mount(data_partition, wl_handle);
 }
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) */
 
 void device_app(void)
 {
     ESP_LOGI(TAG, "Initializing storage...");
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     configure_vbus_monitoring();
 
     static wl_handle_t wl_handle = WL_INVALID_HANDLE;
     ESP_ERROR_CHECK(storage_init_spiflash(&wl_handle));
 
-    tinyusb_msc_spiflash_config_t config_spi;
-    config_spi.wl_handle = wl_handle;
+    const tinyusb_msc_spiflash_config_t config_spi = {
+        .wl_handle = wl_handle,
+    };
     ESP_ERROR_CHECK(tinyusb_msc_storage_init_spiflash(&config_spi));
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) */
     storage_init();
     while (1) {
         vTaskDelay(100);
     }
 }
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED
+#if SOC_SDMMC_HOST_SUPPORTED
 static esp_err_t storage_init_sdmmc(sdmmc_card_t **card)
 {
     esp_err_t ret = ESP_OK;
@@ -246,216 +262,6 @@ void device_app_sdmmc(void)
         vTaskDelay(100);
     }
 }
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED */
-
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-// whether host does safe-eject
-static bool ejected = false;
-
-// Some MCU doesn't have enough 8KB SRAM to store the whole disk
-// We will use Flash as read-only disk with board that has
-// CFG_EXAMPLE_MSC_READONLY defined
-
-uint8_t msc_disk[DISK_BLOCK_NUM][DISK_BLOCK_SIZE] = {
-    //------------- Block0: Boot Sector -------------//
-    // byte_per_sector    = DISK_BLOCK_SIZE; fat12_sector_num_16  = DISK_BLOCK_NUM;
-    // sector_per_cluster = 1; reserved_sectors = 1;
-    // fat_num            = 1; fat12_root_entry_num = 16;
-    // sector_per_fat     = 1; sector_per_track = 1; head_num = 1; hidden_sectors = 0;
-    // drive_number       = 0x80; media_type = 0xf8; extended_boot_signature = 0x29;
-    // filesystem_type    = "FAT12   "; volume_serial_number = 0x1234; volume_label = "TinyUSB MSC";
-    // FAT magic code at offset 510-511
-    {
-        0xEB, 0x3C, 0x90, 0x4D, 0x53, 0x44, 0x4F, 0x53, 0x35, 0x2E, 0x30, 0x00, 0x02, 0x01, 0x01, 0x00,
-        0x01, 0x10, 0x00, 0x10, 0x00, 0xF8, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x29, 0x34, 0x12, 0x00, 0x00, 'T', 'i', 'n', 'y', 'U',
-        'S', 'B', ' ', 'M', 'S', 'C', 0x46, 0x41, 0x54, 0x31, 0x32, 0x20, 0x20, 0x20, 0x00, 0x00,
-
-        // Zero up to 2 last bytes of FAT magic code
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 'F', 'A', 'T', '3', '2', ' ', ' ', ' ', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x55, 0xAA
-    },
-
-    //------------- Block1: FAT12 Table -------------//
-    {
-        0xF8, 0xFF, 0xFF, 0xFF, 0x0F // // first 2 entries must be F8FF, third entry is cluster end of readme file
-    },
-
-    //------------- Block2: Root Directory -------------//
-    {
-        // first entry is volume label
-        'T', 'i', 'n', 'y', 'U', 'S', 'B', ' ', 'M', 'S', 'C', 0x08, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4F, 0x6D, 0x65, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        // second entry is readme file
-        'R', 'E', 'A', 'D', 'M', 'E', ' ', ' ', 'T', 'X', 'T', 0x20, 0x00, 0xC6, 0x52, 0x6D,
-        0x65, 0x43, 0x65, 0x43, 0x00, 0x00, 0x88, 0x6D, 0x65, 0x43, 0x02, 0x00,
-        sizeof(README_CONTENTS) - 1, 0x00, 0x00, 0x00 // readme's files size (4 Bytes)
-    },
-
-    //------------- Block3: Readme Content -------------//
-    README_CONTENTS
-};
-
-// Invoked when received SCSI_CMD_INQUIRY
-// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
-void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4])
-{
-    (void) lun;
-
-    const char vid[] = "TinyUSB";
-    const char pid[] = "Mass Storage";
-    const char rev[] = "1.0";
-
-    memcpy(vendor_id, vid, strlen(vid));
-    memcpy(product_id, pid, strlen(pid));
-    memcpy(product_rev, rev, strlen(rev));
-}
-
-// Invoked when received Test Unit Ready command.
-// return true allowing host to read/write this LUN e.g SD card inserted
-bool tud_msc_test_unit_ready_cb(uint8_t lun)
-{
-    (void) lun;
-
-    // RAM disk is ready until ejected
-    if (ejected) {
-        tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3a, 0x00);
-        return false;
-    }
-
-    return true;
-}
-
-// Invoked when received SCSI_CMD_READ_CAPACITY_10 and SCSI_CMD_READ_FORMAT_CAPACITY to determine the disk size
-// Application update block count and block size
-void tud_msc_capacity_cb(uint8_t lun, uint32_t *block_count, uint16_t *block_size)
-{
-    (void) lun;
-
-    *block_count = DISK_BLOCK_NUM;
-    *block_size  = DISK_BLOCK_SIZE;
-}
-
-// Invoked when received Start Stop Unit command
-// - Start = 0 : stopped power mode, if load_eject = 1 : unload disk storage
-// - Start = 1 : active mode, if load_eject = 1 : load disk storage
-bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject)
-{
-    (void) lun;
-    (void) power_condition;
-
-    if ( load_eject ) {
-        if (start) {
-            // load disk storage
-        } else {
-            // unload disk storage
-            ejected = true;
-        }
-    }
-
-    return true;
-}
-
-// Callback invoked when received READ10 command.
-// Copy disk's data to buffer (up to bufsize) and return number of copied bytes.
-int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void *buffer, uint32_t bufsize)
-{
-    (void) lun;
-
-    uint8_t const *addr = msc_disk[lba] + offset;
-    memcpy(buffer, addr, bufsize);
-
-    return bufsize;
-}
-
-// Callback invoked when received WRITE10 command.
-// Process data in buffer to disk's storage and return number of written bytes
-int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t *buffer, uint32_t bufsize)
-{
-    (void) lun;
-
-#ifndef CFG_EXAMPLE_MSC_READONLY
-    uint8_t *addr = msc_disk[lba] + offset;
-    memcpy(addr, buffer, bufsize);
-#else
-    (void) lba; (void) offset; (void) buffer;
-#endif
-
-    return bufsize;
-}
-
-// Callback invoked when received an SCSI command not in built-in list below
-// - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, MODE_SENSE6, REQUEST_SENSE
-// - READ10 and WRITE10 has their own callbacks
-int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void *buffer, uint16_t bufsize)
-{
-    // read10 & write10 has their own callback and MUST not be handled here
-
-    void const *response = NULL;
-    uint16_t resplen = 0;
-
-    // most scsi handled is input
-    bool in_xfer = true;
-
-    switch (scsi_cmd[0]) {
-    case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-        // Host is about to read/write etc ... better not to disconnect disk
-        resplen = 0;
-        break;
-
-    default:
-        // Set Sense = Invalid Command Operation
-        tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
-
-        // negative means error -> tinyusb could stall and/or response with failed status
-        resplen = -1;
-        break;
-    }
-
-    // return resplen must not larger than bufsize
-    if ( resplen > bufsize ) {
-        resplen = bufsize;
-    }
-
-    if ( response && (resplen > 0) ) {
-        if (in_xfer) {
-            memcpy(buffer, response, resplen);
-        } else {
-            // SCSI output
-        }
-    }
-
-    return resplen;
-}
-#endif /* ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0) */
+#endif /* SOC_SDMMC_HOST_SUPPORTED */
 
 #endif /* SOC_USB_OTG_SUPPORTED */

--- a/host/class/msc/usb_host_msc/test_app/main/test_app_main.c
+++ b/host/class/msc/usb_host_msc/test_app/main/test_app_main.c
@@ -7,17 +7,17 @@
 #include <stdio.h>
 #include <string.h>
 #include "unity.h"
-#include "esp_heap_caps.h"
+#include "unity_test_runner.h"
+#include "unity_test_utils_memory.h"
 
-static size_t before_free_8bit;
-static size_t before_free_32bit;
-
-#define TEST_MEMORY_LEAK_THRESHOLD (-530)
-static void check_leak(size_t before_free, size_t after_free, const char *type)
+void setUp(void)
 {
-    ssize_t delta = after_free - before_free;
-    printf("MALLOC_CAP_%s: Before %u bytes free, After %u bytes free (delta %d)\n", type, before_free, after_free, delta);
-    TEST_ASSERT_MESSAGE(delta >= TEST_MEMORY_LEAK_THRESHOLD, "memory leak");
+    unity_utils_record_free_mem();
+}
+
+void tearDown(void)
+{
+    unity_utils_evaluate_leaks();
 }
 
 void app_main(void)
@@ -35,23 +35,7 @@ void app_main(void)
     printf("|______/ /_______  / |______  /  |__|  \\___  >____  > |__|  \r\n");
     printf("                 \\/         \\/             \\/     \\/        \r\n");
 
-    UNITY_BEGIN();
+    unity_utils_setup_heap_record(80);
+    unity_utils_set_leak_level(530);
     unity_run_menu();
-    UNITY_END();
-}
-
-/* setUp runs before every test */
-void setUp(void)
-{
-    before_free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-    before_free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
-}
-
-/* tearDown runs after every test */
-void tearDown(void)
-{
-    size_t after_free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-    size_t after_free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
-    check_leak(before_free_8bit, after_free_8bit, "8BIT");
-    check_leak(before_free_32bit, after_free_32bit, "32BIT");
 }

--- a/host/class/msc/usb_host_msc/test_app/main/test_common.h
+++ b/host/class/msc/usb_host_msc/test_app/main/test_common.h
@@ -1,11 +1,9 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
-
-#include "esp_idf_version.h"
 
 enum {
     // FatFS only allows to format disks with number of blocks greater than 128
@@ -14,9 +12,9 @@ enum {
 };
 
 void device_app(void);
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED
+#if SOC_SDMMC_HOST_SUPPORTED
 void device_app_sdmmc(void);
-#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED */
+#endif /* SOC_SDMMC_HOST_SUPPORTED */
 
 #define README_CONTENTS \
 "This is tinyusb's MassStorage Class demo.\r\n\r\n\

--- a/host/class/msc/usb_host_msc/test_app/pytest_usb_host_msc.py
+++ b/host/class/msc/usb_host_msc/test_app/pytest_usb_host_msc.py
@@ -9,6 +9,7 @@ from pytest_embedded_idf.dut import IdfDut
 
 @pytest.mark.esp32s2
 @pytest.mark.esp32s3
+@pytest.mark.esp32p4
 @pytest.mark.usb_host
 @pytest.mark.parametrize('count', [
     2,
@@ -17,10 +18,10 @@ def test_usb_host_msc(dut: Tuple[IdfDut, IdfDut]) -> None:
     device = dut[0]
     host = dut[1]
 
-    # 2.1 Prepare USB device for MSC test
+    # 1 Prepare USB device for MSC test
     device.expect_exact('Press ENTER to see the list of tests.')
     device.write('[usb_msc_device]')
     device.expect_exact('USB initialization DONE')
 
-    # 2.2 Run MSC test
+    # 2 Run MSC test
     host.run_all_single_board_cases(group='usb_msc')

--- a/host/class/uvc/usb_host_uvc/test_app/README.md
+++ b/host/class/uvc/usb_host_uvc/test_app/README.md
@@ -1,4 +1,12 @@
-| Supported Targets | ESP32-S2 | ESP32-S3 |
-| ----------------- | -------- | -------- |
+| Supported Targets | ESP32-S2 | ESP32-S3 | ESP32-P4 |
+| ----------------- | -------- | -------- | -------- |
 
 # USB: UVC Class test application
+
+## UVC driver
+
+UVC descriptor parsing is checked
+
+### Hardware Required
+
+This test requires an ESP32 development board with USB-OTG support.

--- a/host/class/uvc/usb_host_uvc/test_app/main/test_app_main.c
+++ b/host/class/uvc/usb_host_uvc/test_app/main/test_app_main.c
@@ -7,17 +7,17 @@
 #include <stdio.h>
 #include <string.h>
 #include "unity.h"
-#include "esp_heap_caps.h"
+#include "unity_test_runner.h"
+#include "unity_test_utils_memory.h"
 
-static size_t before_free_8bit;
-static size_t before_free_32bit;
-
-#define TEST_MEMORY_LEAK_THRESHOLD (-530)
-static void check_leak(size_t before_free, size_t after_free, const char *type)
+void setUp(void)
 {
-    ssize_t delta = after_free - before_free;
-    printf("MALLOC_CAP_%s: Before %u bytes free, After %u bytes free (delta %d)\n", type, before_free, after_free, delta);
-    TEST_ASSERT_MESSAGE(delta >= TEST_MEMORY_LEAK_THRESHOLD, "memory leak");
+    unity_utils_record_free_mem();
+}
+
+void tearDown(void)
+{
+    unity_utils_evaluate_leaks();
 }
 
 void app_main(void)
@@ -35,23 +35,7 @@ void app_main(void)
     printf("|______/ /_______  / |______  /  |__|  \\___  >____  > |__|  \r\n");
     printf("                 \\/         \\/             \\/     \\/        \r\n");
 
-    UNITY_BEGIN();
+    unity_utils_setup_heap_record(80);
+    unity_utils_set_leak_level(530);
     unity_run_menu();
-    UNITY_END();
-}
-
-/* setUp runs before every test */
-void setUp(void)
-{
-    before_free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-    before_free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
-}
-
-/* tearDown runs after every test */
-void tearDown(void)
-{
-    size_t after_free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-    size_t after_free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
-    check_leak(before_free_8bit, after_free_8bit, "8BIT");
-    check_leak(before_free_32bit, after_free_32bit, "32BIT");
 }

--- a/host/class/uvc/usb_host_uvc/test_app/pytest_usb_host_uvc.py
+++ b/host/class/uvc/usb_host_uvc/test_app/pytest_usb_host_uvc.py
@@ -7,6 +7,7 @@ from pytest_embedded_idf.dut import IdfDut
 
 @pytest.mark.esp32s2
 @pytest.mark.esp32s3
+@pytest.mark.esp32p4
 @pytest.mark.usb_host
 def test_usb_host_uvc(dut: IdfDut) -> None:
     dut.run_all_single_board_cases(group='usb_uvc')


### PR DESCRIPTION
## Description

This MR enables class drivers test apps, to be run on esp32p4

## Changes
- New `esp32p4` `usb_host` target runner `BrnoVM0114` was added to the CI
- Enabled test apps build and run in CI for esp32p4
- Memory leak checks evaluation during test case teardown updated to new API
- removed all code in test apps related to IDF versions lower than 5.0
- `usb_host_lib_set_root_port_power` function used to toggle connection of USB devices must be used for esp32p4, but has been implemented only in `IDF 5.2`
  - for IDF versions lower than 5.3, the old way of connection toggling (using PHY) is used, because esp32p4 has been added from `IDF 5.3`
  - for IDF versions higher than, including 5.3, the new way of connection toggling (using root power) is used.

## Related
-  RDT-995 Add new esp32p4 usb_host runner
-  IDF-11346 Build USB P4 runners for GitHub
-  IDF-11685 Run esp-usb class driver tests in CI on esp32p4
- Follow up: Enable target run for esp32p4 on IDF 5.3 once the IDF 5.3 docker image is updated

## Testing

- `CDC-ACM`, `HID`, `MSC`, `UVC` class driver tests are passing locally on a reproduced CI target runner setup
- `UAC` class driver not modified, since it's not being run in any CI tests

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
