### PR TITLE
feat(fat_format): add fat file format on kconfig to change MKFS_PARM format options (IEC-294)

### DIFF
--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -187,27 +187,27 @@ menu "TinyUSB Stack"
                 MSC Mount Path of storage.
 
         menu "TinyUSB FAT Format Options"
-            choice TINY_USB_FAT_FORMAT_TYPE
+            choice TINYUSB_FAT_FORMAT_TYPE
                prompt "FatFS Format Type"
-                default TINY_USB_FAT_FORMAT_ANY
+                default TINYUSB_FAT_FORMAT_ANY
                 help
                     Select the FAT filesystem type used when formatting storage.
 
             config TINYUSB_FAT_FORMAT_ANY
                 bool "FM_ANY - Automatically select from FAT12/FAT16/FAT32"
 
-            config TINY_USB_FAT_FORMAT_FAT
+            config TINYUSB_FAT_FORMAT_FAT
                 bool "FM_FAT - Allow only FAT12/FAT16"
 
-            config TINY_USB_FAT_FORMAT_FAT32
+            config TINYUSB_FAT_FORMAT_FAT32
                 bool "FM_FAT32 - Force FAT32 only"
 
-            config TINY_USB_FAT_FORMAT_EXFAT
+            config TINYUSB_FAT_FORMAT_EXFAT
                 bool "FM_EXFAT - Force exFAT (requires exFAT enabled)"
 
             endchoice
 
-            config TINY_USB_FAT_FORMAT_SFD
+            config TINYUSB_FAT_FORMAT_SFD
                 bool "FM_SFD - Use SFD (no partition table)"
                 default n
                 help

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -193,7 +193,7 @@ menu "TinyUSB Stack"
                 help
                     Select the FAT filesystem type used when formatting storage.
 
-            config TINY_USB_FAT_FORMAT_ANY
+            config TINYUSB_FAT_FORMAT_ANY
                 bool "FM_ANY - Automatically select from FAT12/FAT16/FAT32"
 
             config TINY_USB_FAT_FORMAT_FAT

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -185,6 +185,36 @@ menu "TinyUSB Stack"
             default "/data"
             help
                 MSC Mount Path of storage.
+
+        menu "TinyUSB FAT Format Options"
+            choice TINY_USB_FAT_FORMAT_TYPE
+               prompt "FatFS Format Type"
+                default TINY_USB_FAT_FORMAT_ANY
+                help
+                    Select the FAT filesystem type used when formatting storage.
+
+            config TINY_USB_FAT_FORMAT_ANY
+                bool "FM_ANY - Automatically select from FAT12/FAT16/FAT32"
+
+            config TINY_USB_FAT_FORMAT_FAT
+                bool "FM_FAT - Allow only FAT12/FAT16"
+
+            config TINY_USB_FAT_FORMAT_FAT32
+                bool "FM_FAT32 - Force FAT32 only"
+
+            config TINY_USB_FAT_FORMAT_EXFAT
+                bool "FM_EXFAT - Force exFAT (requires exFAT enabled)"
+
+            endchoice
+
+            config TINY_USB_FAT_FORMAT_SFD
+                bool "FM_SFD - Use SFD (no partition table)"
+                default n
+                help
+                    Format as a Super Floppy Disk (no partition table).
+                    This is typical for USB flash drives and small volumes.
+            endmenu
+
     endmenu # "Massive Storage Class"
 
     menu "Communication Device Class (CDC)"

--- a/device/esp_tinyusb/tusb_msc_storage.c
+++ b/device/esp_tinyusb/tusb_msc_storage.c
@@ -255,16 +255,16 @@ static esp_err_t _mount(char *drv, FATFS *fs)
         ESP_LOGW(TAG, "formatting card, allocation unit size=%d", alloc_unit_size);
 
         BYTE format_flags;
-#if defined(CONFIG_TINY_USB_FAT_FORMAT_ANY)
+#if defined(CONFIG_TINYUSB_FAT_FORMAT_ANY)
         format_flags = FM_ANY;
 
-#elif defined(CONFIG_TINY_USB_FAT_FORMAT_FAT)
+#elif defined(CONFIG_TINYUSB_FAT_FORMAT_FAT)
         format_flags = FM_FAT;
 
-#elif defined(CONFIG_TINY_USB_FAT_FORMAT_FAT32)
+#elif defined(CONFIG_TINYUSB_FAT_FORMAT_FAT32)
         format_flags = FM_FAT32;
 
-#elif defined(CONFIG_TINY_USB_FAT_FORMAT_EXFAT)
+#elif defined(CONFIG_TINYUSB_FAT_FORMAT_EXFAT)
         format_flags = FM_EXFAT;
 #else
 
@@ -272,7 +272,7 @@ static esp_err_t _mount(char *drv, FATFS *fs)
 
 #endif
 
-#ifdef CONFIG_TINY_USB_FAT_FORMAT_SFD
+#ifdef CONFIG_TINYUSB_FAT_FORMAT_SFD
         format_flags |= FM_SFD;
 #endif
         const MKFS_PARM opt = {format_flags, 0, 0, 0, alloc_unit_size};

--- a/device/esp_tinyusb/tusb_msc_storage.c
+++ b/device/esp_tinyusb/tusb_msc_storage.c
@@ -253,7 +253,29 @@ static esp_err_t _mount(char *drv, FATFS *fs)
                                      CONFIG_WL_SECTOR_SIZE,
                                      4096);
         ESP_LOGW(TAG, "formatting card, allocation unit size=%d", alloc_unit_size);
-        const MKFS_PARM opt = {(BYTE)FM_FAT, 0, 0, 0, alloc_unit_size};
+
+        BYTE format_flags;
+#if defined(CONFIG_TINY_USB_FAT_FORMAT_ANY)
+        format_flags = FM_ANY;
+
+#elif defined(CONFIG_TINY_USB_FAT_FORMAT_FAT)
+        format_flags = FM_FAT;
+
+#elif defined(CONFIG_TINY_USB_FAT_FORMAT_FAT32)
+        format_flags = FM_FAT32;
+
+#elif defined(CONFIG_TINY_USB_FAT_FORMAT_EXFAT)
+        format_flags = FM_EXFAT;
+#else
+
+#error "No FAT format type selected"
+
+#endif
+
+#ifdef CONFIG_TINY_USB_FAT_FORMAT_SFD
+        format_flags |= FM_SFD;
+#endif
+        const MKFS_PARM opt = {format_flags, 0, 0, 0, alloc_unit_size};
         fresult = f_mkfs("", &opt, workbuf, workbuf_size); // Use default volume
         if (fresult != FR_OK) {
             ret = ESP_FAIL;


### PR DESCRIPTION
## Description

### Make `f_mkfs()` Format Type Configurable — Avoid Hardcoded `FM_FAT` to Support Larger Volumes Like SDMMC

As noted by @metainf in [issue #79](https://github.com/espressif/esp-usb/issues/79#issuecomment-2672324105), the current implementation of `f_mkfs()` uses a hardcoded value `FM_FAT` as the format type:  
https://github.com/espressif/esp-usb/blob/aef6153faad1cd957f789a702135155ce13aae30/device/esp_tinyusb/tusb_msc_storage.c#L228

### ❌ Problem

Hardcoding `FM_FAT` restricts formatting to FAT12/16, which fails on volumes that require FAT32 or higher, such as an 8GB SDMMC. According to the [Keil File System 6.6 documentation](https://www.keil.com/pack/doc/mw6/FileSystem/html/fat_fs.html), the maximum volume sizes are:

- **FAT12**: up to 256MB  
- **FAT16**: up to 4GB  
- **FAT32**: up to 2TB  

Attempting to format an 8GB SDMMC using `FM_FAT` causes an error because it's above the FAT16 limit.

### ✅ Proposal

Make the format type passed to `f_mkfs()` configurable through `menuconfig`. This will allow developers to explicitly select from `FM_FAT`, `FM_FAT32`, `FM_EXFAT`, or `FM_ANY`.

**Suggested changes:**

- Default to `FM_ANY` so that FatFS automatically selects the appropriate format based on volume size.
- Allow override via `Kconfig` to avoid unpredictable results during repeated format operations or with large volumes.
- Optionally add `FM_SFD` support through `CONFIG_TINY_USB_FAT_FORMAT_SFD` for super floppy disk formatting (no partition table).

This approach improves compatibility with a wider range of storage devices and aligns with official FatFS recommendations.

## Related

Fixes [#79](https://github.com/espressif/esp-usb/issues/79)

## Testing

- Verified formatting behavior on SDMMC with various storage capacities.
- Ensured correct format type is selected based on `menuconfig` option and volume size.
- Successfully formatted 8GB SD cards using `FM_FAT32`.

## Checklist

- [x] 🚨 This PR does not introduce breaking changes
- [x] All CI checks (GitHub Actions) pass
- [x] Documentation updated as necessary
- [x] Tests updated or added as needed
- [x] Code is well-commented in complex areas
- [x] Git history is clean — commits are squashed appropriately
