### PR TITLE
feature(esp_tinyusb): Added mode configuration for dcd_dwc2 layer

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0 (Unreleased)
+
+- esp_tinyusb: Added DMA mode option to tinyusb DCD DWC2 configuration 
+
 ## 1.4.5
 
 - CDC-ACM: Fixed memory leak at VFS unregister

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -17,6 +17,20 @@ menu "TinyUSB Stack"
             bool "HS"
     endchoice
 
+    menu "TinyUSB DCD"
+        choice TINYUSB_MODE
+            prompt "DCD Mode"
+            default TINYUSB_MODE_DMA
+            help
+                TinyUSB DCD DWC2 Driver supports two modes: Slave mode (based on IRQ) and Buffer DMA mode.
+
+            config TINYUSB_MODE_SLAVE
+                bool "Slave/IRQ"
+            config TINYUSB_MODE_DMA
+                bool "Buffer DMA"
+        endchoice
+    endmenu # "TinyUSB DCD"
+
     menu "TinyUSB task configuration"
         config TINYUSB_NO_DEFAULT_TASK
             bool "Do not create a TinyUSB task"
@@ -71,7 +85,7 @@ menu "TinyUSB Stack"
                 This is especially useful in multicore scenarios, when we need to pin the task
                 to a specific core and, at the same time initialize TinyUSB stack
                 (i.e. install interrupts) on the same core.
-    endmenu
+    endmenu # "TinyUSB task configuration"
 
     menu "Descriptor configuration"
         comment "You can provide your custom descriptors via tinyusb_driver_install()"
@@ -151,8 +165,10 @@ menu "TinyUSB Stack"
         config TINYUSB_MSC_BUFSIZE
             depends on TINYUSB_MSC_ENABLED
             int "MSC FIFO size"
-            default 512
-            range 64 10000
+            default 512 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+            default 8192 if IDF_TARGET_ESP32P4
+            range 64 8192 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+            range 64 32768 if IDF_TARGET_ESP32P4
             help
                 MSC FIFO size, in bytes.
 

--- a/device/esp_tinyusb/include/tusb_config.h
+++ b/device/esp_tinyusb/include/tusb_config.h
@@ -90,6 +90,30 @@ extern "C" {
 #   define CFG_TUSB_RHPORT0_MODE    OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED
 #endif
 
+// ------------------------------------------------------------------------
+//                              DCD DWC2 Mode
+// ------------------------------------------------------------------------
+#define CFG_TUD_DWC2_SLAVE_ENABLE   1       // Enable Slave/IRQ by default
+
+// ------------------------------------------------------------------------
+//                              DMA & Cache
+// ------------------------------------------------------------------------
+#ifdef CONFIG_TINYUSB_MODE_DMA
+// DMA Mode has a priority over Slave/IRQ mode and will be used if hardware supports it
+#define CFG_TUD_DWC2_DMA_ENABLE     1       // Enable DMA
+
+#if CONFIG_CACHE_L1_CACHE_LINE_SIZE
+// To enable the dcd_dcache clean/invalidate/clean_invalidate calls
+#   define CFG_TUD_MEM_DCACHE_ENABLE    1
+#define CFG_TUD_MEM_DCACHE_LINE_SIZE    CONFIG_CACHE_L1_CACHE_LINE_SIZE
+// NOTE: starting with esp-idf v5.3 there is specific attribute present: DRAM_DMA_ALIGNED_ATTR
+#   define CFG_TUSB_MEM_SECTION         __attribute__((aligned(CONFIG_CACHE_L1_CACHE_LINE_SIZE))) DRAM_ATTR
+#else
+#   define CFG_TUD_MEM_CACHE_ENABLE     0
+#   define CFG_TUSB_MEM_SECTION         TU_ATTR_ALIGNED(4) DRAM_ATTR
+#endif // CONFIG_CACHE_L1_CACHE_LINE_SIZE
+#endif // CONFIG_TINYUSB_MODE_DMA
+
 #define CFG_TUSB_OS                 OPT_OS_FREERTOS
 
 /* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.


### PR DESCRIPTION
# [esp_tinyusb component](https://components.espressif.com/components/espressif/esp_tinyusb), v1.5.0

## Description

DMA support for TinyUSB device stack. 

DMA (Buffer mode) is a default mode for device, meanwhile there is an option to change the mode to Single/IRQ by disabling DMA mode via menuconfig. 

If (by any reason) hardware isn't support DMA (`arch != GHWCFG2_ARCH_INTERNAL_DMA`) then the Single/IRQ mode will be used. 

## Related

* Related to https://github.com/espressif/tinyusb/pull/37
* Closes https://github.com/espressif/esp-idf/issues/11161

## Testing
This PR is already compatible with the branch: https://github.com/espressif/tinyusb/tree/release/v0.17

## Measurements 

Measurements were made on `tusb_msc` example (read-write operations benchmark, SDMMC target).

### ESP32S3

| MSC Buffer size (bytes)   |      Slave Mode (R/W)      |  Buffer DMA (R/W) |
|:----------:|:-------------:|:------:|
| 512 |  503.4 kB/s / 187.2 kB/s  | 509.8 kB/s / 186.2 kB/s |
| 8192 |  N/A / N/A |  920.6 kB/s /  612.9 kB/s |

### ESP32P4

| MSC Buffer size (bytes)   |      Slave Mode (R/W)      |  Buffer DMA (R/W) |
|:----------:|:-------------:|:------:|
| 512 | 976.3 kB/s /  232.7 kB/s| 1.0 MB/s / 234.6 kB/s |
| 8192* |  999.4 kB/s / 237.6 kB/s |  5,3 MB/s / 1,8 MB/s |

*Benchmark results provided

![image](https://github.com/user-attachments/assets/02ab48d6-4dad-4285-be72-4827f6afe8d7)

![image](https://github.com/user-attachments/assets/2329b2ab-602d-455a-b3f0-bac76c68a211)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
