### PR TITLE
ci: Update IDF Component Manager version (IEC-258)

### DIFF
--- a/.github/ci/override_managed_component.py
+++ b/.github/ci/override_managed_component.py
@@ -5,9 +5,10 @@
 
 import sys
 import argparse
+import yaml
 from pathlib import Path
 from glob import glob
-from idf_component_tools.manifest import ManifestManager
+from idf_component_tools.manager import ManifestManager
 
 
 def override_with_local_component(component, local_path, app):
@@ -28,16 +29,16 @@ def override_with_local_component(component, local_path, app):
         component_with_namespace = 'espressif/' + component
 
     try:
-        manager.manifest_tree['dependencies'][component_with_namespace] = {
+        manifest_tree = yaml.safe_load(Path(manager.path).read_text())
+        manifest_tree['dependencies'][component_with_namespace] = {
             'version': '*',
             'override_path': str(absolute_local_path)
-            }
+        }
+        with open(manager.path, 'w') as f:
+            yaml.dump(manifest_tree, f, allow_unicode=True, Dumper=yaml.SafeDumper)
     except KeyError:
         print('[Error] {} app does not depend on {}'.format(app, component_with_namespace))
         raise KeyError
-
-    manager.dump()
-
 
 def override_with_local_component_all(component, local_path, apps):
     # Process wildcard, e.g. "app_prefix_*"

--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -2,7 +2,7 @@ name: Build ESP-IDF USB examples
 
 on:
   schedule:
-    - cron: '0 0 * * SAT' # Saturday midnight
+    - cron: "0 0 * * SAT" # Saturday midnight
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -10,18 +10,26 @@ jobs:
   build:
     strategy:
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
+        idf_ver:
+          [
+            "release-v5.0",
+            "release-v5.1",
+            "release-v5.2",
+            "release-v5.3",
+            "release-v5.4",
+            "latest",
+          ]
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'true'
+          submodules: "true"
       - name: Build ESP-IDF USB examples
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install idf-component-manager==1.5.2 idf-build-apps==2.4.3 --upgrade
+          pip install idf-component-manager==2.1.2 idf-build-apps==2.4.3 pyyaml  --upgrade
           python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
           cd ${IDF_PATH}
           idf-build-apps find --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w


### PR DESCRIPTION
## Description
This PR updates the IDF Component Manager version in `.build_idf_examples.yml` and updates the import in `override_managed_component.py` 

## Related

* Closes [PACMAN-1051](https://jira.espressif.com:8443/browse/PACMAN-1051)

## Testing

Changes were tested on a fork of the repository in Github Actions

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
