### PR TITLE
feat(uac_host): Release of UAC Host driver v1.3.0

### DIFF
--- a/host/class/uac/usb_host_uac/CHANGELOG.md
+++ b/host/class/uac/usb_host_uac/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for USB Host UAC
 
-## [Unreleased]
+## 1.3.0
 
 1. Added Linux target build for the UAC component, host tests (https://github.com/espressif/esp-usb/issues/143)
 

--- a/host/class/uac/usb_host_uac/idf_component.yml
+++ b/host/class/uac/usb_host_uac/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.2.0"
+version: "1.3.0"
 description: USB Host UAC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uac/usb_host_uac
 dependencies:


### PR DESCRIPTION
## Description

Release UAC Host driver v1.3.0

## Changes
 - Added Linux target build for UAC Host driver
 - Added Linux Host tests (Cmock tests), tests are run in CI


## Related

 - https://github.com/espressif/esp-usb/issues/143

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
