### PR TITLE
feat(msc_host): Add format MSC support

### DIFF
--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased] 
+
+- Added public API support for formatting
+
 ## 1.1.3 
 
 - Implemented request sense, to get sense data from USB device in case of an error

--- a/host/class/msc/usb_host_msc/include/usb/msc_host_vfs.h
+++ b/host/class/msc/usb_host_msc/include/usb/msc_host_vfs.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,6 +15,20 @@ extern "C" {
 #endif
 
 typedef struct msc_host_vfs *msc_host_vfs_handle_t;           /**< VFS handle to attached Mass Storage device */
+
+/**
+ * @brief Format MSC device.
+ *
+ * @param[in] device Device handle obtained from MSC callback provided upon initialization
+ * @param[in] mount_config Mount configuration
+ * @param[in] vfs_handle Handle to MSC device associated with registered VFS
+ * @return esp_err_t
+ * @return
+ *    - ESP_OK: Format completed
+ *    - ESP_ERR_INVALID_ARG: All arguments must be present and couldn't be NULL
+ *    - ESP_ERR_MSC_FORMAT_FAILED: Formatting failed
+ */
+esp_err_t msc_host_vfs_format(msc_host_device_handle_t device, const esp_vfs_fat_mount_config_t *mount_config, const msc_host_vfs_handle_t vfs_handle);
 
 /**
  * @brief Register MSC device to Virtual filesystem.

--- a/host/class/msc/usb_host_msc/src/msc_host_vfs.c
+++ b/host/class/msc/usb_host_msc/src/msc_host_vfs.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -50,6 +50,18 @@ static esp_err_t msc_format_storage(size_t block_size, size_t allocation_size, c
 
     free(workbuf);
     return ESP_OK;
+}
+
+esp_err_t msc_host_vfs_format(msc_host_device_handle_t device, const esp_vfs_fat_mount_config_t *mount_config, const msc_host_vfs_handle_t vfs_handle)
+{
+    MSC_RETURN_ON_INVALID_ARG(device);
+    MSC_RETURN_ON_INVALID_ARG(mount_config);
+    MSC_RETURN_ON_INVALID_ARG(vfs_handle);
+
+    size_t block_size = ((msc_device_t *)device)->disk.block_size;
+    size_t alloc_size = mount_config->allocation_unit_size;
+
+    return msc_format_storage(block_size, alloc_size, vfs_handle->drive);
 }
 
 static void dealloc_msc_vfs(msc_host_vfs_t *vfs)

--- a/host/class/msc/usb_host_msc/test_app/main/test_msc.c
+++ b/host/class/msc/usb_host_msc/test_app/main/test_msc.c
@@ -459,6 +459,26 @@ TEST_CASE("can_be_formated", "[usb_msc]")
     mount_config.format_if_mount_failed = false;
 }
 
+/**
+ * @brief USB MSC API format testcase
+ * @attention This testcase deletes all content on the USB MSC device.
+ *            The device must be reset in order to contain the FILE_NAME again.
+ */
+TEST_CASE("can_be_formated_by_api", "[usb_msc]")
+{
+    printf("Create file on MSC device\n");
+    msc_setup();
+    write_read_file(FILE_NAME);
+
+    printf("Format storage device using msc_host_vfs_format\n");
+    esp_err_t ret = msc_host_vfs_format(device, &mount_config, vfs_handle);
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+
+    printf("Verify file does not exist after formatting\n");
+    TEST_ASSERT_FALSE(file_exists(FILE_NAME));
+    msc_teardown();
+}
+
 static void print_device_info(msc_host_device_info_t *info)
 {
     const size_t megabyte = 1024 * 1024;


### PR DESCRIPTION
## Requirements
Provide the possibility to format connected flash drive

## Description
Currently the flash drive should be formatted in advance, otherwise it can be formatted by ESP when mount error is present. To have the possibility to format connected flash drives in the USB Host MSC class driver explicitly, the new API call has been added. Now, the format process of the flash drive can be done not only during the mounting failure (format_if_mount_failed and FR_NO_FILESYSTEM) but explicitly from the application logic.
## Related
- Closes https://github.com/espressif/esp-idf/issues/14890
- IDFGH-14076 Missing option for USB MSC drive format
## Testing
Added test case for testing public API.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
