### PR TITLE
fix(tusb_msc): Check Wear leveling sector size during build

### DIFF
--- a/device/esp_tinyusb/tusb_msc_storage.c
+++ b/device/esp_tinyusb/tusb_msc_storage.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,11 @@
 #endif
 
 static const char *TAG = "tinyusb_msc_storage";
+
+// CONFIG_TINYUSB_MSC_BUFSIZE must be bigger, or equal to the CONFIG_WL_SECTOR_SIZE
+#if (CONFIG_TINYUSB_MSC_BUFSIZE < CONFIG_WL_SECTOR_SIZE)
+#error "CONFIG_TINYUSB_MSC_BUFSIZE must be at least at the size of CONFIG_WL_SECTOR_SIZE"
+#endif
 
 typedef struct {
     bool is_fat_mounted;


### PR DESCRIPTION
## Description

This MR adds a build time check for Wear leveling sector size. 

The WL sector size must be at least the size of the `CONFIG_TINYUSB_MSC_BUFSIZE`. otherwise the `msc_storage_write_sector()` function registered to `tud_msc_write10_cb()` callback would keep trying to write to the sector in an infinite loop, producing a following output:

```
E (25811) tinyusb_msc_storage: msc_storage_write_sector failed: 0x102
E (25821) tinyusb_msc_storage: Invalid Argument lba(0) offset(0) size(512) sector_size(4096)
```

### MSC Device example configuraiton

In the `tusb_msc` example, the wear leveling sector size is set in `sdkconfig.defatults` to 512 [`CONFIG_WL_SECTOR_SIZE_512=y`](https://github.com/espressif/esp-idf/blob/master/examples/peripherals/usb/device/tusb_msc/sdkconfig.defaults#L10).

But the description in the wear leveling [Kconifg](https://github.com/espressif/esp-idf/blob/master/components/wear_levelling/Kconfig#L11) suggests, that the sector size could be changed to `4096` for better efficiency.

The `CONFIG_TINYUSB_MSC_BUFSIZE` is set to [512](https://github.com/espressif/esp-usb/blob/master/device/esp_tinyusb/Kconfig#L175) by default in the `esp_tinyusb` for esp32s3 and esp32s2.

For esp32p4, the default `CONFIG_TINYUSB_MSC_BUFSIZE` is 8192, (we can consider increasing the WL sector size to 4096 for esp32p4 in the `tusb_msc` example's `sdkconfig.defaults`)

As the linked GH Issue shows, users try to change this config, which is causing errors.

## Related

- Closes [TinyUSB MSC FAT format fails, flooding log with errors](https://github.com/espressif/esp-idf/issues/14566)

## Testing

The error can be reproduced by running the `tusb_msc` example and chaining WL sector size on esp32s3(s2) from `512` to `4096`

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
