### PR TITLE
esp_tinyusb v1.6.0

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,6 +1,7 @@
-## (Unreleased)
+## 1.6.0
 
 - CDC-ACM: Fixed memory leak on deinit
+- esp_tinyusb: Added Teardown 
 
 ## 1.5.0
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.5.0"
+version: "1.6.0"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule


### PR DESCRIPTION
# esp_tinyusb component, [release v1.6.0](https://components.espressif.com/components/espressif/esp_tinyusb/versions/1.5.0) 

## Changes
- Added support of  `tusb_teardown()` during uninstall
- Fixed memory leakage during CDC ACM uninstall


## Related
- https://github.com/espressif/esp-usb/pull/105
- https://github.com/espressif/esp-usb/pull/39

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
