### PR TITLE
fix(usb_host): Update USB Host Cmock paths

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/CMakeLists.txt
@@ -4,8 +4,10 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)
 
 list(APPEND EXTRA_COMPONENT_DIRS
-     "$ENV{IDF_PATH}/tools/mocks/usb/"
-     #"$ENV{IDF_PATH}/tools/mocks/freertos/"    We are using freertos as real component
+    "$ENV{IDF_PATH}/tools/mocks/usb/usb_host_full_mock/usb/"    # Full USB Host stack mock (all the layers are mocked)
+
+     # The following line would be needed to include the freertos mock component if this test used mocked FreeRTOS.
+     #"$ENV{IDF_PATH}/tools/mocks/freertos/"
     )
 
 add_definitions("-DCMOCK_MEM_DYNAMIC")

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/README.md
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/README.md
@@ -25,7 +25,11 @@ The build produces an executable in the build folder.
 Just run:
 
 ```
-./build/host_test_usb_cdc.elf
+idf.py monitor
 ```
 
-The test executable have some options provided by the test framework.
+or run the executable directly:
+
+```
+./build/host_test_usb_cdc.elf
+```

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/CMakeLists.txt
@@ -4,6 +4,6 @@ idf_component_register(SRC_DIRS .
                         PRIV_INCLUDE_DIRS "../../../private_include"
                         WHOLE_ARCHIVE)
 
-# Currently 'main' for IDF_TARGET=linux is defined in freertos component.
-# Since we are using a freertos mock here, need to let Catch2 provide 'main'.
-#target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain) # We don't mock FreeRTOS for this test
+# The following line would be needed to provide the 'main' function if this test used mocked FreeRTOS.
+# As this test uses the real FreeRTOS implementation, we don't need Catch2 to provide 'main'.
+#target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)

--- a/host/class/cdc/usb_host_cdc_acm/host_test/parsing_tests/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/parsing_tests/CMakeLists.txt
@@ -4,7 +4,7 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)
 
 list(APPEND EXTRA_COMPONENT_DIRS
-     "$ENV{IDF_PATH}/tools/mocks/usb/"
+     "$ENV{IDF_PATH}/tools/mocks/usb/usb_host_full_mock/usb/"    # Full USB Host stack mock (all the layers are mocked)
      "$ENV{IDF_PATH}/tools/mocks/freertos/"
     )
 

--- a/host/class/hid/usb_host_hid/host_test/CMakeLists.txt
+++ b/host/class/hid/usb_host_hid/host_test/CMakeLists.txt
@@ -4,7 +4,7 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)
 
 list(APPEND EXTRA_COMPONENT_DIRS
-     "$ENV{IDF_PATH}/tools/mocks/usb/"
+     "$ENV{IDF_PATH}/tools/mocks/usb/usb_host_full_mock/usb/"    # Full USB Host stack mock (all the layers are mocked)
      "$ENV{IDF_PATH}/tools/mocks/freertos/"
     )
 

--- a/host/class/uac/usb_host_uac/host_test/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/host_test/CMakeLists.txt
@@ -4,8 +4,10 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)
 
 list(APPEND EXTRA_COMPONENT_DIRS
-     "$ENV{IDF_PATH}/tools/mocks/usb/"
-     #"$ENV{IDF_PATH}/tools/mocks/freertos/"    We are using freertos as real component (missing Ringbuffer mock)
+     "$ENV{IDF_PATH}/tools/mocks/usb/usb_host_full_mock/usb/"    # Full USB Host stack mock (all the layers are mocked)
+
+     # The following line would be needed to include the freertos mock component if this test used mocked FreeRTOS. (missing Ringbuffer mock)
+     #"$ENV{IDF_PATH}/tools/mocks/freertos/"
     )
 
 add_definitions("-DCMOCK_MEM_DYNAMIC")

--- a/host/class/uac/usb_host_uac/host_test/README.md
+++ b/host/class/uac/usb_host_uac/host_test/README.md
@@ -24,7 +24,11 @@ The build produces an executable in the build folder.
 Just run:
 
 ```
-./build/host_test_usb_uac.elf
+idf.py monitor
 ```
 
-The test executable have some options provided by the test framework.
+or run the executable directly:
+
+```
+./build/host_test_usb_uac.elf
+```

--- a/host/class/uac/usb_host_uac/host_test/main/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/host_test/main/CMakeLists.txt
@@ -3,4 +3,6 @@ idf_component_register(SRC_DIRS .
                         INCLUDE_DIRS .
                         WHOLE_ARCHIVE)
 
-#target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain) # We don't mock FreeRTOS for this test
+# The following line would be needed to provide the 'main' function if this test used mocked FreeRTOS.
+# As this test uses the real FreeRTOS implementation, we don't need Catch2 to provide 'main'.
+#target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)

--- a/host/class/uvc/usb_host_uvc/host_test/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/host_test/CMakeLists.txt
@@ -4,7 +4,10 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)
 
 list(APPEND EXTRA_COMPONENT_DIRS
-     "$ENV{IDF_PATH}/tools/mocks/usb/"
+     "$ENV{IDF_PATH}/tools/mocks/usb/usb_host_full_mock/usb/"    # Full USB Host stack mock (all the layers are mocked)
+
+     # The following line would be needed to include the freertos mock component if this test used mocked FreeRTOS.
+     #"$ENV{IDF_PATH}/tools/mocks/freertos/"
     )
 add_definitions("-DCMOCK_MEM_DYNAMIC") # We need a lot of memory for our frame buffers
 project(host_test_usb_uvc)

--- a/host/class/uvc/usb_host_uvc/host_test/README.md
+++ b/host/class/uvc/usb_host_uvc/host_test/README.md
@@ -26,7 +26,11 @@ The build produces an executable in the build folder.
 Just run:
 
 ```
-./build/host_test_usb_uvc.elf
+idf.py monitor
 ```
 
-The test executable have some options provided by the test framework.
+or run the executable directly:
+
+```
+./build/host_test_usb_uvc.elf
+```

--- a/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
@@ -4,6 +4,6 @@ idf_component_register(SRC_DIRS . parsing streaming opening
                         PRIV_INCLUDE_DIRS "../../private_include"
                         WHOLE_ARCHIVE)
 
-# Currently 'main' for IDF_TARGET=linux is defined in freertos component.
-# Since we are using a freertos mock here, need to let Catch2 provide 'main'.
-# target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain) # We don't mock FreeRTOS for now
+# The following line would be needed to provide the 'main' function if this test used mocked FreeRTOS.
+# As this test uses the real FreeRTOS implementation, we don't need Catch2 to provide 'main'.
+# target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)


### PR DESCRIPTION
## Description

Updating path to USB Host CMock, as folder structure with USB mocks was updated.
Ready to merge, once the  is merged into esp-idf and master branches synced.

Changing USB Mock path from:
`"$ENV{IDF_PATH}/tools/mocks/usb/"`
to
`"$ENV{IDF_PATH}/tools/mocks/usb/usb_host_full_mock/usb/"`

## Related
 - preceding:  

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
