### PR TITLE
feat(esp_tinyusb): Add support for IDF 6

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.4~1
+
+- esp_tinyusb: Claim forward compatibility with IDF 6.0
+
 ## 1.7.4
 
 - MSC: WL Sector runtime check during spiflash init (fix for build time error check)
@@ -15,7 +19,7 @@
 
 - NCM: Changed default NTB config to decrease DRAM memory usage (fix for DRAM overflow on ESP32S2)
 
-## 1.7.0
+## 1.7.0 [yanked]
 
 - NCM: Added possibility to configure NCM Transfer Blocks (NTB) via menuconfig
 - esp_tinyusb: Added option to select TinyUSB peripheral on esp32p4 via menuconfig (USB_PHY_SUPPORTS_P4_OTG11 in esp-idf is required)

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,10 +1,10 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.7.4"
+version: "1.7.4~1"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
-  idf: '^5.0' # IDF 4.x contains TinyUSB as submodule; expecting breaking changes in IDF v6.0
+  idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
     version: '>=0.14.2'
     public: true


### PR DESCRIPTION
Adding support for IDF6 to esp_tinyusb to unblock its development.

There are no breaking changes planned at this time
