### PR TITLE
fix(host/uvc): Fixed negotiation for some non-conforming UVC devices

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fixed negotiation for some non-conforming UVC devices (https://github.com/espressif/esp-idf/issues/9868)
+
 ## 2.0.0
 
 - New version of the driver, native to Espressif's USB Host Library

--- a/host/class/uvc/usb_host_uvc/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.0.0"
+version: "2.0.1"
 description: USB Host UVC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uvc/usb_host_uvc
 dependencies:

--- a/host/class/uvc/usb_host_uvc/uvc_descriptor_parsing.c
+++ b/host/class/uvc/usb_host_uvc/uvc_descriptor_parsing.c
@@ -6,13 +6,13 @@
 
 #include <inttypes.h>
 #include <string.h> // strncmp for guid format parsing
-#include <math.h>   // fabs for float comparison
+#include <math.h>   // fabsf for float comparison
 #include "usb/usb_helpers.h"
 #include "usb/uvc_host.h"
 #include "uvc_check_priv.h"
 #include "uvc_descriptors_priv.h"
 
-#define FLOAT_EQUAL(a, b) (fabs(a - b) < 0.0001f) // For comparing float values with acceptable difference (epsilon value)
+#define FLOAT_EQUAL(a, b) (fabsf(a - b) < 0.0001f) // For comparing float values with acceptable difference (epsilon value)
 
 static const uvc_vs_input_header_desc_t *uvc_desc_get_streaming_input_header(const usb_config_desc_t *cfg_desc, uint8_t bInterfaceNumber)
 {


### PR DESCRIPTION
Some UVC devices require to set alternate setting to 0 before the negotiation starts.

Closes https://github.com/espressif/esp-idf/issues/9868

