### PR TITLE
fix(esp_tinyusb): Fix crash when external PHY is used

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - esp_tinyusb: Fixed crash on logging from ISR
+- PHY: Fixed crash with external_phy=true configuration
 
 ## 1.7.1
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -4,7 +4,7 @@ documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/ap
 version: "1.7.1"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
-  idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
+  idf: '^5.0' # IDF 4.x contains TinyUSB as submodule; expecting breaking changes in IDF v6.0
   tinyusb:
     version: '>=0.14.2'
     public: true

--- a/device/esp_tinyusb/tinyusb.c
+++ b/device/esp_tinyusb/tinyusb.c
@@ -10,7 +10,7 @@
 #include "esp_err.h"
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/usb_phy.h"
-#include "soc/usb_pins.h"
+#include "soc/usb_pins.h" // TODO: Will be removed in IDF v6.0 IDF-9029
 #include "tinyusb.h"
 #include "descriptors_control.h"
 #include "tusb.h"
@@ -53,6 +53,13 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     if (config->external_phy) {
         phy_conf.target = USB_PHY_TARGET_EXT;
         phy_conf.ext_io_conf = &ext_io_conf;
+
+        /*
+        There is a bug in esp-idf that does not allow device speed selection
+        when External PHY is used.
+        Remove this when proper fix is implemented in IDF-11144
+        */
+        phy_conf.otg_speed = USB_PHY_SPEED_UNDEFINED;
     } else {
         phy_conf.target = USB_PHY_TARGET_INT;
     }


### PR DESCRIPTION
* Bug in esp-idf: when external phy is selected, we cannot call set_speed()