### PR TITLE
feat(tusb_msc): Add WL Sector runtime check during spiflash init

### DIFF
--- a/device/esp_tinyusb/include/tusb_msc_storage.h
+++ b/device/esp_tinyusb/include/tusb_msc_storage.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -83,6 +83,8 @@ typedef struct {
  * @return esp_err_t
  *       - ESP_OK, if success;
  *       - ESP_ERR_NO_MEM, if there was no memory to allocate storage components;
+ *       - ESP_ERR_NOT_SUPPORTED, if wear leveling sector size CONFIG_WL_SECTOR_SIZE is bigger than
+ *                                the tinyusb MSC buffer size CONFIG_TINYUSB_MSC_BUFSIZE
  */
 esp_err_t tinyusb_msc_storage_init_spiflash(const tinyusb_msc_spiflash_config_t *config);
 

--- a/device/esp_tinyusb/tusb_msc_storage.c
+++ b/device/esp_tinyusb/tusb_msc_storage.c
@@ -33,11 +33,6 @@ static const char *TAG = "tinyusb_msc_storage";
 #error "CONFIG_TINYUSB_MSC_BUFSIZE must be divisible by MSC_STORAGE_MEM_ALIGN. Adjust your configuration (MSC FIFO size) in menuconfig."
 #endif
 
-// CONFIG_TINYUSB_MSC_BUFSIZE must be bigger, or equal to the CONFIG_WL_SECTOR_SIZE
-#if (CONFIG_TINYUSB_MSC_BUFSIZE < CONFIG_WL_SECTOR_SIZE)
-#error "CONFIG_TINYUSB_MSC_BUFSIZE must be at least at the size of CONFIG_WL_SECTOR_SIZE"
-#endif
-
 /**
  * @brief Structure representing a single write buffer for MSC operations.
  */
@@ -432,6 +427,9 @@ uint32_t tinyusb_msc_storage_get_sector_size(void)
 esp_err_t tinyusb_msc_storage_init_spiflash(const tinyusb_msc_spiflash_config_t *config)
 {
     assert(!s_storage_handle);
+    ESP_RETURN_ON_FALSE(CONFIG_TINYUSB_MSC_BUFSIZE >= CONFIG_WL_SECTOR_SIZE,
+                        ESP_ERR_NOT_SUPPORTED, TAG,
+                        "CONFIG_TINYUSB_MSC_BUFSIZE (%d) must be at least the size of CONFIG_WL_SECTOR_SIZE (%d)", (int)(CONFIG_TINYUSB_MSC_BUFSIZE), (int)(CONFIG_WL_SECTOR_SIZE));
     s_storage_handle = (tinyusb_msc_storage_handle_s *)heap_caps_aligned_alloc(MSC_STORAGE_MEM_ALIGN, sizeof(tinyusb_msc_storage_handle_s), MALLOC_CAP_DMA);
     ESP_RETURN_ON_FALSE(s_storage_handle, ESP_ERR_NO_MEM, TAG, "Failed to allocate memory for storage handle");
     s_storage_handle->mount = &_mount_spiflash;


### PR DESCRIPTION
## Description

Add Wear leveling sector size runtime check.

As the wear leveling sector size is only relevant to spiflash storage type (not SDMMC storage), the WL Sector size is checked during the `tinyusb_msc_storage_init_spiflash()`.

The `CONFIG_WL_SECTOR_SIZE` (being 4096 by default, but set to 512 using `sdkconfig.defaults` in [tusb_msc example](https://github.com/espressif/esp-idf/blob/master/examples/peripherals/usb/device/tusb_msc/sdkconfig.defaults#L10)) must be lower or equal to the `CONFIG_TINYUSB_MSC_BUFSIZE`.

## Related

- Reverting #157 
- Closes #159 
- Closes [TinyUSB MSC FAT format fails, flooding log with errors](https://github.com/espressif/esp-idf/issues/14566)

## Testing

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
