### PR TITLE
feat(ci): Build and run target tests everyday

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -2,7 +2,7 @@ name: Build and Run USB Test Application
 
 on:
   schedule:
-    - cron: '0 0 * * SAT' # Saturday midnight
+    - cron: '0 0 * * *' # Every day at midnight
   pull_request:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
In https://github.com/espressif/esp-usb/pull/75 we refactored the test runners' configuration. We want to run the test more frequently so we can evaluate their stability.

This entire commit can be reverted after the evaluation period is over (in couple of weeks).
