### PR TITLE
fix(ncm): Changed NTB default value to fix DRAM overflow on esp32s2

### DIFF
--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -315,7 +315,7 @@ menu "TinyUSB Stack"
         config TINYUSB_NCM_OUT_NTB_BUFF_MAX_SIZE
             int "NCM NTB Buffer size for reception size"
             depends on TINYUSB_NET_MODE_NCM
-            default 8192
+            default 3200
             range 1600 10240
             help
               Size of NTB buffers on the reception side. The minimum size used by Linux is 2048 bytes.
@@ -327,7 +327,7 @@ menu "TinyUSB Stack"
         config TINYUSB_NCM_IN_NTB_BUFF_MAX_SIZE
             int "NCM NTB Buffer size for transmission size"
             depends on TINYUSB_NET_MODE_NCM
-            default 8192
+            default 3200
             range 1600 10240
             help
               Size of NTB buffers on the transmission side. The minimum size used by Linux is 2048 bytes.


### PR DESCRIPTION
## Requirements
Default value for NCM NTB buffers were 3/3 of 8192 bytes, which led to DRAM overflow on ESP32S2 during the esp-idf sta2eth example build. 
Amount of memory, that could be used to hold NTB does depend on the application logic.

## Description
This is a 2/3 PR to fix the problem. 

To enable the build of the Network example, default value of the buffers amount for  transmission and reception side were changed to 1. 

### Memory Usage for ESP32S2

Comparison values for `examples/network/sta2eth` to select the optimal buffer size and count. 

| Count(In/Out)  | Size(In/Out) | Remain DRAM (Bytes, %) | release |
| ------------- | ------------- | ------------- | ------------- |
| 3/3 | 3200/3200 |  35769 (20,3%)       | v5.2 |
| 3/3 | 3200/3200 |  28437 (11,53%)  | v5.3 |
| 3/3 | 3200/3200  | 31477 (18.3%)| v5.4 |
| 3/3 | 3200/3200 |  28008 (16,28%)      | latest |


PR plan: 
1. Add all esp-idf releases to the current CI build process (https://github.com/espressif/esp-usb/pull/123)
2. Fix the NCM Driver memory usage on ESP32S2 (this PR)
3. Add network examples to the CI build process (https://github.com/espressif/esp-usb/pull/124)

## Related
- https://github.com/espressif/esp-usb/pull/114

## Testing
N/A

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
