### PR TITLE
esp_tinyusb v1.7.2

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## 1.7.2
 
 - esp_tinyusb: Fixed crash on logging from ISR
 - PHY: Fixed crash with external_phy=true configuration

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.7.1"
+version: "1.7.2"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '^5.0' # IDF 4.x contains TinyUSB as submodule; expecting breaking changes in IDF v6.0


### PR DESCRIPTION
# esp_tinyusb component, [release v1.7.2](https://components.espressif.com/components/espressif/esp_tinyusb/versions/1.7.2) 

## Changes
- esp_tinyusb: Fixed crash on logging from ISR
- PHY: Fixed crash with external_phy=true configuration


## Related
- https://github.com/espressif/esp-usb/pull/132
- https://github.com/espressif/esp-usb/pull/139

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
