### PR TITLE
fix(esp_tinyusb): Fix NCM NTB buffers configuration

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- esp_tinyusb: Added possibility to configure NCM Transfer Blocks (NTB) via menuconfig
+
 ## 1.6.0
 
 - CDC-ACM: Fixed memory leak on deinit

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -285,6 +285,51 @@ menu "TinyUSB Stack"
             config TINYUSB_NET_MODE_NONE
                 bool "None"
         endchoice
+
+        config TINYUSB_NCM_OUT_NTB_BUFFS_COUNT
+            int "Number of NCM NTB buffers for reception side"
+            depends on TINYUSB_NET_MODE_NCM
+            default 3
+            range 1 6
+            help
+                Number of NTB buffers for reception side.
+                Can be increased to improve performance and stability with the cost of additional RAM requirements.
+                Helps to mitigate "tud_network_can_xmit: request blocked" warning message when running NCM device.
+
+        config TINYUSB_NCM_IN_NTB_BUFFS_COUNT
+            int "Number of NCM NTB buffers for transmission side"
+            depends on TINYUSB_NET_MODE_NCM
+            default 3
+            range 1 6
+            help
+                Number of NTB buffers for transmission side.
+                Can be increased to improve performance and stability with the cost of additional RAM requirements.
+                Helps to mitigate "tud_network_can_xmit: request blocked" warning message when running NCM device.
+
+        config TINYUSB_NCM_OUT_NTB_BUFF_MAX_SIZE
+            int "NCM NTB Buffer size for reception size"
+            depends on TINYUSB_NET_MODE_NCM
+            default 8192
+            range 1600 10240
+            help
+              Size of NTB buffers on the reception side. The minimum size used by Linux is 2048 bytes.
+              NTB buffer size must be significantly larger than the MTU (Maximum Transmission Unit).
+              The typical default MTU size for Ethernet is 1500 bytes, plus an additional packet overhead.
+              To improve performance, the NTB buffer size should be large enough to fit multiple MTU-sized
+              frames in a single NTB buffer and it's length should be multiple of 4.
+
+        config TINYUSB_NCM_IN_NTB_BUFF_MAX_SIZE
+            int "NCM NTB Buffer size for transmission size"
+            depends on TINYUSB_NET_MODE_NCM
+            default 8192
+            range 1600 10240
+            help
+              Size of NTB buffers on the transmission side. The minimum size used by Linux is 2048 bytes.
+              NTB buffer size must be significantly larger than the MTU (Maximum Transmission Unit).
+              The typical default MTU size for Ethernet is 1500 bytes, plus an additional packet overhead.
+              To improve performance, the NTB buffer size should be large enough to fit multiple MTU-sized
+              frames in a single NTB buffer and it's length should be multiple of 4.
+
     endmenu # "Network driver (ECM/NCM/RNDIS)"
 
     menu "Vendor Specific Interface"

--- a/device/esp_tinyusb/include/tusb_config.h
+++ b/device/esp_tinyusb/include/tusb_config.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2019 Ha Thach (tinyusb.org),
- * SPDX-FileContributor: 2020-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileContributor: 2020-2025 Espressif Systems (Shanghai) CO LTD
  * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org),
@@ -172,6 +172,12 @@ extern "C" {
 #define CFG_TUD_DFU                 CONFIG_TINYUSB_DFU_MODE_DFU
 #define CFG_TUD_DFU_RUNTIME         CONFIG_TINYUSB_DFU_MODE_DFU_RUNTIME
 #define CFG_TUD_BTH                 CONFIG_TINYUSB_BTH_ENABLED
+
+// NCM NET Mode NTB buffers configuration
+#define CFG_TUD_NCM_OUT_NTB_N         CONFIG_TINYUSB_NCM_OUT_NTB_BUFFS_COUNT
+#define CFG_TUD_NCM_IN_NTB_N          CONFIG_TINYUSB_NCM_IN_NTB_BUFFS_COUNT
+#define CFG_TUD_NCM_OUT_NTB_MAX_SIZE  CONFIG_TINYUSB_NCM_OUT_NTB_BUFF_MAX_SIZE
+#define CFG_TUD_NCM_IN_NTB_MAX_SIZE   CONFIG_TINYUSB_NCM_IN_NTB_BUFF_MAX_SIZE
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

This MR adds a possibility to configure NCM transfer blocks via menuconfig.

A table below shows RAM usage and performance dependency on NTB buffers configuration, NTB buffers count and NTB buffers length. Memory occupation was measured using [NCM Device Example](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/device/tusb_ncm) on esp32s3.

| NTB Buffers count (IN/OUT) | 1/1             | 2/2             | 2/2           | 3/3             | 4/4            |
|--------------------------|-----------------|-----------------|---------------|-----------------|----------------|
| NTB Buffers length (IN/OUT)   | 3200/3200       | 3200/3200       | 6400/6400     | 8192/8192       | 8192/8192      |
| Used RAM [bytes]         | 112320          | 118736          | 131552        | 155120          | 171520         |
| Used RAM [%]             | 32.9            | 34.7            | 38.5          | 45.5            | 50.2           |
| Download [Mbps]          | 1.19            | 4.22            | 5.7           | 7.21            | 7.6            |
| Upload [Mbps]            | 5.04            | 5.67            | 5.96          | 6.14            | 6.03           |

Measuring the performance did prove a significant gain dependency on NTB buffers configurations, similarly to the description in [tinyusb](https://github.com/espressif/tinyusb/blob/37995c70595164aa82f5b13496ae71c9584224b9/src/class/net/ncm.h#L61l) upstream is caliming for RP2040.

NTB Buffers count 1/1 and length 3200/3200 is a default value in tinyusb upstream.
The most efficient settings (RAM to performance gain ratio) seems to be the 4th option (NTB Buffers count 3/3, Buffers length 8192/8192).

Increasing the NTB Buffers count and length did also help to mitigate the [tud_network_can_xmit: request blocked](https://github.com/espressif/tinyusb/blob/37995c70595164aa82f5b13496ae71c9584224b9/src/class/net/ncm.h#L63) warning messages while running NCM device.

## Related

Closes #113 
Relates to #107 

## Testing

Performance measurement using [Iperf](https://github.com/espressif/esp-idf/blob/master/examples/wifi/iperf/README.md) did not prove to be useful.

Online speed test was used for the performance measurement (using the esp32s3 NCM device WIFi station to wired interface)

Below is a performance comparison between the 
 - tinyusb's upstream default settings of the NTB buffers (count 1/1, length 3200/3200)
 - NTB Buffers configured to: count 4/4, length 8192/8192

## NTB Buffers(IN/OUT) count: 1/1, length(bytes): 3200/3200 

![alt text](https://www.speedtest.net/result/17252847258.png)

## NTB Buffers(IN/OUT) count: 4/4, length(bytes): 8192/8192 

![alt text](https://www.speedtest.net/result/17252783293.png)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
