### PR TITLE
esp_tinyusb v1.7.0

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,7 +1,8 @@
-## [Unreleased]
+## 1.7.0
 
-- esp_tinyusb: Added possibility to configure NCM Transfer Blocks (NTB) via menuconfig
+- NCM: Added possibility to configure NCM Transfer Blocks (NTB) via menuconfig
 - esp_tinyusb: Added option to select TinyUSB peripheral on esp32p4 via menuconfig (USB_PHY_SUPPORTS_P4_OTG11 in esp-idf is required)
+- esp_tinyusb: Fixed uninstall tinyusb driver with not default task configuration
 
 ## 1.6.0
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.6.0"
+version: "1.7.0"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule


### PR DESCRIPTION
# esp_tinyusb component, [release v1.7.0](https://components.espressif.com/components/espressif/esp_tinyusb/versions/1.7.0) 

## Changes
- NCM: Added possibility to configure NCM Transfer Blocks (NTB) via menuconfig
- esp_tinyusb: Added option to select TinyUSB peripheral on esp32p4 via menuconfig (USB_PHY_SUPPORTS_P4_OTG11 in esp-idf is required)
- esp_tinyusb: Fixed uninstall tinyusb driver with not default task configuration


## Related
- https://github.com/espressif/esp-usb/pull/114
- https://github.com/espressif/esp-usb/pull/91
- https://github.com/espressif/esp-usb/pull/115

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
