### PR TITLE
release(esp_tinyusb): v1.7.3

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.3
+
+- MSC: Improved transfer speed to SD cards and SPI flash
+
 ## 1.7.2
 
 - esp_tinyusb: Fixed crash on logging from ISR

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.7.2"
+version: "1.7.3"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '^5.0' # IDF 4.x contains TinyUSB as submodule; expecting breaking changes in IDF v6.0


### PR DESCRIPTION
# esp_tinyusb component, [release v1.7.3](https://components.espressif.com/components/espressif/esp_tinyusb/versions/1.7.3) 

## Changes
- MSC: Improved transfer speed to SD cards and SPI flash

## Related
- https://github.com/espressif/esp-usb/pull/131
- https://github.com/espressif/esp-usb/pull/157

