### PR TITLE
feature(esp_tinyusb): Added config option to select USB OTG1.1 periph on P4

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - esp_tinyusb: Added possibility to configure NCM Transfer Blocks (NTB) via menuconfig
+- esp_tinyusb: Added option to select TinyUSB peripheral on esp32p4 via menuconfig (USB_PHY_SUPPORTS_P4_OTG11 in esp-idf is required)
 
 ## 1.6.0
 

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -7,14 +7,20 @@ menu "TinyUSB Stack"
             Specify verbosity of TinyUSB log output.
 
     choice TINYUSB_RHPORT
-        depends on IDF_TARGET_ESP32P4
-        prompt "TinyUSB PHY"
-        default TINYUSB_RHPORT_HS
+        prompt "USB Peripheral"
+        default TINYUSB_RHPORT_HS if IDF_TARGET_ESP32P4
+        default TINYUSB_RHPORT_FS
         help
-            Allows set the USB PHY Controller for TinyUSB: HS (USB OTG2.0 PHY for HighSpeed)
+            Allows set the USB Peripheral Controller for TinyUSB.
+
+            - High-speed (USB OTG2.0 Peripheral for High-, Full- and Low-speed)
+            - Full-speed (USB OTG1.1 Peripheral for Full- and Low-speed)
 
         config TINYUSB_RHPORT_HS
-            bool "HS"
+            bool "OTG2.0"
+            depends on IDF_TARGET_ESP32P4
+        config TINYUSB_RHPORT_FS
+            bool "OTG1.1"
     endchoice
 
     menu "TinyUSB DCD"

--- a/device/esp_tinyusb/tinyusb.c
+++ b/device/esp_tinyusb/tinyusb.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,6 +32,13 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     usb_phy_config_t phy_conf = {
         .controller = USB_PHY_CTRL_OTG,
         .otg_mode = USB_OTG_MODE_DEVICE,
+#if (USB_PHY_SUPPORTS_P4_OTG11)
+        .otg_speed = (TUD_OPT_HIGH_SPEED) ? USB_PHY_SPEED_HIGH : USB_PHY_SPEED_FULL,
+#else
+#if (CONFIG_IDF_TARGET_ESP32P4 && CONFIG_TINYUSB_RHPORT_FS)
+#error "USB PHY for OTG1.1 is not supported, please update your esp-idf."
+#endif // IDF_TARGET_ESP32P4 && CONFIG_TINYUSB_RHPORT_FS
+#endif // USB_PHY_SUPPORTS_P4_OTG11
     };
 
     // External PHY IOs config


### PR DESCRIPTION
## Description

Added possibility to select the USB OTG1.1 Peripheral (FS) on ESP32P4 via menuconfig.

## Related
N/A

## Testing
Could be tested only on correct P4 board. 

## Limitation
- This changes are available only after removing `usb_phy_p4.c` in esp-idf. Removing the specific P4-related file additionally unlocks the possibility to initialize PHY for USB OTG1.1, which it necessary for USB OTG1.1 Peripheral.  

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
