### PR TITLE
refactor(esp_tinyusb): Add an option to skip PHY setup

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build USB TestApps
     strategy:
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
+        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
@@ -46,13 +46,11 @@ jobs:
     needs: build
     strategy:
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
+        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
         idf_target: ["esp32s2", "esp32p4"]
         runner_tag: ["usb_host", "usb_device"]
         exclude:
           # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
-          - idf_ver: "release-v5.0"
-            idf_target: "esp32p4"
           - idf_ver: "release-v5.1"
             idf_target: "esp32p4"
           - idf_ver: "release-v5.2"

--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 0 * * SAT" # Saturday midnight
   pull_request:
     types: [opened, reopened, synchronize]
+    branches-ignore:
+      - esp_tinyusb/v2.0
 
 jobs:
   build:
@@ -12,7 +14,6 @@ jobs:
       matrix:
         idf_ver:
           [
-            "release-v5.0",
             "release-v5.1",
             "release-v5.2",
             "release-v5.3",

--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0 [Unreleased]
+
+### Breaking changes
+- phy: esp_tinyusb will no longer initialize external PHY. If external PHY is required, it must be explicitly initialized by user and esp_tinyusb must be configured with `skip_phy_setup = true`
+
 ## 1.7.2
 
 - esp_tinyusb: Fixed crash on logging from ISR

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -4,7 +4,7 @@ documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/ap
 version: "1.7.2"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
-  idf: '^5.0' # IDF 4.x contains TinyUSB as submodule; expecting breaking changes in IDF v6.0
+  idf: '^5.1'
   tinyusb:
-    version: '>=0.14.2'
+    version: '>=0.17.0'
     public: true

--- a/device/esp_tinyusb/include/tinyusb.h
+++ b/device/esp_tinyusb/include/tinyusb.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,11 +17,6 @@ extern "C" {
 
 /**
  * @brief Configuration structure of the TinyUSB core
- *
- * USB specification mandates self-powered devices to monitor USB VBUS to detect connection/disconnection events.
- * If you want to use this feature, connected VBUS to any free GPIO through a voltage divider or voltage comparator.
- * The voltage divider output should be (0.75 * Vdd) if VBUS is 4.4V (lowest valid voltage at device port).
- * The comparator thresholds should be set with hysteresis: 4.35V (falling edge) and 4.75V (raising edge).
  */
 typedef struct {
     union {
@@ -30,7 +25,10 @@ typedef struct {
     };
     const char **string_descriptor;            /*!< Pointer to array of string descriptors. If set to NULL, TinyUSB device will use a default string descriptors whose values are set in Kconfig */
     int string_descriptor_count;               /*!< Number of descriptors in above array */
-    bool external_phy;                         /*!< Should USB use an external PHY */
+    bool skip_phy_setup;                       /*!< If set, the esp_tinyusb will not configure the USB PHY thus allowing
+                                                    the user to manually configure the USB PHY before calling tinyusb_driver_install().
+                                                    Users should set this if they want to use an external USB PHY. Otherwise,
+                                                    the esp_tinyusb will automatically configure the internal USB PHY */
     union {
         struct {
             const uint8_t *configuration_descriptor;            /*!< Pointer to a configuration descriptor. If set to NULL, TinyUSB device will use a default configuration descriptor whose values are set in Kconfig */
@@ -45,8 +43,11 @@ typedef struct {
 #else
     };
 #endif // TUD_OPT_HIGH_SPEED
-    bool self_powered;                         /*!< This is a self-powered USB device. USB VBUS must be monitored. */
-    int vbus_monitor_io;                       /*!< GPIO for VBUS monitoring. Ignored if not self_powered. */
+    bool self_powered;                        /*!< USB specification mandates self-powered devices to monitor USB VBUS to detect connection/disconnection events.
+                                                   If you want to use this feature, connected VBUS to any free GPIO through a voltage divider or voltage comparator.
+                                                   The voltage divider output should be (0.75 * Vdd) if VBUS is 4.4V (lowest valid voltage at device port).
+                                                   The comparator thresholds should be set with hysteresis: 4.35V (falling edge) and 4.75V (raising edge). */
+    int vbus_monitor_io;                      /*!< GPIO for VBUS monitoring. Ignored if not self_powered. */
 } tinyusb_config_t;
 
 /**

--- a/device/esp_tinyusb/test_apps/cdc/main/test_cdc.c
+++ b/device/esp_tinyusb/test_apps/cdc/main/test_cdc.c
@@ -83,7 +83,6 @@ TEST_CASE("tinyusb_cdc", "[esp_tinyusb][cdc]")
         .device_descriptor = &cdc_device_descriptor,
         .string_descriptor = NULL,
         .string_descriptor_count = 0,
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = cdc_desc_configuration,
         .hs_configuration_descriptor = cdc_desc_configuration,

--- a/device/esp_tinyusb/test_apps/configuration_desc/main/test_config_desc.c
+++ b/device/esp_tinyusb/test_apps/configuration_desc/main/test_config_desc.c
@@ -179,7 +179,6 @@ void tud_mount_cb(void)
 TEST_CASE("descriptors_config_all_default", "[esp_tinyusb][usb_device][config]")
 {
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
         .device_descriptor = NULL,
         .configuration_descriptor = NULL,
 #if (CONFIG_TINYUSB_RHPORT_HS)
@@ -200,7 +199,6 @@ TEST_CASE("descriptors_config_all_default", "[esp_tinyusb][usb_device][config]")
 TEST_CASE("descriptors_config_device", "[esp_tinyusb][usb_device][config]")
 {
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
         .device_descriptor = &test_device_descriptor,
         .configuration_descriptor = NULL,
 #if (CONFIG_TINYUSB_RHPORT_HS)
@@ -224,7 +222,6 @@ TEST_CASE("descriptors_config_device", "[esp_tinyusb][usb_device][config]")
 TEST_CASE("descriptors_config_device_and_config", "[esp_tinyusb][usb_device][config]")
 {
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
         .device_descriptor = &test_device_descriptor,
         .configuration_descriptor = test_fs_configuration_descriptor,
 #if (CONFIG_TINYUSB_RHPORT_HS)
@@ -246,7 +243,6 @@ TEST_CASE("descriptors_config_device_and_config", "[esp_tinyusb][usb_device][con
 TEST_CASE("descriptors_config_device_and_hs_config_only", "[esp_tinyusb][usb_device][config]")
 {
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
         .device_descriptor = &test_device_descriptor,
         .configuration_descriptor = NULL,
         .hs_configuration_descriptor = test_hs_configuration_descriptor,
@@ -264,7 +260,6 @@ TEST_CASE("descriptors_config_device_and_hs_config_only", "[esp_tinyusb][usb_dev
 TEST_CASE("descriptors_config_all_configured", "[esp_tinyusb][usb_device][config]")
 {
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
         .device_descriptor = &test_device_descriptor,
         .fs_configuration_descriptor = test_fs_configuration_descriptor,
         .hs_configuration_descriptor = test_hs_configuration_descriptor,

--- a/device/esp_tinyusb/test_apps/dconn_detection/main/test_dconn_detection.c
+++ b/device/esp_tinyusb/test_apps/dconn_detection/main/test_dconn_detection.c
@@ -121,7 +121,6 @@ TEST_CASE("dconn_detection", "[esp_tinyusb][dconn]")
         .device_descriptor = &test_device_descriptor,
         .string_descriptor = NULL,
         .string_descriptor_count = 0,
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = test_configuration_descriptor,
         .hs_configuration_descriptor = test_configuration_descriptor,

--- a/device/esp_tinyusb/test_apps/default_task/main/test_tusb.c
+++ b/device/esp_tinyusb/test_apps/default_task/main/test_tusb.c
@@ -91,7 +91,6 @@ TEST_CASE("tinyusb_default_task_with_init", "[esp_tinyusb][tusb_task]")
         .device_descriptor = &test_device_descriptor,
         .string_descriptor = NULL,
         .string_descriptor_count = 0,
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = test_configuration_descriptor,
         .hs_configuration_descriptor = test_configuration_descriptor,

--- a/device/esp_tinyusb/test_apps/default_task_with_init/main/test_tusb.c
+++ b/device/esp_tinyusb/test_apps/default_task_with_init/main/test_tusb.c
@@ -91,7 +91,6 @@ TEST_CASE("tinyusb_default_task_with_init", "[esp_tinyusb][tusb_task]")
         .device_descriptor = &test_device_descriptor,
         .string_descriptor = NULL,
         .string_descriptor_count = 0,
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = test_configuration_descriptor,
         .hs_configuration_descriptor = test_configuration_descriptor,

--- a/device/esp_tinyusb/test_apps/external_task/main/test_tusb.c
+++ b/device/esp_tinyusb/test_apps/external_task/main/test_tusb.c
@@ -109,7 +109,6 @@ TEST_CASE("tinyusb_external_task", "[esp_tinyusb][tusb_task]")
         .device_descriptor = &test_device_descriptor,
         .string_descriptor = NULL,
         .string_descriptor_count = 0,
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = test_configuration_descriptor,
         .hs_configuration_descriptor = test_configuration_descriptor,

--- a/device/esp_tinyusb/test_apps/teardown_device/main/test_teardown.c
+++ b/device/esp_tinyusb/test_apps/teardown_device/main/test_teardown.c
@@ -100,7 +100,6 @@ TEST_CASE("tinyusb_teardown", "[esp_tinyusb][teardown]")
         .device_descriptor = &test_device_descriptor,
         .string_descriptor = NULL,
         .string_descriptor_count = 0,
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = test_configuration_descriptor,
         .hs_configuration_descriptor = test_configuration_descriptor,

--- a/device/esp_tinyusb/test_apps/vendor/main/test_vendor.c
+++ b/device/esp_tinyusb/test_apps/vendor/main/test_vendor.c
@@ -53,7 +53,6 @@ TEST_CASE("tinyusb_vendor", "[esp_tinyusb][vendor]")
 {
     // Install TinyUSB driver
     const tinyusb_config_t tusb_cfg = {
-        .external_phy = false,
         .device_descriptor = NULL,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = NULL,

--- a/device/esp_tinyusb/tinyusb.c
+++ b/device/esp_tinyusb/tinyusb.c
@@ -10,7 +10,6 @@
 #include "esp_err.h"
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/usb_phy.h"
-#include "soc/usb_pins.h" // TODO: Will be removed in IDF v6.0 IDF-9029
 #include "tinyusb.h"
 #include "descriptors_control.h"
 #include "tusb.h"
@@ -28,48 +27,28 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
 {
     ESP_RETURN_ON_FALSE(config, ESP_ERR_INVALID_ARG, TAG, "Config can't be NULL");
 
-    // Configure USB PHY
-    usb_phy_config_t phy_conf = {
-        .controller = USB_PHY_CTRL_OTG,
-        .otg_mode = USB_OTG_MODE_DEVICE,
+    if (!config->skip_phy_setup) {
+        // Configure USB PHY
+        usb_phy_config_t phy_conf = {
+            .controller = USB_PHY_CTRL_OTG,
+            .target = USB_PHY_TARGET_INT,
+            .otg_mode = USB_OTG_MODE_DEVICE,
 #if (USB_PHY_SUPPORTS_P4_OTG11)
-        .otg_speed = (TUD_OPT_HIGH_SPEED) ? USB_PHY_SPEED_HIGH : USB_PHY_SPEED_FULL,
+            .otg_speed = (TUD_OPT_HIGH_SPEED) ? USB_PHY_SPEED_HIGH : USB_PHY_SPEED_FULL,
 #else
 #if (CONFIG_IDF_TARGET_ESP32P4 && CONFIG_TINYUSB_RHPORT_FS)
 #error "USB PHY for OTG1.1 is not supported, please update your esp-idf."
 #endif // IDF_TARGET_ESP32P4 && CONFIG_TINYUSB_RHPORT_FS
 #endif // USB_PHY_SUPPORTS_P4_OTG11
-    };
+        };
 
-    // External PHY IOs config
-    usb_phy_ext_io_conf_t ext_io_conf = {
-        .vp_io_num = USBPHY_VP_NUM,
-        .vm_io_num = USBPHY_VM_NUM,
-        .rcv_io_num = USBPHY_RCV_NUM,
-        .oen_io_num = USBPHY_OEN_NUM,
-        .vpo_io_num = USBPHY_VPO_NUM,
-        .vmo_io_num = USBPHY_VMO_NUM,
-    };
-    if (config->external_phy) {
-        phy_conf.target = USB_PHY_TARGET_EXT;
-        phy_conf.ext_io_conf = &ext_io_conf;
-
-        /*
-        There is a bug in esp-idf that does not allow device speed selection
-        when External PHY is used.
-        Remove this when proper fix is implemented in IDF-11144
-        */
-        phy_conf.otg_speed = USB_PHY_SPEED_UNDEFINED;
-    } else {
-        phy_conf.target = USB_PHY_TARGET_INT;
+        // OTG IOs config
+        const usb_phy_otg_io_conf_t otg_io_conf = USB_PHY_SELF_POWERED_DEVICE(config->vbus_monitor_io);
+        if (config->self_powered) {
+            phy_conf.otg_io_conf = &otg_io_conf;
+        }
+        ESP_RETURN_ON_ERROR(usb_new_phy(&phy_conf, &phy_hdl), TAG, "Install USB PHY failed");
     }
-
-    // OTG IOs config
-    const usb_phy_otg_io_conf_t otg_io_conf = USB_PHY_SELF_POWERED_DEVICE(config->vbus_monitor_io);
-    if (config->self_powered) {
-        phy_conf.otg_io_conf = &otg_io_conf;
-    }
-    ESP_RETURN_ON_ERROR(usb_new_phy(&phy_conf, &phy_hdl), TAG, "Install USB PHY failed");
 
     // Descriptors config
     ESP_RETURN_ON_ERROR(tinyusb_set_descriptors(config), TAG, "Descriptors config failed");

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/usb_device.c
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/usb_device.c
@@ -70,7 +70,6 @@ void run_usb_dual_cdc_device(void)
         .device_descriptor = &cdc_device_descriptor,
         .string_descriptor = NULL,
         .string_descriptor_count = 0,
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = cdc_fs_desc_configuration,
         .hs_configuration_descriptor = cdc_hs_desc_configuration,

--- a/host/class/hid/usb_host_hid/test_app/main/hid_mock_device.c
+++ b/host/class/hid/usb_host_hid/test_app/main/hid_mock_device.c
@@ -198,7 +198,6 @@ void hid_mock_device(tusb_iface_count_t iface_count)
         .device_descriptor = NULL,
         .string_descriptor = hid_string_descriptor,
         .string_descriptor_count = sizeof(hid_string_descriptor) / sizeof(hid_string_descriptor[0]),
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = hid_configuration_descriptor_list[tusb_iface_count],
         .hs_configuration_descriptor = hid_configuration_descriptor_list[tusb_iface_count],

--- a/host/class/msc/usb_host_msc/test_app/main/msc_device.c
+++ b/host/class/msc/usb_host_msc/test_app/main/msc_device.c
@@ -126,7 +126,6 @@ static void storage_init(void)
         .device_descriptor = &descriptor_config,
         .string_descriptor = string_desc_arr,
         .string_descriptor_count = sizeof(string_desc_arr) / sizeof(string_desc_arr[0]),
-        .external_phy = false,
 #if (TUD_OPT_HIGH_SPEED)
         .fs_configuration_descriptor = msc_fs_desc_configuration,
         .hs_configuration_descriptor = msc_hs_desc_configuration,


### PR DESCRIPTION
esp_tinyusb will no longer initialize external PHY. If external PHY is required, it must be explicitly initialized by user and esp_tinyusb must be configured with `skip_phy_setup = true`

Closes https://github.com/espressif/esp-usb/issues/138