### PR TITLE
feature(tinyusb): Added device events callback

### DIFF
--- a/device/esp_tinyusb/include/tinyusb.h
+++ b/device/esp_tinyusb/include/tinyusb.h
@@ -100,6 +100,33 @@ typedef struct {
                                                        Can be NULL for Full-Speed only devices. */
 } tinyusb_desc_config_t;
 
+/**
+ * @brief TinyUSB event type
+ */
+typedef enum {
+    TINYUSB_EVENT_ATTACHED,             /*!< USB device attached to the Host */
+    TINYUSB_EVENT_DETACHED,             /*!< USB device detached from the Host */
+} tinyusb_event_id_t;
+
+/**
+ * @brief TinyUSB event structure
+ *
+ * This structure is used to pass the event information to the callback function.
+ */
+typedef struct {
+    tinyusb_event_id_t id;            /*!< Event ID */
+    union {
+        uint8_t rhport;               /*!< USB Peripheral hardware port number. Available when hardware has several available peripherals. */
+    };
+} tinyusb_event_t;
+
+/**
+ * @brief Callback used to indicate TinyUSB events
+ *
+ * @param event  Pointer to event data structure
+ * @param arg    Pointer to the argument passed to the callback
+ */
+typedef void (*tinyusb_event_cb_t)(tinyusb_event_t *event, void *arg);
 
 /**
  * @brief Configuration structure of the TinyUSB driver
@@ -109,6 +136,8 @@ typedef struct {
     tinyusb_phy_config_t phy;                   /*!< USB PHY configuration. */
     tinyusb_task_config_t task;                 /*!< USB Device Task configuration. */
     tinyusb_desc_config_t descriptor;           /*!< Pointer to a descriptor configuration. If set to NULL, the TinyUSB device will use a default descriptor configuration whose values are set in Kconfig */
+    tinyusb_event_cb_t event_cb;                /*!< Callback function that will be called when USB events occur. */
+    void *event_arg;                            /*!< Pointer to the argument passed to the callback */
 } tinyusb_config_t;
 
 /**

--- a/device/esp_tinyusb/include/tusb_msc_storage.h
+++ b/device/esp_tinyusb/include/tusb_msc_storage.h
@@ -125,6 +125,7 @@ esp_err_t tinyusb_msc_register_callback(tinyusb_msc_event_type_t event_type,
  */
 esp_err_t tinyusb_msc_unregister_callback(tinyusb_msc_event_type_t event_type);
 
+// TODO: check the description and update it after MSC storage refactoring
 /**
  * @brief Mount the storage partition locally on the firmware application.
  *
@@ -143,7 +144,8 @@ esp_err_t tinyusb_msc_unregister_callback(tinyusb_msc_event_type_t event_type);
  *       - ESP_ERR_NOT_FOUND if the maximum count of volumes is already mounted
  *       - ESP_ERR_NO_MEM if not enough memory or too many VFSes already registered;
  */
-esp_err_t tinyusb_msc_storage_mount(const char *base_path);
+// esp_err_t tinyusb_msc_storage_mount(const char *base_path);
+void tinyusb_msc_storage_to_app(void);
 
 /**
  * @brief Unmount the storage partition from the firmware application.
@@ -160,7 +162,8 @@ esp_err_t tinyusb_msc_storage_mount(const char *base_path);
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if FATFS is not registered in VFS
  */
-esp_err_t tinyusb_msc_storage_unmount(void);
+// esp_err_t tinyusb_msc_storage_unmount(void);
+void tinyusb_msc_storage_to_usb(void);
 
 /**
  * @brief Get number of sectors in storage media

--- a/device/esp_tinyusb/test_apps/runtime_config/main/device_handling.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/device_handling.c
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+//
+#include <stdio.h>
+#include <string.h>
+//
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+//
+#include "esp_system.h"
+#include "esp_log.h"
+#include "esp_err.h"
+//
+#include "unity.h"
+#include "tinyusb.h"
+
+static SemaphoreHandle_t wait_mount = NULL;
+
+#define TUSB_DEVICE_DELAY_MS        1000
+
+void test_device_setup(void)
+{
+    wait_mount = xSemaphoreCreateBinary();
+    TEST_ASSERT_NOT_NULL(wait_mount);
+}
+
+void test_device_release(void)
+{
+    TEST_ASSERT_NOT_NULL(wait_mount);
+    vSemaphoreDelete(wait_mount);
+}
+
+void test_device_wait(void)
+{
+    // Wait for tud_mount_cb() to be called
+    TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(wait_mount, pdMS_TO_TICKS(TUSB_DEVICE_DELAY_MS)), "No tusb_mount_cb() in time");
+    // Delay to allow finish the enumeration
+    // Disable this delay could lead to potential race conditions when the tud_task() is pinned to another CPU
+    vTaskDelay(pdMS_TO_TICKS(250));
+}
+
+void test_device_event_handler(tinyusb_event_t *event, void *arg)
+{
+    switch (event->id) {
+    case TINYUSB_EVENT_ATTACHED:
+        xSemaphoreGive(wait_mount);
+        break;
+    case TINYUSB_EVENT_DETACHED:
+        break;
+    default:
+        break;
+    }
+}
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/runtime_config/main/device_handling.h
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/device_handling.h
@@ -3,6 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#pragma once
+
+#include "tinyusb.h"
 
 /**
  * @brief Test device setup
@@ -20,3 +23,12 @@ void test_device_release(void);
  * Waits the tusb_mount_cb() which indicates the device connected to the Host and enumerated.
  */
 void test_device_wait(void);
+
+/**
+ * @brief TinyUSB callback for device mount.
+ *
+ * @note
+ * For Linux-based Hosts: Reflects the SetConfiguration() request from the Host Driver.
+ * For Win-based Hosts: SetConfiguration() request is present only with available Class in device descriptor.
+ */
+void test_device_event_handler(tinyusb_event_t *event, void *arg);

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_app_main.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_app_main.c
@@ -11,7 +11,7 @@
 #include "freertos/task.h"
 #include "unity_test_runner.h"
 #include "unity_test_utils_memory.h"
-#include "test_device.h"
+#include "device_handling.h"
 
 /* setUp runs before every test */
 void setUp(void)

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_config.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_config.c
@@ -12,6 +12,40 @@
 #include "tinyusb.h"
 #include "tinyusb_default_configs.h"
 
+
+// Enable to verify static assert during the build
+#define RUNTIME_CONFIG_CHECK_STATIC_ASSERTS         0
+
+/**
+ * @brief TinyUSB Task specific testcase
+ *
+ * Scenario: Verifies the default macros arguments
+ * Awaiting:
+ * - Default macros should configure to NULL when no arguments are provided
+ * - Default macros should configure to the provided arguments when one or two arguments are provided
+ */
+TEST_CASE("Config: Default macros arguments", "[runtime_config][default]")
+{
+    void *dummy_event_hdl = (void *) 0xDEADBEEF;
+    void *dummy_event_arg = (void *) 0xBEEFDEAD;
+
+    const tinyusb_config_t tusb_cfg_arg0 = TINYUSB_DEFAULT_CONFIG();
+    const tinyusb_config_t tusb_cfg_arg1 = TINYUSB_DEFAULT_CONFIG(dummy_event_hdl);
+    const tinyusb_config_t tusb_cfg_arg2 = TINYUSB_DEFAULT_CONFIG(dummy_event_hdl, dummy_event_arg);
+#if (RUNTIME_CONFIG_CHECK_STATIC_ASSERTS)
+    const tinyusb_config_t tusb_cfg_arg3 = TINYUSB_DEFAULT_CONFIG(dummy_event_hdl, dummy_event_arg, NULL);
+#endif // RUNTIME_CONFIG_CHECK_STATIC_ASSERTS
+
+    TEST_ASSERT_EQUAL_MESSAGE(NULL, tusb_cfg_arg0.event_cb, "Event callback should be NULL when no arguments provided");
+    TEST_ASSERT_EQUAL_MESSAGE(NULL, tusb_cfg_arg0.event_arg, "Event argument should be NULL when no arguments provided");
+
+    TEST_ASSERT_EQUAL_MESSAGE(dummy_event_hdl, tusb_cfg_arg1.event_cb, "Event callback was not set correctly");
+    TEST_ASSERT_EQUAL_MESSAGE(NULL, tusb_cfg_arg1.event_arg, "Event argument should be NULL when one argument is provided");
+
+    TEST_ASSERT_EQUAL_MESSAGE(dummy_event_hdl, tusb_cfg_arg2.event_cb, "Event callback was not set correctly");
+    TEST_ASSERT_EQUAL_MESSAGE(dummy_event_arg, tusb_cfg_arg2.event_arg, "Event argument was not set correctly");
+}
+
 #if (SOC_USB_OTG_PERIPH_NUM == 1)
 /**
  * @brief TinyUSB Task specific testcase
@@ -45,7 +79,7 @@ TEST_CASE("Config: Full-speed default (Full-speed)", "[runtime_config][full_spee
  */
 TEST_CASE("Config: Full-speed (High-speed)", "[runtime_config][full_speed]")
 {
-    const tinyusb_config_t tusb_cfg = TINYUSB_CONFIG_FULL_SPEED();
+    const tinyusb_config_t tusb_cfg = TINYUSB_CONFIG_FULL_SPEED(NULL, NULL);
 
     TEST_ASSERT_EQUAL_MESSAGE(TINYUSB_PORT_FULL_SPEED_0, tusb_cfg.port, "Wrong default port number");
     TEST_ASSERT_EQUAL_MESSAGE(false, tusb_cfg.phy.skip_setup, "Wrong default skip_setup value");

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_multitask_access.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_multitask_access.c
@@ -23,9 +23,9 @@
 #include "unity.h"
 #include "tinyusb.h"
 #include "tinyusb_default_configs.h"
-#include "test_device.h"
 #include "test_task.h"
 #include "sdkconfig.h"
+#include "device_handling.h"
 
 #define MULTIPLE_THREADS_TASKS_NUM 5
 
@@ -36,7 +36,7 @@ static void test_task_install(void *arg)
     TaskHandle_t parent_task_handle = (TaskHandle_t)arg;
 
     // Install TinyUSB driver
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG();
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
     tusb_cfg.phy.skip_setup = true; // Skip phy setup to allow multiple tasks to install the driver
 
     if (tinyusb_driver_install(&tusb_cfg) == ESP_OK) {

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_periph.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_periph.c
@@ -22,9 +22,9 @@
 #include "unity.h"
 #include "tinyusb.h"
 #include "tinyusb_default_configs.h"
-#include "test_device.h"
 #include "test_task.h"
 #include "sdkconfig.h"
+#include "device_handling.h"
 
 /**
  * @brief TinyUSB Task specific testcase
@@ -35,7 +35,7 @@
 TEST_CASE("Periph: Full-speed", "[periph][full_speed]")
 {
     // TinyUSB driver default configuration
-    const tinyusb_config_t tusb_cfg = TINYUSB_CONFIG_FULL_SPEED();
+    const tinyusb_config_t tusb_cfg = TINYUSB_CONFIG_FULL_SPEED(test_device_event_handler, NULL);
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
     test_device_wait();
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
@@ -51,7 +51,7 @@ TEST_CASE("Periph: Full-speed", "[periph][full_speed]")
 TEST_CASE("Periph: High-speed", "[periph][high_speed]")
 {
     // TinyUSB driver default configuration
-    const tinyusb_config_t tusb_cfg = TINYUSB_CONFIG_HIGH_SPEED();
+    const tinyusb_config_t tusb_cfg = TINYUSB_CONFIG_HIGH_SPEED(test_device_event_handler, NULL);
     // Install TinyUSB driver
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
     test_device_wait();

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_task.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_task.c
@@ -22,9 +22,9 @@
 #include "unity.h"
 #include "tinyusb.h"
 #include "tinyusb_default_configs.h"
-#include "test_device.h"
 #include "test_task.h"
 #include "sdkconfig.h"
+#include "device_handling.h"
 
 // ============================= Tests =========================================
 
@@ -58,7 +58,7 @@ TEST_CASE("Task: Invalid params", "[runtime_config][default]")
 TEST_CASE("Task: Default configuration", "[task][default]")
 {
     // TinyUSB driver default configuration
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG();
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
     // Install TinyUSB driver
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
     test_device_wait();
@@ -74,7 +74,7 @@ TEST_CASE("Task: Default configuration", "[task][default]")
 TEST_CASE("Task: Default configuration, pin to CPU0", "[task][default]")
 {
     // TinyUSB driver default configuration
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG();
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
     tusb_cfg.task.xCoreID = 0;
     // Install TinyUSB driver
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
@@ -92,7 +92,7 @@ TEST_CASE("Task: Default configuration, pin to CPU0", "[task][default]")
 TEST_CASE("Task: Default configuration, pin to CPU1", "[task][default]")
 {
     // TinyUSB driver default configuration
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG();
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
     tusb_cfg.task.xCoreID = 1;
     // Install TinyUSB driver
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_task.h
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_task.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#pragma once
 
 #include "sdkconfig.h"
 

--- a/device/esp_tinyusb/test_apps/teardown_device/main/test_teardown.c
+++ b/device/esp_tinyusb/test_apps/teardown_device/main/test_teardown.c
@@ -71,10 +71,22 @@ static const tusb_desc_device_qualifier_t device_qualifier = {
 };
 #endif // TUD_OPT_HIGH_SPEED
 
-// Invoked when device is mounted
-void tud_mount_cb(void)
+/**
+ * @brief TinyUSB callback for device event
+ *
+ * @note
+ * For Linux-based Hosts: Reflects the SetConfiguration() request from the Host Driver.
+ * For Win-based Hosts: SetConfiguration() request is present only with available Class in device descriptor.
+ */
+void test_teardown_event_handler(tinyusb_event_t *event, void *arg)
 {
-    xSemaphoreGive(wait_mount);
+    switch (event->id) {
+    case TINYUSB_EVENT_ATTACHED:
+        xSemaphoreGive(wait_mount);
+        break;
+    default:
+        break;
+    }
 }
 
 /**
@@ -97,7 +109,7 @@ TEST_CASE("tinyusb_teardown", "[esp_tinyusb][teardown]")
     TEST_ASSERT_NOT_EQUAL(NULL, wait_mount);
 
     // TinyUSB driver configuration
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG();
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_teardown_event_handler);
     tusb_cfg.descriptor.device = &test_device_descriptor;
     tusb_cfg.descriptor.full_speed_config = test_configuration_descriptor;
 #if (TUD_OPT_HIGH_SPEED)

--- a/device/esp_tinyusb/tinyusb.c
+++ b/device/esp_tinyusb/tinyusb.c
@@ -13,16 +13,84 @@
 #include "tinyusb_task.h"
 #include "tusb.h"
 
+#if (CONFIG_TINYUSB_MSC_ENABLED)
+#include "tusb_msc_storage.h"
+#endif // CONFIG_TINYUSB_MSC_ENABLED
+
 const static char *TAG = "TinyUSB";
 
-// Tinyusb supports only one instance of the driver per peripheral
-// Otherwise, the next parameters could be stored in the context
-static usb_phy_handle_t s_phy_hdl;
+/**
+ * @brief TinyUSB context
+ */
+typedef struct {
+    tinyusb_port_t port;                      /*!< USB Peripheral hardware port number. Available when hardware has several available peripherals. */
+    usb_phy_handle_t phy_hdl;                 /*!< USB PHY handle */
+    tinyusb_event_cb_t event_cb;              /*!< Callback function that will be called when USB events occur. */
+    void *event_arg;                          /*!< Pointer to the argument passed to the callback */
+} tinyusb_ctx_t;
+
+static tinyusb_ctx_t s_ctx; // TinyUSB context
 
 // For the tinyusb component without tusb_teardown() implementation
 #ifndef tusb_teardown
 #   define tusb_teardown()   (true)
 #endif // tusb_teardown
+
+// ==================================================================================
+// ============================= TinyUSB Callbacks ==================================
+// ==================================================================================
+
+/**
+ * @brief Callback function invoked when device is mounted (configured)
+ *
+ * This function is called by TinyUSB stack when:
+ *
+ * - SetConfiguration(n) is called by the host, where n is the configuration number and not zero.
+ *
+ * @note
+ * For Win-based Hosts: SetConfiguration(n) request is present only with available Class in Device Descriptor.
+ */
+void tud_mount_cb(void)
+{
+#if (CONFIG_TINYUSB_MSC_ENABLED)
+    tinyusb_msc_storage_to_usb();
+#endif // CONFIG_TINYUSB_MSC_ENABLED
+    tinyusb_event_t event = {
+        .id = TINYUSB_EVENT_ATTACHED,
+        .rhport = s_ctx.port,
+    };
+
+    if (s_ctx.event_cb) {
+        s_ctx.event_cb(&event, s_ctx.event_arg);
+    }
+}
+
+/**
+ * @brief Callback function invoked when device is unmounted
+ *
+ * This function is called by TinyUSB stack when:
+ *
+ * - SetConfiguration(0) is called by the host.
+ * - Device is disconnected (DCD_EVENT_UNPLUGGED) from the host.
+ */
+void tud_umount_cb(void)
+{
+#if (CONFIG_TINYUSB_MSC_ENABLED)
+    tinyusb_msc_storage_to_app();
+#endif // CONFIG_TINYUSB_MSC_ENABLED
+    tinyusb_event_t event = {
+        .id = TINYUSB_EVENT_DETACHED,
+        .rhport = s_ctx.port,
+    };
+
+    if (s_ctx.event_cb) {
+        s_ctx.event_cb(&event, s_ctx.event_arg);
+    }
+}
+
+// ==================================================================================
+// ============================= ESP TinyUSB Driver =================================
+// ==================================================================================
 
 /**
  * @brief Check the TinyUSB configuration
@@ -72,7 +140,12 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     }
     // Init TinyUSB stack in task
     ESP_GOTO_ON_ERROR(tinyusb_task_start(config->port, &config->task, &config->descriptor), del_phy, TAG, "Init TinyUSB task failed");
-    s_phy_hdl = phy_hdl; // Save the PHY handle for uninstallation
+
+    s_ctx.port = config->port;              // Save the port number
+    s_ctx.phy_hdl = phy_hdl;                // Save the PHY handle for uninstallation
+    s_ctx.event_cb = config->event_cb;      // Save the event callback
+    s_ctx.event_arg = config->event_arg;    // Save the event callback argument
+
     ESP_LOGI(TAG, "TinyUSB Driver installed on port %d", config->port);
     return ESP_OK;
 
@@ -86,9 +159,9 @@ del_phy:
 esp_err_t tinyusb_driver_uninstall(void)
 {
     ESP_RETURN_ON_ERROR(tinyusb_task_stop(), TAG, "Deinit TinyUSB task failed");
-    if (s_phy_hdl) {
-        ESP_RETURN_ON_ERROR(usb_del_phy(s_phy_hdl), TAG, "Unable to delete PHY");
-        s_phy_hdl = NULL;
+    if (s_ctx.phy_hdl) {
+        ESP_RETURN_ON_ERROR(usb_del_phy(s_ctx.phy_hdl), TAG, "Unable to delete PHY");
+        s_ctx.phy_hdl = NULL;
     }
     return ESP_OK;
 }

--- a/device/esp_tinyusb/tusb_msc_storage.c
+++ b/device/esp_tinyusb/tusb_msc_storage.c
@@ -322,7 +322,7 @@ static void _write_func(void *param)
     }
 }
 
-esp_err_t tinyusb_msc_storage_mount(const char *base_path)
+static esp_err_t tinyusb_msc_storage_mount(const char *base_path)
 {
     esp_err_t ret = ESP_OK;
     assert(s_storage_handle);
@@ -391,7 +391,7 @@ fail:
     return ret;
 }
 
-esp_err_t tinyusb_msc_storage_unmount(void)
+static esp_err_t tinyusb_msc_storage_unmount(void)
 {
     if (!s_storage_handle) {
         return ESP_FAIL;
@@ -715,16 +715,14 @@ int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void *buffer, u
     return ret;
 }
 
-// Invoked when device is unmounted
-void tud_umount_cb(void)
+void tinyusb_msc_storage_to_app(void)
 {
     if (tinyusb_msc_storage_mount(s_storage_handle->base_path) != ESP_OK) {
         ESP_LOGW(TAG, "tud_umount_cb() mount Fails");
     }
 }
 
-// Invoked when device is mounted (configured)
-void tud_mount_cb(void)
+void tinyusb_msc_storage_to_usb(void)
 {
     tinyusb_msc_storage_unmount();
 }


### PR DESCRIPTION
## Description

User could specify the specific callback, that will be called with specific event:
- `TINYUSB_EVENT_ATTACHED`: Host enumerates the device and fulfill SetConfiguration() request on a device. 
- `TINYUSB_EVENT_DETACHED`: Device detaches from the Host. 

In the future, events list could be extended to: `SUSPEND`, `RESUME`, `SOF` etc.

## Related
- Prerequisites for https://github.com/espressif/esp-usb/pull/178
- https://github.com/espressif/esp-usb/pull/122

## Testing

Testing is possible with the same tests.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
