### PR TITLE
feat(host/uvc): Allow format change of open stream (IDF-12571)

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- Added `uvc_host_stream_format_select()` function that allows change of format of an opened stream
+
 ## 2.1.0
 
 - support get frame list when device insert

--- a/host/class/uvc/usb_host_uvc/README.md
+++ b/host/class/uvc/usb_host_uvc/README.md
@@ -1,7 +1,7 @@
 # USB Host UVC Class Driver
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_uvc/badge.svg)](https://components.espressif.com/components/espressif/usb_host_uvc)
-![maintenance-status](https://img.shields.io/badge/maintenance-experimental-blue.svg)
+![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 This component contains an implementation of a USB Host UVC Class Driver that is implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
 
@@ -13,6 +13,7 @@ The UVC driver allows video streaming from USB cameras.
 - Frame buffers in PSRAM
 - Video Stream format negotiation
 - Stream overflow and underflow management
+- Dynamic resolution change
 
 ### Usage
 

--- a/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/basic_uvc_stream.c
+++ b/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/basic_uvc_stream.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,9 +32,8 @@
 #else
 #define EXAMPLE_FRAME_COUNT         (2)
 #endif
-#define EXAMPLE_STREAM_FPS          (15)
 #define EXAMPLE_RECORDING_LENGTH_S  (5) // The stream(s) is enabled, run for EXAMPLE_RECORDING_LENGTH_S and then stopped
-#define EXAMPLE_NUMBER_OF_STREAMS   (2) // This example shows how to control multiple UVC streams. Set this to 1 if you camera offers only 1 stream
+#define EXAMPLE_NUMBER_OF_STREAMS   (1) // This example shows how to control multiple UVC streams. Set this to 1 if you camera offers only 1 stream
 #define EXAMPLE_USE_SDCARD          (0) // SD card on P4 evaluation board will be initialized
 
 static const char *TAG = "UVC example";
@@ -128,8 +127,8 @@ static void frame_handling_task(void *arg)
 
             do {
                 uvc_host_frame_t *frame;
-                if (xQueueReceive(frame_q, &frame, pdMS_TO_TICKS(1000)) == pdPASS) {
-                    ESP_LOGI(TAG, "Stream %d: New frame! Len: %d", uvc_index, frame->data_len);
+                if (xQueueReceive(frame_q, &frame, pdMS_TO_TICKS(5000)) == pdPASS) {
+                    ESP_LOGI(TAG, "Stream %d: New frame %dx%d! Len: %d", uvc_index, frame->vs_format.h_res, frame->vs_format.v_res, frame->data_len);
 
                     // Process the frame data here!!
 

--- a/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
+++ b/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -254,6 +254,20 @@ esp_err_t uvc_host_stream_open(const uvc_host_stream_config_t *stream_config, in
  *     - Else: USB lib error
  */
 esp_err_t uvc_host_stream_start(uvc_host_stream_hdl_t stream_hdl);
+
+/**
+ * @brief Change the format of opened stream
+ *
+ * @note  If the stream is already streaming, it will be stopped, reconfigured and started again
+ * @param[in] stream_hdl UVC handle obtained from uvc_host_stream_open()
+ * @param[in] format     Format to configure
+ * @return
+ *     - ESP_OK: Success
+ *     - ESP_ERR_INVALID_ARG: Input parameter is NULL
+ *     - ESP_ERR_NOT_FOUND: Format negotiation error
+ *     - Else: USB lib error
+ */
+esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *format);
 
 /**
  * @brief Stop UVC stream

--- a/host/class/uvc/usb_host_uvc/private_include/uvc_frame_priv.h
+++ b/host/class/uvc/usb_host_uvc/private_include/uvc_frame_priv.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -73,7 +73,21 @@ esp_err_t uvc_frame_add_data(uvc_host_frame_t *frame, const uint8_t *data, size_
  *
  * @param[in] frame Frame buffer
  */
-void uvc_frame_reset(uvc_host_frame_t *frame);
+static inline void uvc_frame_reset(uvc_host_frame_t *frame)
+{
+    assert(frame);
+    frame->data_len = 0;
+}
+
+/**
+ * @brief Saves format to all frame buffers
+ *
+ * All frames must be returned when this function is called
+ *
+ * @param[in] uvc_stream UVC stream
+ * @param[in] vs_format  VS format to save to frame buffers
+ */
+void uvc_frame_format_update(uvc_stream_t *uvc_stream, const uvc_host_stream_format_t *vs_format);
 
 #ifdef __cplusplus
 }

--- a/host/class/uvc/usb_host_uvc/private_include/uvc_types_priv.h
+++ b/host/class/uvc/usb_host_uvc/private_include/uvc_types_priv.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,7 +35,6 @@ struct uvc_host_stream_s {
         uvc_host_stream_callback_t stream_cb; // User's callback for stream events
         uvc_host_frame_callback_t frame_cb;   // User's frame callback
         void *cb_arg;                         // Common argument for user's callbacks
-        uvc_host_stream_format_t vs_format;   // Format of the video stream (Runtime format change of opened stream is not supported)
         QueueHandle_t empty_fb_queue;         // Queue of empty framebuffers
 
         // Constant USB descriptor values
@@ -51,6 +50,7 @@ struct uvc_host_stream_s {
     } constant; // Constant members do no change after installation thus do not require a critical section
 
     struct {
+        uvc_host_stream_format_t vs_format;   // Format of the video stream
         uvc_host_frame_t *current_frame;      // Frame that is being written to
         bool streaming;                       // Flag whether stream is on/off
     } dynamic; // Dynamic members require a critical section

--- a/host/class/uvc/usb_host_uvc/uvc_bulk.c
+++ b/host/class/uvc/usb_host_uvc/uvc_bulk.c
@@ -105,8 +105,6 @@ void bulk_transfer_callback(usb_transfer_t *transfer)
 
             bool return_frame = true; // Default to returning the frame in case streaming has been stopped
             if (invoke_fb_callback) {
-                memcpy((uvc_host_stream_format_t *)&this_frame->vs_format, &uvc_stream->constant.vs_format, sizeof(uvc_host_stream_format_t));
-
                 // Call the user's frame callback. If the callback returns false,
                 // we do not return the frame to the empty queue (i.e., the user wants to keep it for processing)
                 return_frame = uvc_stream->constant.frame_cb(this_frame, uvc_stream->constant.cb_arg);

--- a/host/class/uvc/usb_host_uvc/uvc_frame.c
+++ b/host/class/uvc/usb_host_uvc/uvc_frame.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -120,8 +120,16 @@ esp_err_t uvc_frame_add_data(uvc_host_frame_t *frame, const uint8_t *data, size_
     return ESP_OK;
 }
 
-void uvc_frame_reset(uvc_host_frame_t *frame)
+void uvc_frame_format_update(uvc_stream_t *uvc_stream, const uvc_host_stream_format_t *vs_format)
 {
-    assert(frame);
-    frame->data_len = 0;
+    uvc_host_frame_t *this_frame = uvc_frame_get_empty(uvc_stream);
+    if (this_frame == NULL) {
+        return;
+    }
+    memcpy((uvc_host_stream_format_t *)&this_frame->vs_format, vs_format, sizeof(uvc_host_stream_format_t));
+
+    // Attention: recursive call!
+    // The recursive loop is broken once we run out of empty frame buffers
+    uvc_frame_format_update(uvc_stream, vs_format);
+    uvc_host_frame_return(uvc_stream, this_frame);
 }

--- a/host/class/uvc/usb_host_uvc/uvc_isoc.c
+++ b/host/class/uvc/usb_host_uvc/uvc_isoc.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -164,7 +164,6 @@ void isoc_transfer_callback(usb_transfer_t *transfer)
             UVC_EXIT_CRITICAL();
 
             if (invoke_fb_callback) {
-                memcpy((uvc_host_stream_format_t *)&this_frame->vs_format, &uvc_stream->constant.vs_format, sizeof(uvc_host_stream_format_t));
                 return_frame = uvc_stream->constant.frame_cb(this_frame, uvc_stream->constant.cb_arg);
             }
             if (return_frame) {


### PR DESCRIPTION
## Requirements 
Support modifying the requested resolution without reopening the UVC device.

## Changes
* New function `esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *format);` that allows change of video format of an opened stream
* Few minor optimizations and clean-ups in tests

All cameras that I tested do not support format change while streaming.
So in case the camera is streaming at the time the format change is requested, we stop the stream, reconfigure the stream format and start the stream again.
