### PR TITLE
fix(esp_tinyusb): Pinned tinyusb task to the CPU1 by default

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.5.0 (Unreleased)
+## 1.5.0
 
 - esp_tinyusb: Added DMA mode option to tinyusb DCD DWC2 configuration 
+- esp_tinyusb: Changed the default affinity mask of the task to CPU1
 
 ## 1.4.5
 

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -55,6 +55,7 @@ menu "TinyUSB Stack"
 
         choice TINYUSB_TASK_AFFINITY
             prompt "TinyUSB task affinity"
+            default TINYUSB_TASK_AFFINITY_CPU1 if !FREERTOS_UNICORE
             default TINYUSB_TASK_AFFINITY_NO_AFFINITY
             depends on !TINYUSB_NO_DEFAULT_TASK
             help

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.4.5"
+version: "1.5.0"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule


### PR DESCRIPTION
# [esp_tinyusb component](https://components.espressif.com/components/espressif/esp_tinyusb), v1.5.0

## Requirements

A problem could be present in a high-loaded systems (with several interfaces) and when large amounts of data were being sent and received simultaneously, the dcd_event_xfer_complete event was not triggered. 

## Description

Pinned tinyusb FreeRTOS task to CPU1 by default in the dual-core systems. 

## Related

- Releated to IDF-4552

## Testing
N/A

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
