### PR TITLE
fix(tusb_cdc): Added freeing cdc object

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## (Unreleased)
+
+- CDC-ACM: Fixed memory leak on deinit
+
 ## 1.5.0
 
 - esp_tinyusb: Added DMA mode option to tinyusb DCD DWC2 configuration 

--- a/device/esp_tinyusb/tusb_cdc_acm.c
+++ b/device/esp_tinyusb/tusb_cdc_acm.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -295,6 +295,16 @@ static esp_err_t alloc_obj(tinyusb_cdcacm_itf_t itf)
     return ESP_OK;
 }
 
+static esp_err_t obj_free(tinyusb_cdcacm_itf_t itf)
+{
+    esp_tusb_cdc_t *cdc_inst = tinyusb_cdc_get_intf(itf);
+    if (cdc_inst == NULL || cdc_inst->subclass_obj == NULL) {
+        return ESP_FAIL;
+    }
+    free(cdc_inst->subclass_obj);
+    return ESP_OK;
+}
+
 esp_err_t tusb_cdc_acm_init(const tinyusb_config_cdcacm_t *cfg)
 {
     esp_err_t ret = ESP_OK;
@@ -331,7 +341,10 @@ fail:
 
 esp_err_t tusb_cdc_acm_deinit(int itf)
 {
-    return tinyusb_cdc_deinit(itf);
+    esp_err_t ret = ESP_OK;
+    ESP_RETURN_ON_ERROR(obj_free(itf), TAG, "obj_free failed");
+    ESP_RETURN_ON_ERROR(tinyusb_cdc_deinit(itf), TAG, "tinyusb_cdc_deinit failed");
+    return ret;
 }
 
 bool tusb_cdc_acm_initialized(tinyusb_cdcacm_itf_t itf)


### PR DESCRIPTION
## Description
Common sequence for tinyusb CDC driver install: 
1. `tinyusb_driver_install()`
2. `tusb_cdc_acm_initialized()`
3. `tusb_cdc_acm_init()`

During the `tusb_cdc_acm_init()` the internal object `cdc_inst->subclass_obj` is allocated. 
And doesn't freeing during the common uninstall:
1. `tusb_cdc_acm_deinit()`
2. `tinyusb_driver_uninstall()`

## Changes
- Implemented new static function: `obj_free(itf)`, which is the freeing mechanism for function `alloc_obj(itf)`
- Added the `obj_free(itf)` call while `tusb_cdc_acm_deinit()`

And during these steps there is no freeing present. 

## Related
- Was found in https://github.com/espressif/esp-usb/pull/39

## Testing
- eps_tinyusb teardown PR: https://github.com/espressif/esp-usb/pull/39

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
