### PR TITLE
feat(tusb_msc): Add device mount/unmount callback

### DIFF
--- a/device/esp_tinyusb/include/tusb_msc_storage.h
+++ b/device/esp_tinyusb/include/tusb_msc_storage.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,22 +22,24 @@ extern "C" {
  * @brief Data provided to the input of the `callback_mount_changed` and `callback_premount_changed` callback
  */
 typedef struct {
-    bool is_mounted;                        /*!< Flag if storage is mounted or not */
+    bool is_mounted;                                /*!< Flag if storage is mounted or not */
+    bool is_device_mounted;                         /*!< Flag if device is mounted or not */
 } tinyusb_msc_event_mount_changed_data_t;
 
 /**
  * @brief Types of MSC events
  */
 typedef enum {
-    TINYUSB_MSC_EVENT_MOUNT_CHANGED,        /*!< Event type AFTER mount/unmount operation is successfully finished */
-    TINYUSB_MSC_EVENT_PREMOUNT_CHANGED      /*!< Event type BEFORE mount/unmount operation is started */
+    TINYUSB_MSC_EVENT_MOUNT_CHANGED,                /*!< Event type AFTER storage mount/unmount operation is successfully finished */
+    TINYUSB_MSC_EVENT_PREMOUNT_CHANGED,             /*!< Event type BEFORE storage mount/unmount operation is started */
+    TINYUSB_MSC_EVENT_DEVICE_MOUNT_CHANGED,         /*!< Event type at device mounted/unmounted event */
 } tinyusb_msc_event_type_t;
 
 /**
  * @brief Describes an event passing to the input of a callbacks
  */
 typedef struct {
-    tinyusb_msc_event_type_t type; /*!< Event type */
+    tinyusb_msc_event_type_t type;                  /*!< Event type */
     union {
         tinyusb_msc_event_mount_changed_data_t mount_changed_data; /*!< Data input of the callback */
     };
@@ -56,10 +58,11 @@ typedef void(*tusb_msc_callback_t)(tinyusb_msc_event_t *event);
  * initializing the sdmmc media.
  */
 typedef struct {
-    sdmmc_card_t *card;                             /*!< Pointer to sdmmc card configuration structure */
-    tusb_msc_callback_t callback_mount_changed;     /*!< Pointer to the function callback that will be delivered AFTER mount/unmount operation is successfully finished */
-    tusb_msc_callback_t callback_premount_changed;  /*!< Pointer to the function callback that will be delivered BEFORE mount/unmount operation is started */
-    const esp_vfs_fat_mount_config_t mount_config; /*!< FATFS mount config */
+    sdmmc_card_t *card;                                     /*!< Pointer to sdmmc card configuration structure */
+    tusb_msc_callback_t callback_mount_changed;             /*!< Pointer to the function callback that will be delivered AFTER storage mount/unmount operation is successfully finished */
+    tusb_msc_callback_t callback_premount_changed;          /*!< Pointer to the function callback that will be delivered BEFORE storage mount/unmount operation is started */
+    tusb_msc_callback_t callback_device_mount_changed;      /*!< Pointer to the function callback that will be delivered when a device mounted/unmounted */
+    const esp_vfs_fat_mount_config_t mount_config;          /*!< FATFS mount config */
 } tinyusb_msc_sdmmc_config_t;
 #endif
 
@@ -70,19 +73,20 @@ typedef struct {
  * initializing the SPI Flash media.
  */
 typedef struct {
-    wl_handle_t wl_handle;                          /*!< Pointer to spiflash wera-levelling handle */
-    tusb_msc_callback_t callback_mount_changed;     /*!< Pointer to the function callback that will be delivered AFTER mount/unmount operation is successfully finished */
-    tusb_msc_callback_t callback_premount_changed;  /*!< Pointer to the function callback that will be delivered BEFORE mount/unmount operation is started */
-    const esp_vfs_fat_mount_config_t mount_config; /*!< FATFS mount config */
+    wl_handle_t wl_handle;                                  /*!< Pointer to spiflash wear-levelling handle */
+    tusb_msc_callback_t callback_mount_changed;             /*!< Pointer to the function callback that will be delivered AFTER storage mount/unmount operation is successfully finished */
+    tusb_msc_callback_t callback_premount_changed;          /*!< Pointer to the function callback that will be delivered BEFORE storage mount/unmount operation is started */
+    tusb_msc_callback_t callback_device_mount_changed;      /*!< Pointer to the function callback that will be delivered when a device is unmounted, from tud_umount_cb()  */
+    const esp_vfs_fat_mount_config_t mount_config;          /*!< FATFS mount config */
 } tinyusb_msc_spiflash_config_t;
 
 /**
  * @brief Register storage type spiflash with tinyusb driver
  *
  * @param config pointer to the spiflash configuration
- * @return esp_err_t
- *       - ESP_OK, if success;
- *       - ESP_ERR_NO_MEM, if there was no memory to allocate storage components;
+ * @return
+ *    - ESP_OK: SPI Flash storage initialized successfully
+ *    - ESP_ERR_NO_MEM: if there was no memory to allocate storage components;
  */
 esp_err_t tinyusb_msc_storage_init_spiflash(const tinyusb_msc_spiflash_config_t *config);
 
@@ -91,9 +95,9 @@ esp_err_t tinyusb_msc_storage_init_spiflash(const tinyusb_msc_spiflash_config_t 
  * @brief Register storage type sd-card with tinyusb driver
  *
  * @param config pointer to the sd card configuration
- * @return esp_err_t
- *       - ESP_OK, if success;
- *       - ESP_ERR_NO_MEM, if there was no memory to allocate storage components;
+ * @return
+ *    - ESP_OK: SDMMC storage initialized successfully
+ *    - ESP_ERR_NO_MEM: There was no memory to allocate storage components;
  */
 esp_err_t tinyusb_msc_storage_init_sdmmc(const tinyusb_msc_sdmmc_config_t *config);
 #endif
@@ -109,17 +113,20 @@ void tinyusb_msc_storage_deinit(void);
  *
  * @param event_type - type of registered event for a callback
  * @param callback  - callback function
- * @return esp_err_t - ESP_OK or ESP_ERR_INVALID_ARG
+ * @return
+ *    - ESP_OK: Callback successfully registered
+ *    - ESP_ERR_INVALID_ARG: Invalid input argument - Invalid type of event
  */
 esp_err_t tinyusb_msc_register_callback(tinyusb_msc_event_type_t event_type,
                                         tusb_msc_callback_t callback);
-
 
 /**
  * @brief Unregister a callback invoking on MSC event.
  *
  * @param event_type - type of registered event for a callback
- * @return esp_err_t - ESP_OK or ESP_ERR_INVALID_ARG
+ * @return
+ *    - ESP_OK: Callback successfully unregistered
+ *    - ESP_ERR_INVALID_ARG: Invalid input argument - Invalid type of event
  */
 esp_err_t tinyusb_msc_unregister_callback(tinyusb_msc_event_type_t event_type);
 
@@ -136,10 +143,10 @@ esp_err_t tinyusb_msc_unregister_callback(tinyusb_msc_event_type_t event_type);
  * specific time. Otherwise, MSC device may re-appear again on Host.
  *
  * @param base_path  path prefix where FATFS should be registered
- * @return esp_err_t
- *       - ESP_OK, if success;
- *       - ESP_ERR_NOT_FOUND if the maximum count of volumes is already mounted
- *       - ESP_ERR_NO_MEM if not enough memory or too many VFSes already registered;
+ * @return
+ *    - ESP_OK: Storage mounted successfully, or storage is already mounted
+ *    - ESP_ERR_NOT_FOUND: The maximum count of volumes is already mounted
+ *    - ESP_ERR_NO_MEM: Not enough memory, or too many VFSes already registered
  */
 esp_err_t tinyusb_msc_storage_mount(const char *base_path);
 
@@ -154,32 +161,35 @@ esp_err_t tinyusb_msc_storage_mount(const char *base_path);
  * so as to make sure that user callbacks must be completed within a specific time.
  * Otherwise, MSC device may not appear on Host.
  *
- * @return esp_err_t
- *      - ESP_OK on success
- *      - ESP_ERR_INVALID_STATE if FATFS is not registered in VFS
+ * @return
+ *    - ESP_OK: Storage unmounted successfully, or storage is already unmounted
+ *    - ESP_ERR_INVALID_STATE: FATFS is not registered in VFS
+ *    - ESP_FAIL: Storage has been de-initialized
  */
 esp_err_t tinyusb_msc_storage_unmount(void);
 
 /**
  * @brief Get number of sectors in storage media
  *
- * @return usable size, in bytes
+ * @return
+ *    - usable size, in bytes
  */
 uint32_t tinyusb_msc_storage_get_sector_count(void);
 
 /**
  * @brief Get sector size of storage media
  *
- * @return sector count
+ * @return
+ *    - sector count
  */
 uint32_t tinyusb_msc_storage_get_sector_size(void);
 
 /**
- * @brief Get status if storage media is exposed over USB to Host
+ * @brief Get status if storage media is exposed over USB to USB Host
  *
- * @return bool
- *      - true, if the storage media is exposed to Host
- *      - false, if the stoarge media is mounted on application (not exposed to Host)
+ * @return
+ *    - true: The storage media is exposed to USB Host
+ *    - false: The storage media is mounted on application (not exposed to USB Host)
  */
 bool tinyusb_msc_storage_in_use_by_usb_host(void);
 


### PR DESCRIPTION
## Description

This MR adds a possibility to define a user callback for device mount/unmount events.

Right now, the `tusb_msc_storage.c` automatically calls:
- `tinyusb_msc_storage_mount()` at `tud_umount_cb()`
- `tinyusb_msc_storage_unmount()` at `tud_mount_cb()`

User has no flexibility to do anything else upon the device mount/unmount.

This MR adds a flexibility to the user, to for example control an owership of the storage (eg, not to automatically unmount a storage when a USB device is plugged in)

Also cleaned conceptions between device mount/unmount and storage mount/unmount, not to confuse anyone when the code refers to device mount/unmount and when to storage mount/unmount.

## Related

Related to #78 

## Testing

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
