### PR TITLE
ci(workflow): Added esp-idf releases matrix for examples build

### DIFF
--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        idf_ver: ["latest"]
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:


### PR DESCRIPTION
## Requirements
Latest release v1.7.0 breaks the example/network/sta2eth build on ESP32S2. 
Reason: region `dram0_0_seg' overflowed by:
- 1336 bytes (in my local build)
- 2024 bytes (in the CI build) 

To prevent same result in the future, add example to the CI with all available versions of esp-idf

## Description

This is a 1/3 PR to fix the problem. 

PR plan: 
1. Add all esp-idf releases to the current CI build process (this PR)
2. Add network examples to the CI build process (https://github.com/espressif/esp-usb/pull/124)
3. Fix the NCM Driver memory usage on ESP32S2 (https://github.com/espressif/esp-usb/pull/125)

Several PR's could be merged after completion in one (or not).

## Related
N/A

## Testing

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
