### PR TITLE
release(esp_tinyusb): v1.7.4

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.7.3
+## 1.7.4
+
+- MSC: WL Sector runtime check during spiflash init (fix for build time error check)
+
+## 1.7.3 [yanked]
 
 - MSC: Improved transfer speed to SD cards and SPI flash
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.7.3"
+version: "1.7.4"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '^5.0' # IDF 4.x contains TinyUSB as submodule; expecting breaking changes in IDF v6.0


### PR DESCRIPTION
# esp_tinyusb component, [release v1.7.4](https://components.espressif.com/components/espressif/esp_tinyusb/versions/1.7.4) 

## Changes
- MSC: WL Sector runtime check during spiflash init (fix for build time error check)

## Note
Previous [release v1.7.3](https://components.espressif.com/components/espressif/esp_tinyusb/versions/1.7.3)  was yanked due to an error in #157, which was also a part of the release. This release fixes the error.

## Related
- https://github.com/espressif/esp-usb/pull/161
