### PR TITLE
fix(ci): Temporarily disable IDF Latest in CI

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build USB TestApps
     strategy:
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
@@ -46,7 +46,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4"]
         idf_target: ["esp32s2", "esp32p4"]
         runner_tag: ["usb_host", "usb_device"]
         exclude:


### PR DESCRIPTION
## Description
Temporarily disable IDF Latest, to unlock CI until IDF-12980 is merged

## Related
IDF-12980

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
