### PR TITLE
fix(cdc): fix GCC 15 warning -Woverloaded-virtual (IEC-292)

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_acm_host.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_acm_host.h
@@ -219,7 +219,7 @@ public:
         return err;
     }
 
-    virtual inline esp_err_t line_coding_get(cdc_acm_line_coding_t *line_coding) const
+    virtual inline esp_err_t line_coding_get(cdc_acm_line_coding_t *line_coding)
     {
         return cdc_acm_host_line_coding_get(this->cdc_hdl, line_coding);
     }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
GCC 15 generates a warning on `examples/peripherals/usb/host/cdc/cdc_acm_vcp` app:

```
In file included from /home/alex/git/esp-idf/examples/peripherals/usb/host/cdc/cdc_acm_vcp/managed_components/espressif__usb_host_cp210x_vcp/include/usb/vcp_cp210x.hpp:12,
                 from /home/alex/git/esp-idf/examples/peripherals/usb/host/cdc/cdc_acm_vcp/managed_components/espressif__usb_host_cp210x_vcp/usb_host_cp210x_vcp.cpp:7:
/home/alex/git/esp-idf/examples/peripherals/usb/host/cdc/cdc_acm_vcp/managed_components/espressif__usb_host_cdc_acm/include/usb/cdc_acm_host.h:222:30: error: 'virtual esp_err_t CdcAcmDevice::line_coding_get(cdc_acm_line_coding_t*) const' was hidden [-Werror=overloaded-virtual=]
  222 |     virtual inline esp_err_t line_coding_get(cdc_acm_line_coding_t *line_coding) const
      |                              ^~~~~~~~~~~~~~~
/home/alex/git/esp-idf/examples/peripherals/usb/host/cdc/cdc_acm_vcp/managed_components/espressif__usb_host_cp210x_vcp/include/usb/vcp_cp210x.hpp:73:15: note:   by 'esp_err_t esp_usb::CP210x::line_coding_get(cdc_acm_line_coding_t*)'
   73 |     esp_err_t line_coding_get(cdc_acm_line_coding_t *line_coding);
      |               ^~~~~~~~~~~~~~~
```

You may have a better solution by adding `const` to the overriding method. But it seems the solution should be more complex...

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
- Upgrade to GCC 15
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
