### PR TITLE
ci(tinyusb): Run tinyusb tests in CI for esp32p4

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -62,10 +62,6 @@ jobs:
           - idf_ver: "release-v5.3" # TODO: enable IDF 5.3 once the docker image is updated
             idf_target: "esp32p4"
 
-          # Exclude esp32p4 for all versions when using the usb_device runner
-          - idf_target: "esp32p4"   # TODO: esp32p4 usb_device runner not built yet
-            runner_tag: "usb_device"
-
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
     container:
       image: python:3.11-bookworm

--- a/device/esp_tinyusb/test_apps/cdc_and_usb_device/main/test_bvalid_sig.c
+++ b/device/esp_tinyusb/test_apps/cdc_and_usb_device/main/test_bvalid_sig.c
@@ -58,6 +58,20 @@ static const tusb_desc_device_t test_device_descriptor = {
     .bNumConfigurations = 0x01
 };
 
+#if (TUD_OPT_HIGH_SPEED)
+static const tusb_desc_device_qualifier_t device_qualifier = {
+    .bLength = sizeof(tusb_desc_device_qualifier_t),
+    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .bNumConfigurations = 0x01,
+    .bReserved = 0
+};
+#endif // TUD_OPT_HIGH_SPEED
+
 void test_bvalid_sig_mount_cb(void)
 {
     dev_mounted++;
@@ -74,10 +88,19 @@ TEST_CASE("bvalid_signal", "[esp_tinyusb][usb_device]")
 
     // Install TinyUSB driver
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
         .device_descriptor = &test_device_descriptor,
+        .string_descriptor = NULL,
+        .string_descriptor_count = 0,
+        .external_phy = false,
+#if (TUD_OPT_HIGH_SPEED)
+        .fs_configuration_descriptor = test_configuration_descriptor,
+        .hs_configuration_descriptor = test_configuration_descriptor,
+        .qualifier_descriptor = &device_qualifier,
+#else
         .configuration_descriptor = test_configuration_descriptor,
+#endif // TUD_OPT_HIGH_SPEED
     };
+
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
 
     dev_mounted = 0;

--- a/device/esp_tinyusb/test_apps/cdc_and_usb_device/main/test_descriptors_config.c
+++ b/device/esp_tinyusb/test_apps/cdc_and_usb_device/main/test_descriptors_config.c
@@ -27,18 +27,36 @@
 #define DEVICE_MOUNT_TIMEOUT_MS         5000
 
 // ========================= TinyUSB descriptors ===============================
-#define TUSB_DESC_TOTAL_LEN         (TUD_CONFIG_DESC_LEN)
 
-static uint8_t const test_fs_configuration_descriptor[] = {
+// Here we need to create dual CDC device, to match the CONFIG_TINYUSB_CDC_COUNT from sdkconfig.defaults
+static const uint16_t cdc_desc_config_len = TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN;
+static const uint8_t test_fs_configuration_descriptor[] = {
     // Config number, interface count, string index, total length, attribute, power in mA
-    TUD_CONFIG_DESCRIPTOR(1, 0, 0, TUSB_DESC_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_SELF_POWERED | TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CONFIG_DESCRIPTOR(1, 0, 0, cdc_desc_config_len, TUSB_DESC_CONFIG_ATT_SELF_POWERED | TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CDC_DESCRIPTOR(0, 4, 0x81, 8, 0x02, 0x82, 64),
+    TUD_CDC_DESCRIPTOR(2, 4, 0x83, 8, 0x04, 0x84, 64),
 };
 
 #if (TUD_OPT_HIGH_SPEED)
-static uint8_t const test_hs_configuration_descriptor[] = {
+static const uint8_t test_hs_configuration_descriptor[] = {
     // Config number, interface count, string index, total length, attribute, power in mA
-    TUD_CONFIG_DESCRIPTOR(1, 0, 0, TUSB_DESC_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_SELF_POWERED | TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CONFIG_DESCRIPTOR(1, 4, 0, cdc_desc_config_len, TUSB_DESC_CONFIG_ATT_SELF_POWERED | TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CDC_DESCRIPTOR(0, 4, 0x81, 8, 0x02, 0x82, 512),
+    TUD_CDC_DESCRIPTOR(2, 4, 0x83, 8, 0x04, 0x84, 512),
 };
+
+static const tusb_desc_device_qualifier_t device_qualifier = {
+    .bLength = sizeof(tusb_desc_device_qualifier_t),
+    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .bNumConfigurations = 0x01,
+    .bReserved = 0
+};
+
 #endif // TUD_OPT_HIGH_SPEED
 
 static const tusb_desc_device_t test_device_descriptor = {
@@ -136,6 +154,7 @@ TEST_CASE("descriptors_config_device", "[esp_tinyusb][usb_device]")
         .configuration_descriptor = NULL,
 #if (TUD_OPT_HIGH_SPEED)
         .hs_configuration_descriptor = NULL,
+        .qualifier_descriptor = &device_qualifier,
 #endif // TUD_OPT_HIGH_SPEED
     };
     // Install
@@ -158,6 +177,7 @@ TEST_CASE("descriptors_config_device_and_config", "[esp_tinyusb][usb_device]")
         .configuration_descriptor = test_fs_configuration_descriptor,
 #if (TUD_OPT_HIGH_SPEED)
         .hs_configuration_descriptor = NULL,
+        .qualifier_descriptor = &device_qualifier,
 #endif // TUD_OPT_HIGH_SPEED
     };
     // Install
@@ -180,6 +200,7 @@ TEST_CASE("descriptors_config_device_and_fs_config_only", "[esp_tinyusb][usb_dev
         .device_descriptor = &test_device_descriptor,
         .configuration_descriptor = test_fs_configuration_descriptor,
         .hs_configuration_descriptor = NULL,
+        .qualifier_descriptor = &device_qualifier,
     };
     // Install
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
@@ -200,6 +221,7 @@ TEST_CASE("descriptors_config_device_and_hs_config_only", "[esp_tinyusb][usb_dev
         .device_descriptor = &test_device_descriptor,
         .configuration_descriptor = NULL,
         .hs_configuration_descriptor = test_hs_configuration_descriptor,
+        .qualifier_descriptor = &device_qualifier,
     };
     // Install
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
@@ -220,6 +242,7 @@ TEST_CASE("descriptors_config_all_configured", "[esp_tinyusb][usb_device]")
         .device_descriptor = &test_device_descriptor,
         .fs_configuration_descriptor = test_fs_configuration_descriptor,
         .hs_configuration_descriptor = test_hs_configuration_descriptor,
+        .qualifier_descriptor = &device_qualifier,
     };
     // Install
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));


### PR DESCRIPTION
## Description

This MR enables `esp_tinyusb` tests in CI on a new `usb_device` `esp32p4` runner.

The new runner `BrnoRPIG009` was updated with a script introduced in #75, allowing us to access USB devices from running docker container.

In esp_tinyusb, there are 3 groups of tests:

 - `pytest_cdc.py` - Test is run in CI
 - `pytest_usb_device.py` - Test not run in CI, missing teradown function in tinyusb (also bvalid signal test not tested on esp32p4)
 - `pytest_vendor.py` - Test not run in CI due to Docker container problems accessing a vendor specific device

## Related

- IDF-11684 Run esp_tinyusb tests on esp32p4 in GH CI
- IDF-11345 Run esp_tinyusb tests in GH CI

## Follow-up

- IDF-11804 Invesitagate usage of VBUS monitor on HS PHY for esp32p4


## Testing

To pass current CI tests

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
