### PR TITLE
fix(uac_host): Fix deprecated warning in test app

### DIFF
--- a/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c
+++ b/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "esp_log.h"
+#include "esp_idf_version.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "freertos/queue.h"
@@ -18,8 +19,6 @@
 #include "usb/usb_host.h"
 #include "usb/uac_host.h"
 
-// USB PHY for device disconnection emulation
-static usb_phy_handle_t phy_hdl = NULL;
 const static char *TAG = "UAC_TEST";
 
 // ----------------------- Public -------------------------
@@ -62,19 +61,6 @@ static const uint8_t UAC_DEV_SPK_IFACE_SAMPLE_FREQ_TPYE_ALT[UAC_DEV_SPK_IFACE_AL
 static const uint32_t UAC_DEV_SPK_IFACE_SAMPLE_FREQ_ALT[UAC_DEV_SPK_IFACE_ALT_NUM][UAC_DEV_SPK_IFACE_ALT_1_SAMPLE_FREQ_TYPE] = {{UAC_DEV_SPK_IFACE_ALT_1_SAMPLE_FREQ_1}};
 
 
-static void force_conn_state(bool connected, TickType_t delay_ticks)
-{
-    if (!phy_hdl) {
-        // P4 currently not support phy operation
-        return;
-    }
-    if (delay_ticks > 0) {
-        //Delay of 0 ticks causes a yield. So skip if delay_ticks is 0.
-        vTaskDelay(delay_ticks);
-    }
-    TEST_ASSERT_EQUAL(ESP_OK, usb_phy_action(phy_hdl, (connected) ? USB_PHY_ACTION_HOST_ALLOW_CONN : USB_PHY_ACTION_HOST_FORCE_DISCONN));
-}
-
 typedef enum {
     APP_EVENT = 0,
     UAC_DRIVER_EVENT,
@@ -101,6 +87,63 @@ typedef struct {
         } device_evt;
     };
 } event_queue_t;
+
+// usb_host_lib_set_root_port_power is used to force toggle connection, primary developed for esp32p4
+// esp32p4 is supported from IDF 5.3
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
+static usb_phy_handle_t phy_hdl = NULL;
+
+// Force connection/disconnection using PHY
+static void force_conn_state(bool connected, TickType_t delay_ticks)
+{
+    TEST_ASSERT_NOT_EQUAL(NULL, phy_hdl);
+    if (delay_ticks > 0) {
+        // Delay of 0 ticks causes a yield. So skip if delay_ticks is 0.
+        vTaskDelay(delay_ticks);
+    }
+    ESP_ERROR_CHECK(usb_phy_action(phy_hdl, (connected) ? USB_PHY_ACTION_HOST_ALLOW_CONN : USB_PHY_ACTION_HOST_FORCE_DISCONN));
+}
+
+// Initialize the internal USB PHY to connect to the USB OTG peripheral. We manually install the USB PHY for testing
+static bool install_phy(void)
+{
+    usb_phy_config_t phy_config = {
+        .controller = USB_PHY_CTRL_OTG,
+        .target = USB_PHY_TARGET_INT,
+        .otg_mode = USB_OTG_MODE_HOST,
+        .otg_speed = USB_PHY_SPEED_UNDEFINED,   // In Host mode, the speed is determined by the connected device
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, usb_new_phy(&phy_config, &phy_hdl));
+    // Return true, to skip_phy_setup during the usb_host_install()
+    return true;
+}
+
+static void delete_phy(void)
+{
+    TEST_ASSERT_EQUAL(ESP_OK, usb_del_phy(phy_hdl)); // Tear down USB PHY
+    phy_hdl = NULL;
+}
+#else // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
+
+// Force connection/disconnection using root port power
+static void force_conn_state(bool connected, TickType_t delay_ticks)
+{
+    if (delay_ticks > 0) {
+        // Delay of 0 ticks causes a yield. So skip if delay_ticks is 0.
+        vTaskDelay(delay_ticks);
+    }
+    ESP_ERROR_CHECK(usb_host_lib_set_root_port_power(connected));
+}
+
+static bool install_phy(void)
+{
+    // Return false, NOT to skip_phy_setup during the usb_host_install()
+    return false;
+}
+
+static void delete_phy(void) {}
+#endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
+
 
 static void uac_device_callback(uac_host_device_handle_t uac_device_handle, const uac_host_device_event_t event, void *arg)
 {
@@ -140,18 +183,9 @@ static void uac_host_lib_callback(uint8_t addr, uint8_t iface_num, const uac_hos
  */
 static void usb_lib_task(void *arg)
 {
-    // Initialize the internal USB PHY to connect to the USB OTG peripheral.
-    // We manually install the USB PHY for testing
-    usb_phy_config_t phy_config = {
-        .controller = USB_PHY_CTRL_OTG,
-        .target = USB_PHY_TARGET_INT,
-        .otg_mode = USB_OTG_MODE_HOST,
-        .otg_speed = USB_PHY_SPEED_UNDEFINED,   //In Host mode, the speed is determined by the connected device
-    };
-    TEST_ASSERT_EQUAL(ESP_OK, usb_new_phy(&phy_config, &phy_hdl));
-
+    const bool skip_phy_setup = install_phy();
     const usb_host_config_t host_config = {
-        .skip_phy_setup = true,
+        .skip_phy_setup = skip_phy_setup,
         .intr_flags = ESP_INTR_FLAG_LEVEL1,
     };
 
@@ -180,8 +214,7 @@ static void usb_lib_task(void *arg)
     // Clean up USB Host
     vTaskDelay(10); // Short delay to allow clients clean-up
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_uninstall());
-    TEST_ASSERT_EQUAL(ESP_OK, usb_del_phy(phy_hdl)); //Tear down USB PHY
-    phy_hdl = NULL;
+    delete_phy(); //Tear down USB PHY
     // set bit BIT0_USB_HOST_DRIVER_REMOVED to notify driver removed
     xEventGroupSetBits(s_evt_handle, BIT0_USB_HOST_DRIVER_REMOVED);
     vTaskDelete(NULL);


### PR DESCRIPTION
## Description

This MR fixes UAC Host test app build in CI. 

`usb_phy_action()` originally used for forcing connection and disconnection in test apps, is now deprecated, which is causing build errors in CI.

`usb_host_lib_set_root_port_power()` is used instead of the `usb_phy_action()`
Also, it is not possible to use `usb_phy_action()` on esp32p4 targert, because the P4's PHY can't be controlled in the same way as the S3's and S2's PHY

<details>

<summary>An error from CI build for IDF latest fixed in this MR</summary>

```shell
2025-03-06T10:24:51.6003789Z /__w/esp-usb/esp-usb/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c: In function 'force_conn_state':
2025-03-06T10:24:51.6004616Z /__w/esp-usb/esp-usb/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c:75:5: error: 'usb_phy_action' is deprecated [-Werror=deprecated-declarations]
2025-03-06T10:24:51.6005441Z    75 |     TEST_ASSERT_EQUAL(ESP_OK, usb_phy_action(phy_hdl, (connected) ? USB_PHY_ACTION_HOST_ALLOW_CONN : USB_PHY_ACTION_HOST_FORCE_DISCONN));
2025-03-06T10:24:51.6005920Z       |     ^~~~~~~~~~~~~~~~~
2025-03-06T10:24:51.6006324Z In file included from /__w/esp-usb/esp-usb/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c:17:
2025-03-06T10:24:51.6006987Z /opt/esp/idf/components/usb/include/esp_private/usb_phy.h:159:39: note: declared here
2025-03-06T10:24:51.6007612Z   159 | esp_err_t __attribute__((deprecated)) usb_phy_action(usb_phy_handle_t handle, usb_phy_action_t action);
2025-03-06T10:24:51.6008036Z       |                                       ^~~~~~~~~~~~~~
2025-03-06T10:24:51.6008365Z cc1: all warnings being treated as errors
```

</details>



## Related
- Preceding #144 
- The same changes have been implemented in #85  for other class drivers

## Testing

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
