### PR TITLE
change(test_vendor): Compatibility with tinyusb v0.17.x and higher 

### DIFF
--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -24,5 +24,5 @@ jobs:
           pip install idf-component-manager==1.5.2 idf-build-apps==2.4.3 --upgrade
           python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
           cd ${IDF_PATH}
-          idf-build-apps find --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml
-          idf-build-apps build --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml
+          idf-build-apps find --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
+          idf-build-apps build --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w

--- a/device/esp_tinyusb/test_apps/vendor/main/test_vendor.c
+++ b/device/esp_tinyusb/test_apps/vendor/main/test_vendor.c
@@ -21,7 +21,11 @@
 static const char *TAG = "vendor_test";
 
 char buffer_in[64];
+#if (TUSB_VERSION_MINOR >= 17)
+void tud_vendor_rx_cb(uint8_t itf, uint8_t const *buffer, uint16_t bufsize)
+#else
 void tud_vendor_rx_cb(uint8_t itf)
+#endif // TUSB_VERSION_MINOR
 {
     ESP_LOGI(TAG, "tud_vendor_rx_cb(itf=%d)", itf);
     int available = tud_vendor_n_available(itf);


### PR DESCRIPTION
## Description
USB Device Vendor specific class driver API changed from v0.16.0 to v0.17.0.

`void tud_vendor_rx_cb(uint8_t itf)` - > `void tud_vendor_rx_cb(uint8_t itf, uint8_t const *buffer, uint16_t bufsize)`

To build `test_apps` from esp_tinyusb component with tinyusb component, with v0.17.0.1 or higher, the test_app code should be changed accordingly. 

## Related

- Caused by `espressif/tinyusb` [v0.17.0~1](https://github.com/espressif/tinyusb/tree/v0.17.0.1)

## Testing

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
