### PR TITLE
UVC updates for esp_video

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- Added `uvc_host_stream_format_get()` function that returns current stream's format
+
 ## 2.2.0
 
 - Added `uvc_host_stream_format_select()` function that allows change of format of an opened stream

--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `uvc_host_stream_format_get()` function that returns current stream's format
 - Added `uvc_host_buf_info_get()` function for esp_video binding
+- Added option to request default FPS by setting FPS = 0
 
 ## 2.2.0
 

--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `uvc_host_stream_format_get()` function that returns current stream's format
 - Added `uvc_host_buf_info_get()` function for esp_video binding
 - Added option to request default FPS by setting FPS = 0
+- Fixed UVC driver re-installation
 
 ## 2.2.0
 

--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Added `uvc_host_stream_format_get()` function that returns current stream's format
+- Added `uvc_host_buf_info_get()` function for esp_video binding
 
 ## 2.2.0
 

--- a/host/class/uvc/usb_host_uvc/host_test/main/opening/test_opening.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/opening/test_opening.cpp
@@ -67,6 +67,13 @@ SCENARIO("UVC driver install/uninstall")
         }
 
         REQUIRE(ESP_OK == test_uvc_host_uninstall());
+
+        AND_WHEN("UVC driver is installed again") {
+            THEN("Installation succeeds") {
+                REQUIRE(ESP_OK == test_uvc_host_install(&uvc_driver_config));
+                REQUIRE(ESP_OK == test_uvc_host_uninstall());
+            }
+        }
     }
 }
 

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_anker_powerconf_c200.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_anker_powerconf_c200.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,6 +26,7 @@ SCENARIO("Camera descriptor parsing: Anker Powerconf C200", "[anker][powerconf][
             {640, 480, 30, UVC_VS_FORMAT_MJPEG},
             {640, 360, 30, UVC_VS_FORMAT_MJPEG},
             {320, 240, 30, UVC_VS_FORMAT_MJPEG},
+            {320, 240, 0, UVC_VS_FORMAT_MJPEG},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -40,6 +41,7 @@ SCENARIO("Camera descriptor parsing: Anker Powerconf C200", "[anker][powerconf][
             {640, 480, 30, UVC_VS_FORMAT_YUY2},
             {640, 360, 30, UVC_VS_FORMAT_YUY2},
             {320, 240, 30, UVC_VS_FORMAT_YUY2},
+            {320, 240, 0, UVC_VS_FORMAT_YUY2},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -57,6 +59,7 @@ SCENARIO("Camera descriptor parsing: Anker Powerconf C200", "[anker][powerconf][
             {640, 480, 30,   UVC_VS_FORMAT_H264},
             {640, 360, 30,   UVC_VS_FORMAT_H264},
             {320, 240, 30,   UVC_VS_FORMAT_H264},
+            {320, 240, 0,   UVC_VS_FORMAT_H264},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -64,6 +67,10 @@ SCENARIO("Camera descriptor parsing: Anker Powerconf C200", "[anker][powerconf][
                 REQUIRE_FORMAT_SUPPORTED(cfg, this_format, 1);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("Anker Powerconf C200 Unsupported") {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_canyon_cne_cwc2.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_canyon_cne_cwc2.cpp
@@ -29,12 +29,15 @@ SCENARIO("Camera descriptor parsing: Canyon CNE CWC2", "[canyon][cne_cwc2]")
             {1280, 720, 15, UVC_VS_FORMAT_MJPEG},
             {1280, 720, 10, UVC_VS_FORMAT_MJPEG},
             {1280, 720, 5, UVC_VS_FORMAT_MJPEG},
+            {1280, 720, 0, UVC_VS_FORMAT_MJPEG},
             {1280, 960, 15, UVC_VS_FORMAT_MJPEG},
             {1280, 960, 10, UVC_VS_FORMAT_MJPEG},
             {1280, 960, 5, UVC_VS_FORMAT_MJPEG},
+            {1280, 960, 0, UVC_VS_FORMAT_MJPEG},
             {1600, 1200, 15, UVC_VS_FORMAT_MJPEG},
             {1600, 1200, 10, UVC_VS_FORMAT_MJPEG},
             {1600, 1200, 5, UVC_VS_FORMAT_MJPEG},
+            {1600, 1200, 0, UVC_VS_FORMAT_MJPEG},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -54,9 +57,12 @@ SCENARIO("Camera descriptor parsing: Canyon CNE CWC2", "[canyon][cne_cwc2]")
             FORMAT_UNCOMPRESSED_20_5(800, 600),
             {1280, 720, 10, UVC_VS_FORMAT_YUY2},
             {1280, 720, 5, UVC_VS_FORMAT_YUY2},
+            {1280, 720, 0, UVC_VS_FORMAT_YUY2},
             {1280, 960, 9, UVC_VS_FORMAT_YUY2},
             {1280, 960, 5, UVC_VS_FORMAT_YUY2},
+            {1280, 960, 0, UVC_VS_FORMAT_YUY2},
             {1600, 1200, 5, UVC_VS_FORMAT_YUY2},
+            {1600, 1200, 0, UVC_VS_FORMAT_YUY2},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -64,6 +70,10 @@ SCENARIO("Camera descriptor parsing: Canyon CNE CWC2", "[canyon][cne_cwc2]")
                 REQUIRE_FORMAT_SUPPORTED(cfg, this_format, 1);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("Canyon CNE CWC2 Unsupported") {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_customer.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_customer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,12 +22,16 @@ SCENARIO("Camera descriptor parsing: Customer", "[customer][single]")
         uvc_host_stream_format_t formats[] = {
             {1280, 720, 15, UVC_VS_FORMAT_MJPEG},
             {1280, 720, 10, UVC_VS_FORMAT_MJPEG},
+            {1280, 720, 0, UVC_VS_FORMAT_MJPEG},
             {800, 480, 20, UVC_VS_FORMAT_MJPEG},
             {800, 480, 15, UVC_VS_FORMAT_MJPEG},
+            {800, 480, 0, UVC_VS_FORMAT_MJPEG},
             {640, 480, 25, UVC_VS_FORMAT_MJPEG},
             {640, 480, 15, UVC_VS_FORMAT_MJPEG},
+            {640, 480, 0, UVC_VS_FORMAT_MJPEG},
             {480, 320, 25, UVC_VS_FORMAT_MJPEG},
             {480, 320, 15, UVC_VS_FORMAT_MJPEG},
+            {480, 320, 0, UVC_VS_FORMAT_MJPEG},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -35,6 +39,10 @@ SCENARIO("Camera descriptor parsing: Customer", "[customer][single]")
                 REQUIRE_FORMAT_SUPPORTED(cfg, this_format, 1);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("Customer Unsupported") {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_customer_dual.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_customer_dual.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,6 +24,7 @@ SCENARIO("Camera descriptor parsing: Customer dual", "[customer][dual]")
             {720, 1280, 15, UVC_VS_FORMAT_MJPEG},
             {720, 1280, 10, UVC_VS_FORMAT_MJPEG},
             {720, 1280, 5, UVC_VS_FORMAT_MJPEG},
+            {720, 1280, 0, UVC_VS_FORMAT_MJPEG},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -70,6 +71,10 @@ SCENARIO("Camera descriptor parsing: Customer dual", "[customer][dual]")
                 REQUIRE(frame_desc != nullptr);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("Customer dual Unsupported") {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_elp_h264.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_elp_h264.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -40,6 +40,7 @@ SCENARIO("Camera descriptor parsing: ELP h264", "[elp][h264]")
         uvc_host_stream_format_t formats[] = {
             FORMAT_UNCOMPRESSED_30_25_15(640, 480),
             {800, 600, 15, UVC_VS_FORMAT_YUY2},
+            {800, 600, 0, UVC_VS_FORMAT_YUY2},
             FORMAT_UNCOMPRESSED_30_25_15(640, 360),
             FORMAT_UNCOMPRESSED_30_25_15(352, 288),
             FORMAT_UNCOMPRESSED_30_25_15(320, 240),
@@ -68,6 +69,10 @@ SCENARIO("Camera descriptor parsing: ELP h264", "[elp][h264]")
                 REQUIRE_FORMAT_SUPPORTED(cfg, this_format, 2);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("ELP h264 Unsupported") {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_elp_h265.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_elp_h265.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -79,17 +79,25 @@ SCENARIO("Camera descriptor parsing: ELP h265", "[elp][h265]")
         uvc_host_stream_format_t formats[] = {
             FORMAT_UNCOMPRESSED_30_20_15(640, 360),
             FORMAT_UNCOMPRESSED_30_20_15(640, 480),
+
             {960, 540, 15, UVC_VS_FORMAT_YUY2},
             {960, 540, 10, UVC_VS_FORMAT_YUY2},
             {960, 540, 5, UVC_VS_FORMAT_YUY2},
+            {960, 540, 0, UVC_VS_FORMAT_YUY2},
+
             {1024, 576, 15, UVC_VS_FORMAT_YUY2},
             {1024, 576, 10, UVC_VS_FORMAT_YUY2},
             {1024, 576, 5, UVC_VS_FORMAT_YUY2},
+            {1024, 576, 0, UVC_VS_FORMAT_YUY2},
+
             {1280, 720, 10, UVC_VS_FORMAT_YUY2},
             {1280, 720, 5, UVC_VS_FORMAT_YUY2},
             {1280, 720, 2, UVC_VS_FORMAT_YUY2},
+            {1280, 720, 0, UVC_VS_FORMAT_YUY2},
+
             {1920, 1080, 5, UVC_VS_FORMAT_YUY2},
             {1920, 1080, 2, UVC_VS_FORMAT_YUY2},
+            {1920, 1080, 0, UVC_VS_FORMAT_YUY2},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -99,11 +107,14 @@ SCENARIO("Camera descriptor parsing: ELP h265", "[elp][h265]")
         }
     }
 
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
+    }
+
     GIVEN("ELP h265 Unsupported") {
         uvc_host_stream_format_t formats[] = {
             {640, 480, 28, UVC_VS_FORMAT_MJPEG}, // Invalid FPS
             {645, 480, 25, UVC_VS_FORMAT_MJPEG}, // Invalid definition
-            {640, 480, 20, UVC_VS_FORMAT_UNDEFINED},  // Invalid format
         };
 
         for (uvc_host_stream_format_t this_format : formats) {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_helpers.hpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_helpers.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 /**
- * @brief Define MJPEG formats with FPS 30-5
+ * @brief Define MJPEG formats with FPS 30-5 and 0 (default)
  */
 #define FORMAT_MJPEG_30_5(x, y)      \
     {x, y, 30, UVC_VS_FORMAT_MJPEG}, \
@@ -19,7 +19,7 @@
     {x, y, 0, UVC_VS_FORMAT_MJPEG}
 
 /**
- * @brief Define MJPEG formats with FPS 30-15
+ * @brief Define MJPEG formats with FPS 30-15 and 0 (default)
  */
 #define FORMAT_MJPEG_30_25_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_MJPEG}, \
@@ -28,7 +28,7 @@
     {x, y, 0, UVC_VS_FORMAT_MJPEG}
 
 /**
- * @brief Define MJPEG formats with FPS 30-15
+ * @brief Define MJPEG formats with FPS 30-15 and 0 (default)
  */
 #define FORMAT_MJPEG_30_20_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_MJPEG}, \
@@ -37,7 +37,7 @@
     {x, y, 0, UVC_VS_FORMAT_MJPEG}
 
 /**
- * @brief Define YUY2 formats with FPS 30-5
+ * @brief Define YUY2 formats with FPS 30-5 and 0 (default)
  */
 #define FORMAT_UNCOMPRESSED_30_5(x, y) \
     {x, y, 30, UVC_VS_FORMAT_YUY2},    \
@@ -49,7 +49,7 @@
     {x, y, 0, UVC_VS_FORMAT_YUY2}
 
 /**
- * @brief Define YUY2 formats with FPS 30-15
+ * @brief Define YUY2 formats with FPS 30-15 and 0 (default)
  */
 #define FORMAT_UNCOMPRESSED_30_25_15(x, y) \
     {x, y, 30, UVC_VS_FORMAT_YUY2},        \
@@ -58,7 +58,7 @@
     {x, y, 0, UVC_VS_FORMAT_YUY2}
 
 /**
- * @brief Define YUY2 formats with FPS 30-15
+ * @brief Define YUY2 formats with FPS 30-15 and 0 (default)
  */
 #define FORMAT_UNCOMPRESSED_30_20_15(x, y) \
     {x, y, 30, UVC_VS_FORMAT_YUY2},        \
@@ -67,7 +67,7 @@
     {x, y, 0, UVC_VS_FORMAT_YUY2}
 
 /**
- * @brief Define YUY2 formats with FPS 20-5
+ * @brief Define YUY2 formats with FPS 20-5 and 0 (default)
  */
 #define FORMAT_UNCOMPRESSED_20_5(x, y) \
     {x, y, 20, UVC_VS_FORMAT_YUY2},    \
@@ -77,7 +77,7 @@
     {x, y, 0, UVC_VS_FORMAT_YUY2}
 
 /**
- * @brief Define h264 formats with FPS 30-15
+ * @brief Define h264 formats with FPS 30-15 and 0 (default)
  */
 #define FORMAT_H264_30_25_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_H264}, \
@@ -86,7 +86,7 @@
     {x, y, 0, UVC_VS_FORMAT_H264}
 
 /**
- * @brief Define h264 formats with FPS 30-15
+ * @brief Define h264 formats with FPS 30-15 and 0 (default)
  */
 #define FORMAT_H264_30_20_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_H264}, \
@@ -95,7 +95,7 @@
     {x, y, 0, UVC_VS_FORMAT_H264}
 
 /**
- * @brief Define h265 formats with FPS 30-15
+ * @brief Define h265 formats with FPS 30-15 and 0 (default)
  */
 #define FORMAT_H265_30_20_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_H265}, \

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_helpers.hpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,7 +15,8 @@
     {x, y, 20, UVC_VS_FORMAT_MJPEG}, \
     {x, y, 15, UVC_VS_FORMAT_MJPEG}, \
     {x, y, 10, UVC_VS_FORMAT_MJPEG}, \
-    {x, y, 5, UVC_VS_FORMAT_MJPEG}
+    {x, y, 5, UVC_VS_FORMAT_MJPEG},  \
+    {x, y, 0, UVC_VS_FORMAT_MJPEG}
 
 /**
  * @brief Define MJPEG formats with FPS 30-15
@@ -23,7 +24,8 @@
 #define FORMAT_MJPEG_30_25_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_MJPEG}, \
     {x, y, 25, UVC_VS_FORMAT_MJPEG}, \
-    {x, y, 15, UVC_VS_FORMAT_MJPEG}
+    {x, y, 15, UVC_VS_FORMAT_MJPEG}, \
+    {x, y, 0, UVC_VS_FORMAT_MJPEG}
 
 /**
  * @brief Define MJPEG formats with FPS 30-15
@@ -31,7 +33,8 @@
 #define FORMAT_MJPEG_30_20_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_MJPEG}, \
     {x, y, 20, UVC_VS_FORMAT_MJPEG}, \
-    {x, y, 15, UVC_VS_FORMAT_MJPEG}
+    {x, y, 15, UVC_VS_FORMAT_MJPEG}, \
+    {x, y, 0, UVC_VS_FORMAT_MJPEG}
 
 /**
  * @brief Define YUY2 formats with FPS 30-5
@@ -42,7 +45,8 @@
     {x, y, 20, UVC_VS_FORMAT_YUY2},    \
     {x, y, 15, UVC_VS_FORMAT_YUY2},    \
     {x, y, 10, UVC_VS_FORMAT_YUY2},    \
-    {x, y, 5, UVC_VS_FORMAT_YUY2}
+    {x, y, 5, UVC_VS_FORMAT_YUY2},     \
+    {x, y, 0, UVC_VS_FORMAT_YUY2}
 
 /**
  * @brief Define YUY2 formats with FPS 30-15
@@ -50,7 +54,8 @@
 #define FORMAT_UNCOMPRESSED_30_25_15(x, y) \
     {x, y, 30, UVC_VS_FORMAT_YUY2},        \
     {x, y, 25, UVC_VS_FORMAT_YUY2},        \
-    {x, y, 15, UVC_VS_FORMAT_YUY2}
+    {x, y, 15, UVC_VS_FORMAT_YUY2},        \
+    {x, y, 0, UVC_VS_FORMAT_YUY2}
 
 /**
  * @brief Define YUY2 formats with FPS 30-15
@@ -58,7 +63,8 @@
 #define FORMAT_UNCOMPRESSED_30_20_15(x, y) \
     {x, y, 30, UVC_VS_FORMAT_YUY2},        \
     {x, y, 20, UVC_VS_FORMAT_YUY2},        \
-    {x, y, 15, UVC_VS_FORMAT_YUY2}
+    {x, y, 15, UVC_VS_FORMAT_YUY2},        \
+    {x, y, 0, UVC_VS_FORMAT_YUY2}
 
 /**
  * @brief Define YUY2 formats with FPS 20-5
@@ -67,7 +73,8 @@
     {x, y, 20, UVC_VS_FORMAT_YUY2},    \
     {x, y, 15, UVC_VS_FORMAT_YUY2},    \
     {x, y, 10, UVC_VS_FORMAT_YUY2},    \
-    {x, y, 5, UVC_VS_FORMAT_YUY2}
+    {x, y, 5, UVC_VS_FORMAT_YUY2},     \
+    {x, y, 0, UVC_VS_FORMAT_YUY2}
 
 /**
  * @brief Define h264 formats with FPS 30-15
@@ -75,7 +82,8 @@
 #define FORMAT_H264_30_25_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_H264}, \
     {x, y, 25, UVC_VS_FORMAT_H264}, \
-    {x, y, 15, UVC_VS_FORMAT_H264}
+    {x, y, 15, UVC_VS_FORMAT_H264}, \
+    {x, y, 0, UVC_VS_FORMAT_H264}
 
 /**
  * @brief Define h264 formats with FPS 30-15
@@ -83,7 +91,8 @@
 #define FORMAT_H264_30_20_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_H264}, \
     {x, y, 20, UVC_VS_FORMAT_H264}, \
-    {x, y, 15, UVC_VS_FORMAT_H264}
+    {x, y, 15, UVC_VS_FORMAT_H264}, \
+    {x, y, 0, UVC_VS_FORMAT_H264}
 
 /**
  * @brief Define h265 formats with FPS 30-15
@@ -91,7 +100,8 @@
 #define FORMAT_H265_30_20_15(x, y)  \
     {x, y, 30, UVC_VS_FORMAT_H265}, \
     {x, y, 20, UVC_VS_FORMAT_H265}, \
-    {x, y, 15, UVC_VS_FORMAT_H265}
+    {x, y, 15, UVC_VS_FORMAT_H265}, \
+    {x, y, 0, UVC_VS_FORMAT_H265}
 
 /**
  * @brief Helper that check if required format is supported

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_helpers.hpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_helpers.hpp
@@ -114,7 +114,7 @@
         REQUIRE(bInterfaceNumber == expected_intf_num);                                                                    \
         const usb_intf_desc_t *intf_desc = nullptr;                                                                        \
         const usb_ep_desc_t *ep_desc = nullptr;                                                                            \
-        REQUIRE(ESP_OK == uvc_desc_get_streaming_intf_and_ep(cfg, bInterfaceNumber, 1024, &intf_desc, &ep_desc));                \
+        REQUIRE(ESP_OK == uvc_desc_get_streaming_intf_and_ep(cfg, bInterfaceNumber, 1024, &intf_desc, &ep_desc));          \
         REQUIRE(intf_desc != nullptr);                                                                                     \
         REQUIRE(ep_desc != nullptr);                                                                                       \
         const uvc_format_desc_t *format_desc = nullptr;                                                                    \
@@ -132,4 +132,22 @@
         uint8_t bInterfaceNumber = 0;                                                                                    \
         uint16_t bcdUVC = 0;                                                                                             \
         REQUIRE_FALSE(ESP_OK == uvc_desc_get_streaming_interface_num(cfg, 0, &this_format, &bcdUVC, &bInterfaceNumber)); \
+    } while (0)
+
+/**
+ * @brief Helper that check if default format is supported
+ */
+#define REQUIRE_FORMAT_DEFAULT(cfg, expected_intf_num)                                                                     \
+    do {                                                                                                                   \
+        uvc_host_stream_format_t format;                                                                                   \
+        format.format = UVC_VS_FORMAT_DEFAULT;                                                                             \
+        uint8_t bInterfaceNumber = 0;                                                                                      \
+        uint16_t bcdUVC = 0;                                                                                               \
+        REQUIRE(ESP_OK == uvc_desc_get_streaming_interface_num(cfg, 0, &format, &bcdUVC, &bInterfaceNumber));              \
+        REQUIRE(bInterfaceNumber == expected_intf_num);                                                                    \
+        const usb_intf_desc_t *intf_desc = nullptr;                                                                        \
+        const usb_ep_desc_t *ep_desc = nullptr;                                                                            \
+        REQUIRE(ESP_OK == uvc_desc_get_streaming_intf_and_ep(cfg, bInterfaceNumber, 1024, &intf_desc, &ep_desc));          \
+        REQUIRE(intf_desc != nullptr);                                                                                     \
+        REQUIRE(ep_desc != nullptr);                                                                                       \
     } while (0)

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_logitech_c270.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_logitech_c270.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -67,16 +67,22 @@ SCENARIO("Camera descriptor parsing: Logitech C270", "[logitech][c270]")
             {960, 544, 15, UVC_VS_FORMAT_YUY2},
             {960, 544, 10, UVC_VS_FORMAT_YUY2},
             {960, 544, 5, UVC_VS_FORMAT_YUY2},
+            {960, 544, 0, UVC_VS_FORMAT_YUY2},
             {960, 720, 10, UVC_VS_FORMAT_YUY2},
             {960, 720, 5, UVC_VS_FORMAT_YUY2},
+            {960, 720, 0, UVC_VS_FORMAT_YUY2},
             {1024, 576, 10, UVC_VS_FORMAT_YUY2},
             {1024, 576, 5, UVC_VS_FORMAT_YUY2},
+            {1024, 576, 0, UVC_VS_FORMAT_YUY2},
             {1184, 656, 10, UVC_VS_FORMAT_YUY2},
             {1184, 656, 5, UVC_VS_FORMAT_YUY2},
+            {1184, 656, 0, UVC_VS_FORMAT_YUY2},
             {1280, 720, 7.5f, UVC_VS_FORMAT_YUY2},
             {1280, 720, 5, UVC_VS_FORMAT_YUY2},
+            {1280, 720, 0, UVC_VS_FORMAT_YUY2},
             {1280, 960, 7.5f, UVC_VS_FORMAT_YUY2},
             {1280, 960, 5, UVC_VS_FORMAT_YUY2},
+            {1280, 960, 0, UVC_VS_FORMAT_YUY2},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -84,6 +90,10 @@ SCENARIO("Camera descriptor parsing: Logitech C270", "[logitech][c270]")
                 REQUIRE_FORMAT_SUPPORTED(cfg, this_format, 1);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("Logitech C270 Unsupported") {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_logitech_streamcam.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_logitech_streamcam.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -70,15 +70,19 @@ SCENARIO("Camera descriptor parsing: Logitech Streamcam", "[logitech][streamcam]
             {960, 540, 10, UVC_VS_FORMAT_YUY2},
             {960, 540, 7.5f, UVC_VS_FORMAT_YUY2},
             {960, 540, 5, UVC_VS_FORMAT_YUY2},
+            {960, 540, 0, UVC_VS_FORMAT_YUY2},
 
             {1280, 720, 10, UVC_VS_FORMAT_YUY2},
             {1280, 720, 7.5f, UVC_VS_FORMAT_YUY2},
             {1280, 720, 5, UVC_VS_FORMAT_YUY2},
+            {1280, 720, 0, UVC_VS_FORMAT_YUY2},
 
             {1600, 896, 7.5f, UVC_VS_FORMAT_YUY2},
             {1600, 896, 5, UVC_VS_FORMAT_YUY2},
+            {1600, 896, 0, UVC_VS_FORMAT_YUY2},
 
             {1920, 1080, 5, UVC_VS_FORMAT_YUY2},
+            {1920, 1080, 0, UVC_VS_FORMAT_YUY2},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -86,6 +90,10 @@ SCENARIO("Camera descriptor parsing: Logitech Streamcam", "[logitech][streamcam]
                 REQUIRE_FORMAT_SUPPORTED(cfg, this_format, 1);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("Logitech Streamcam Unsupported") {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_old.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_old.cpp
@@ -24,6 +24,7 @@ SCENARIO("Camera descriptor parsing: Logitech C980", "[old][logitech][c980]")
     GIVEN("Logitech C980") {
         uvc_host_stream_format_t formats[] = {
             {640, 480, 30, UVC_VS_FORMAT_MJPEG},
+            {640, 480, 0, UVC_VS_FORMAT_MJPEG},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_trust_webcam.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_trust_webcam.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,7 @@ SCENARIO("Camera descriptor parsing: Trust Webcam", "[trust][webcam]")
             FORMAT_UNCOMPRESSED_30_5(320, 240),
             FORMAT_UNCOMPRESSED_30_5(176, 144),
             {1280, 1024, 5, UVC_VS_FORMAT_YUY2},
+            {1280, 1024, 0, UVC_VS_FORMAT_YUY2},
             FORMAT_UNCOMPRESSED_30_5(160, 120),
         };
 
@@ -33,6 +34,10 @@ SCENARIO("Camera descriptor parsing: Trust Webcam", "[trust][webcam]")
                 REQUIRE_FORMAT_SUPPORTED(cfg, this_format, 1);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("Trust Webcam Unsupported") {

--- a/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_tusb_dual.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/parsing/test_parsing_tusb_dual.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,7 +20,8 @@ SCENARIO("Camera descriptor parsing: TinyUSB dual UVC", "[tusb][dual]")
 
     GIVEN("TinyUSB dual UVC MJPEG 0") {
         uvc_host_stream_format_t formats[] = {
-            {480, 270, 20, UVC_VS_FORMAT_MJPEG}
+            {480, 270, 20, UVC_VS_FORMAT_MJPEG},
+            {480, 270, 0, UVC_VS_FORMAT_MJPEG},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -32,7 +33,8 @@ SCENARIO("Camera descriptor parsing: TinyUSB dual UVC", "[tusb][dual]")
 
     GIVEN("TinyUSB dual UVC MJPEG 1") {
         uvc_host_stream_format_t formats[] = {
-            {1280, 720, 15, UVC_VS_FORMAT_MJPEG}
+            {1280, 720, 15, UVC_VS_FORMAT_MJPEG},
+            {1280, 720, 0, UVC_VS_FORMAT_MJPEG},
         };
 
         for (uvc_host_stream_format_t this_format : formats) {
@@ -54,6 +56,10 @@ SCENARIO("Camera descriptor parsing: TinyUSB dual UVC", "[tusb][dual]")
                 REQUIRE(frame_desc != nullptr);
             }
         }
+    }
+
+    GIVEN("Default format") {
+        REQUIRE_FORMAT_DEFAULT(cfg, 1);
     }
 
     GIVEN("TinyUSB dual UVC Unsupported") {

--- a/host/class/uvc/usb_host_uvc/include/esp_private/uvc_control.h
+++ b/host/class/uvc/usb_host_uvc/include/esp_private/uvc_control.h
@@ -40,15 +40,15 @@ esp_err_t uvc_host_usb_ctrl(uvc_host_stream_hdl_t stream_hdl, uint8_t bmRequestT
  * This function is use for obtaining format negotiation information
  * that are not in any descriptor, but in uvc_vs_ctrl_t
  *
- * @param      stream_hdl    UVC stream
- * @param[in]  vs_format     Requested Video Stream format
- * @param[out] vs_result_ret Negotiation result. Can be NULL if result is not needed
+ * @param         stream_hdl       UVC stream
+ * @param[inout]  requested_format Requested Video Stream format. Negotiated format will be written here
+ * @param[out]    vs_result_ret    Negotiation result. Can be NULL if result is not needed
  * @return
  *     - ESP_OK: Format negotiated and committed
  *     - ESP_ERR_INVALID_ARG: stream_hdl or vs_format is NULL
  *     - Else: USB Control transfer error
  */
-esp_err_t uvc_host_stream_control_probe(uvc_host_stream_hdl_t stream_hdl, const uvc_host_stream_format_t *vs_format, uvc_vs_ctrl_t *vs_result_ret);
+esp_err_t uvc_host_stream_control_probe(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *requested_format, uvc_vs_ctrl_t *vs_result_ret);
 
 /**
  * @brief Negotiate and commit UVC stream format

--- a/host/class/uvc/usb_host_uvc/include/esp_private/uvc_esp_video.h
+++ b/host/class/uvc/usb_host_uvc/include/esp_private/uvc_esp_video.h
@@ -14,7 +14,7 @@ extern "C" {
 
 /**
  * This API provides access to advanced UVC features.
- * It is intended for use with esp_vide component.
+ * It is intended for use with esp_video component.
  */
 
 typedef struct {

--- a/host/class/uvc/usb_host_uvc/include/esp_private/uvc_esp_video.h
+++ b/host/class/uvc/usb_host_uvc/include/esp_private/uvc_esp_video.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "usb/uvc_host.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * This API provides access to advanced UVC features.
+ * It is intended for use with esp_vide component.
+ */
+
+typedef struct {
+    uint32_t dwMaxVideoFrameSize; /**< Maximum frame size of current format */
+} uvc_host_buf_info_t;
+
+/**
+ * @brief Get frame buffer information
+ *
+ * This function is intended for future use. Currently, it only returns the maximum frame size.
+ *
+ * @param[in]  stream_hdl UVC handle obtained from uvc_host_stream_open()
+ * @param[out] buf_info   Pointer to frame information structure to be filled
+ * @return
+ *     - ESP_OK: Success
+ *     - ESP_ERR_INVALID_ARG: Input parameter is NULL
+ */
+esp_err_t uvc_host_buf_info_get(uvc_host_stream_hdl_t stream_hdl, uvc_host_buf_info_t *buf_info);
+
+#ifdef __cplusplus
+}
+#endif

--- a/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
+++ b/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
@@ -124,7 +124,7 @@ typedef struct {
 typedef struct {
     unsigned h_res;                     /**< Horizontal resolution */
     unsigned v_res;                     /**< Vertical resolution */
-    float fps;                          /**< Frames per second */
+    float fps;                          /**< Frames per second, can be set to zero to request default FPS */
     enum uvc_host_stream_format format; /**< Frame coding format */
 } uvc_host_stream_format_t;
 

--- a/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
+++ b/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
@@ -267,7 +267,20 @@ esp_err_t uvc_host_stream_start(uvc_host_stream_hdl_t stream_hdl);
  *     - ESP_ERR_NOT_FOUND: Format negotiation error
  *     - Else: USB lib error
  */
-esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *format);
+esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, const uvc_host_stream_format_t *format);
+
+/**
+ * @brief Get format of opened stream
+ *
+ * @note There will be no CTRL transfer to the device. The format will be taken from the last successful negotiation.
+ *
+ * @param[in]  stream_hdl UVC handle obtained from uvc_host_stream_open()
+ * @param[out] format     Pointer to format structure to be filled
+ * @return
+ *     - ESP_OK: Success
+ *     - ESP_ERR_INVALID_ARG: Input parameter is NULL
+ */
+esp_err_t uvc_host_stream_format_get(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *format);
 
 /**
  * @brief Stop UVC stream

--- a/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
+++ b/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
@@ -30,7 +30,7 @@ enum uvc_host_driver_event {
  * @brief Formats supported by this driver
  */
 enum uvc_host_stream_format {
-    UVC_VS_FORMAT_UNDEFINED = 0, // Invalid format. Do not request this format from the camera.
+    UVC_VS_FORMAT_DEFAULT = 0, /**< Default format. Depends on the camera. */
     UVC_VS_FORMAT_MJPEG,
     UVC_VS_FORMAT_YUY2,
     UVC_VS_FORMAT_H264,
@@ -259,15 +259,15 @@ esp_err_t uvc_host_stream_start(uvc_host_stream_hdl_t stream_hdl);
  * @brief Change the format of opened stream
  *
  * @note  If the stream is already streaming, it will be stopped, reconfigured and started again
- * @param[in] stream_hdl UVC handle obtained from uvc_host_stream_open()
- * @param[in] format     Format to configure
+ * @param[in]    stream_hdl UVC handle obtained from uvc_host_stream_open()
+ * @param[inout] format     Format to configure. Will be updated if default FPS or default format is requested.
  * @return
  *     - ESP_OK: Success
  *     - ESP_ERR_INVALID_ARG: Input parameter is NULL
  *     - ESP_ERR_NOT_FOUND: Format negotiation error
  *     - Else: USB lib error
  */
-esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, const uvc_host_stream_format_t *format);
+esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *format);
 
 /**
  * @brief Get format of opened stream

--- a/host/class/uvc/usb_host_uvc/private_include/uvc_types_priv.h
+++ b/host/class/uvc/usb_host_uvc/private_include/uvc_types_priv.h
@@ -51,6 +51,7 @@ struct uvc_host_stream_s {
 
     struct {
         uvc_host_stream_format_t vs_format;   // Format of the video stream
+        uint32_t dwMaxVideoFrameSize;         // Maximum frame size of this vs_format
         uvc_host_frame_t *current_frame;      // Frame that is being written to
         bool streaming;                       // Flag whether stream is on/off
     } dynamic; // Dynamic members require a critical section

--- a/host/class/uvc/usb_host_uvc/test_app/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/test_app/CMakeLists.txt
@@ -1,0 +1,9 @@
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+# "Trim" the build. Include the minimal set of components, main, and anything it depends on.
+set(COMPONENTS main)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(test_app_usb_host_uvc)

--- a/host/class/uvc/usb_host_uvc/test_app/README.md
+++ b/host/class/uvc/usb_host_uvc/test_app/README.md
@@ -1,0 +1,13 @@
+| Supported Targets | ESP32-S2 | ESP32-S3 | ESP32-P4 |
+| ----------------- | -------- | -------- | -------- |
+
+# USB: UVC Class test application
+
+## UVC driver
+
+Target tests for USB Host UVC driver.
+
+### Hardware Required
+
+A USB camera and USB enabled ESP SoC is needed. Connect the camera to USB host port on ESP.
+Format negotiation results are tested against values from Logitech C270 camera. These constants must be modified if different camera is used.

--- a/host/class/uvc/usb_host_uvc/test_app/main/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/test_app/main/CMakeLists.txt
@@ -1,0 +1,7 @@
+idf_component_register(SRC_DIRS .
+                       INCLUDE_DIRS .
+                       REQUIRES unity
+                       WHOLE_ARCHIVE)
+
+# So we have access to private_include:
+target_include_directories(${COMPONENT_LIB} PRIVATE "../../")

--- a/host/class/uvc/usb_host_uvc/test_app/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/test_app/main/idf_component.yml
@@ -1,0 +1,6 @@
+## IDF Component Manager Manifest File
+dependencies:
+  # Needed as DUT
+  espressif/usb_host_uvc:
+    version: "*"
+    override_path: "../../../usb_host_uvc"

--- a/host/class/uvc/usb_host_uvc/test_app/main/test_app_main.c
+++ b/host/class/uvc/usb_host_uvc/test_app/main/test_app_main.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "unity.h"
+#include "unity_test_runner.h"
+#include "unity_test_utils_memory.h"
+
+void setUp(void)
+{
+    unity_utils_record_free_mem();
+}
+
+void tearDown(void)
+{
+    unity_utils_evaluate_leaks();
+}
+
+void app_main(void)
+{
+    /*
+      ____ _______   _____________     __                   __
+     |    |   \   \ /   /\_   ___ \  _/  |_  ____   _______/  |_
+     |    |   /\   Y   / /    \  \/  \   __\/ __ \ /  ___/\   __\
+     |    |  /  \     /  \     \____  |  | \  ___/ \___ \  |  |
+     |______/    \___/    \______  /  |__|  \___  >____  > |__|
+                                 \/             \/     \/
+    */
+    printf(" ____ _______   _____________     __                   __   \r\n");
+    printf("|    |   \\   \\ /   /\\_   ___ \\  _/  |_  ____   _______/  |_ \r\n");
+    printf("|    |   /\\   Y   / /    \\  \\/  \\   __\\/ __ \\ /  ___/\\   __\\\r\n");
+    printf("|    |  /  \\     /  \\     \\____  |  | \\  ___/ \\___ \\  |  |  \r\n");
+    printf("|______/    \\___/    \\______  /  |__|  \\___  >____  > |__|  \r\n");
+    printf("                            \\/             \\/     \\/  \r\n");
+
+    unity_utils_setup_heap_record(80);
+    unity_utils_set_leak_level(530);
+    unity_run_menu();
+}

--- a/host/class/uvc/usb_host_uvc/test_app/main/test_uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/test_app/main/test_uvc_host.c
@@ -1,0 +1,313 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+#if SOC_USB_OTG_SUPPORTED
+
+#include <stdio.h>
+#include <string.h>
+#include "esp_system.h"
+#include "unity.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "esp_private/usb_phy.h"
+#include "usb/usb_host.h"
+#include "usb/uvc_host.h"
+#include "esp_private/uvc_esp_video.h"
+
+void usb_lib_task(void *arg)
+{
+    const usb_host_config_t host_config = {
+        .skip_phy_setup = false,
+        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_install(&host_config));
+    printf("USB Host installed\n");
+    xTaskNotifyGive(arg);
+
+    bool has_clients = true;
+    bool has_devices = false;
+    while (has_clients) {
+        uint32_t event_flags;
+        ESP_ERROR_CHECK(usb_host_lib_handle_events(portMAX_DELAY, &event_flags));
+        if (event_flags & USB_HOST_LIB_EVENT_FLAGS_NO_CLIENTS) {
+            printf("Get FLAGS_NO_CLIENTS\n");
+            if (ESP_OK == usb_host_device_free_all()) {
+                printf("All devices marked as free, no need to wait FLAGS_ALL_FREE event\n");
+                has_clients = false;
+            } else {
+                printf("Wait for the FLAGS_ALL_FREE\n");
+                has_devices = true;
+            }
+        }
+        if (has_devices && event_flags & USB_HOST_LIB_EVENT_FLAGS_ALL_FREE) {
+            printf("Get FLAGS_ALL_FREE\n");
+            has_clients = false;
+        }
+    }
+    printf("No more clients and devices, uninstall USB Host library\n");
+
+    // Clean up USB Host
+    vTaskDelay(10); // Short delay to allow clients clean-up
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_uninstall());
+    vTaskDelete(NULL);
+}
+
+/**
+ * @brief Install UVC driver
+ *
+ * This function installs prerequisites for many tests: USB Host library and UVC driver.
+ * It also creates a task that handles USB library events.
+ */
+void test_install_uvc_driver(void)
+{
+    // Create a task that will handle USB library events
+    TEST_ASSERT_EQUAL(pdTRUE, xTaskCreatePinnedToCore(usb_lib_task, "usb_lib", 4 * 4096, xTaskGetCurrentTaskHandle(), 10, NULL, 0));
+    ulTaskNotifyTake(false, 1000);
+
+    printf("Installing UVC driver\n");
+    const uvc_host_driver_config_t uvc_driver_config = {
+        .driver_task_stack_size = 4 * 1024,
+        .driver_task_priority = 10,
+        .xCoreID = tskNO_AFFINITY,
+        .create_background_task = true,
+        .event_cb = NULL,
+        .user_ctx = NULL,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_install(&uvc_driver_config));
+}
+
+/**
+ * @brief UVC default FPS test
+ *
+ * -# Request default FPS
+ * -# Check that the stream can be opened
+ * -# Check that the FPS is set 30 (default FPS for 1280x720 MJPEG format on Logitech C270 camera)
+ */
+TEST_CASE("Open with default FPS", "[uvc]")
+{
+    test_install_uvc_driver();
+
+    printf("Opening UVC stream\n");
+    uvc_host_stream_hdl_t stream = NULL;
+    uvc_host_stream_config_t stream_config = {
+        .event_cb = NULL,
+        .frame_cb = NULL,
+        .user_ctx = NULL,
+        .usb = {
+            .dev_addr = UVC_HOST_ANY_DEV_ADDR,
+            .vid = UVC_HOST_ANY_VID,
+            .pid = UVC_HOST_ANY_PID,
+            .uvc_stream_index = 0,
+        },
+        .vs_format = {
+            .h_res = 1280,
+            .v_res = 720,
+            .fps = 0, // Default FPS
+            .format = UVC_VS_FORMAT_MJPEG,
+        },
+        .advanced = {
+            .number_of_frame_buffers = 3,
+            .frame_size = 0,
+            .frame_heap_caps = 0,
+            .number_of_urbs = 4,
+            .urb_size = 10 * 1024,
+        },
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_open(&stream_config, 1000, &stream));
+    TEST_ASSERT_NOT_NULL(stream);
+    vTaskDelay(10);
+
+    // Get format, check if it matches the requested format
+    uvc_host_stream_format_t format_set;
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_get(stream, &format_set));
+    printf("\tFormat: %dx%d@%2.0f, %d\n", format_set.h_res, format_set.v_res, format_set.fps, format_set.format);
+    TEST_ASSERT_EQUAL(stream_config.vs_format.h_res,  format_set.h_res);
+    TEST_ASSERT_EQUAL(stream_config.vs_format.v_res,  format_set.v_res);
+    TEST_ASSERT_EQUAL(30,                             format_set.fps); // Default FPS
+    TEST_ASSERT_EQUAL(stream_config.vs_format.format, format_set.format);
+
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_close(stream));
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_uninstall());
+    vTaskDelay(20); // Short delay to allow task to be cleaned up
+}
+
+/**
+ * @brief UVC default format test
+ *
+ * -# Request UVC_VS_FORMAT_DEFAULT format
+ * -# Check that the stream can be opened
+ * -# Check that the format is set to 640x480@30fps YUY2 (default format after power on Logitech C270 camera)
+ */
+TEST_CASE("Open with default format", "[uvc]")
+{
+    test_install_uvc_driver();
+
+    printf("Opening UVC stream\n");
+    uvc_host_stream_hdl_t stream = NULL;
+    // Minimalistic stream config
+    uvc_host_stream_config_t stream_config = {
+        .advanced = {
+            .number_of_frame_buffers = 3,
+            .number_of_urbs = 4,
+            .urb_size = 10 * 1024,
+        },
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_open(&stream_config, 1000, &stream));
+    TEST_ASSERT_NOT_NULL(stream);
+    vTaskDelay(10);
+
+    // Get format, check if it matches the requested format
+    uvc_host_stream_format_t format_set;
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_get(stream, &format_set));
+    printf("\tDefault format: %dx%d@%2.0f, %d\n", format_set.h_res, format_set.v_res, format_set.fps, format_set.format);
+    TEST_ASSERT_EQUAL(640,                format_set.h_res);
+    TEST_ASSERT_EQUAL(480,                format_set.v_res);
+    TEST_ASSERT_EQUAL(30,                 format_set.fps);
+    TEST_ASSERT_EQUAL(UVC_VS_FORMAT_YUY2, format_set.format);
+
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_close(stream));
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_uninstall());
+    vTaskDelay(20); // Short delay to allow task to be cleaned up
+}
+
+/**
+ * @brief UVC dynamic format change test
+ *
+ * After each check, dwMaxVideoFrameSize is checked to be correct for the format.
+ * The test is done on Logitech C270 camera.
+ *
+ * -# Open UVC stream with 1280x720@15fps MJPEG format
+ * -# Check that the stream can be opened
+ * -# Check that the format is set to 1280x720@15fps MJPEG
+ * -# Change the format to 640x480@30fps MJPEG
+ * -# Check that the format is set to 640x480@30fps MJPEG
+ * -# Change the format to 1280x720 MJPEG
+ * -# Check that the format is set to 1280x720@30fps MJPEG
+ * -# Change the format to YUY2
+ * -# Check that the format is set to 1280x720@5fps YUY2
+ */
+TEST_CASE("Open and change format", "[uvc]")
+{
+    test_install_uvc_driver();
+
+    printf("Opening UVC stream\n");
+    uvc_host_stream_hdl_t stream = NULL;
+    uvc_host_stream_config_t stream_config = {
+        .event_cb = NULL,
+        .frame_cb = NULL,
+        .user_ctx = NULL,
+        .usb = {
+            .dev_addr = UVC_HOST_ANY_DEV_ADDR,
+            .vid = UVC_HOST_ANY_VID,
+            .pid = UVC_HOST_ANY_PID,
+            .uvc_stream_index = 0,
+        },
+        .vs_format = {
+            .h_res = 1280,
+            .v_res = 720,
+            .fps = 15,
+            .format = UVC_VS_FORMAT_MJPEG,
+        },
+        .advanced = {
+            .number_of_frame_buffers = 3,
+            .frame_size = 0,
+            .frame_heap_caps = 0,
+            .number_of_urbs = 4,
+            .urb_size = 10 * 1024,
+        },
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_open(&stream_config, 1000, &stream)); // 0x303A:0x4002 (TinyUSB Dual CDC device)
+    TEST_ASSERT_NOT_NULL(stream);
+    vTaskDelay(10);
+
+    // Get format, check if it matches the requested format
+    uvc_host_stream_format_t format_set;
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_get(stream, &format_set));
+    TEST_ASSERT_EQUAL(stream_config.vs_format.h_res,  format_set.h_res);
+    TEST_ASSERT_EQUAL(stream_config.vs_format.v_res,  format_set.v_res);
+    TEST_ASSERT_EQUAL(stream_config.vs_format.fps,    format_set.fps);
+    TEST_ASSERT_EQUAL(stream_config.vs_format.format, format_set.format);
+
+    // Check dwMaxVideoFrameSize
+    uvc_host_buf_info_t buf_info;
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_buf_info_get(stream, &buf_info));
+    TEST_ASSERT_EQUAL(1632000, buf_info.dwMaxVideoFrameSize); // For this format on Logitech C270 camera
+
+    // Change the format
+    uvc_host_stream_format_t format2 = {
+        .h_res = 640,
+        .v_res = 480,
+        .fps = 30,
+        .format = UVC_VS_FORMAT_MJPEG,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_select(stream, &format2));
+
+    // Get format, check if it matches the requested format
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_get(stream, &format_set));
+    TEST_ASSERT_EQUAL(format2.h_res,  format_set.h_res);
+    TEST_ASSERT_EQUAL(format2.v_res,  format_set.v_res);
+    TEST_ASSERT_EQUAL(format2.fps,    format_set.fps);
+    TEST_ASSERT_EQUAL(format2.format, format_set.format);
+
+    // Check dwMaxVideoFrameSize for the changed format
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_buf_info_get(stream, &buf_info));
+    TEST_ASSERT_EQUAL(102400, buf_info.dwMaxVideoFrameSize); // For this format on Logitech C270 camera
+
+    // Change only FPS
+    uvc_host_stream_format_t format3 = {
+        .fps = 15,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_select(stream, &format3));
+    // Get format, check if it matches the requested format
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_get(stream, &format_set));
+    TEST_ASSERT_EQUAL(format3.fps,    format_set.fps);
+    // Check the rest, should not be changed
+    TEST_ASSERT_EQUAL(format2.h_res,  format_set.h_res);
+    TEST_ASSERT_EQUAL(format2.v_res,  format_set.v_res);
+    TEST_ASSERT_EQUAL(format2.format, format_set.format);
+
+    // Change only resolution with default FPS
+    uvc_host_stream_format_t format4 = {
+        .h_res = 1280,
+        .v_res = 720,
+        .fps = 0,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_select(stream, &format4));
+    // Get format, check if it matches the requested format
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_get(stream, &format_set));
+    TEST_ASSERT_EQUAL(format4.h_res,  format_set.h_res);  // Must be set exactly
+    TEST_ASSERT_EQUAL(format4.v_res,  format_set.v_res);  // Must be set exactly
+    TEST_ASSERT_EQUAL(30,             format_set.fps);    // Must be default
+    TEST_ASSERT_EQUAL(format2.format, format_set.format); // Must be preserved
+
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_buf_info_get(stream, &buf_info));
+    TEST_ASSERT_EQUAL(816000, buf_info.dwMaxVideoFrameSize); // For this format on Logitech C270 camera
+
+    // Change only format with default FPS
+    uvc_host_stream_format_t format5 = {
+        .format = UVC_VS_FORMAT_YUY2,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_select(stream, &format5));
+    // Get format, check if it matches the requested format
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_format_get(stream, &format_set));
+    TEST_ASSERT_EQUAL(format5.format, format_set.format); // Must be set exactly
+    TEST_ASSERT_EQUAL(format4.h_res,  format_set.h_res);  // Must be preserved
+    TEST_ASSERT_EQUAL(format4.v_res,  format_set.v_res);  // Must be preserved
+    TEST_ASSERT_EQUAL(5,              format_set.fps);    // Must be default
+
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_buf_info_get(stream, &buf_info));
+    TEST_ASSERT_EQUAL(1843200, buf_info.dwMaxVideoFrameSize); // For this format on Logitech C270 camera
+
+    // Clean-up
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_close(stream));
+    TEST_ASSERT_EQUAL(ESP_OK, uvc_host_uninstall());
+    vTaskDelay(20); // Short delay to allow task to be cleaned up
+}
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/host/class/uvc/usb_host_uvc/test_app/sdkconfig.defaults
+++ b/host/class/uvc/usb_host_uvc/test_app/sdkconfig.defaults
@@ -1,0 +1,11 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) 6.0.0 Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="esp32p4"
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_SPEED_200M=y
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+CONFIG_ESP_TASK_WDT_EN=n
+CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE=3200
+CONFIG_USB_HOST_HW_BUFFER_BIAS_IN=y
+CONFIG_IDF_EXPERIMENTAL_FEATURES=y

--- a/host/class/uvc/usb_host_uvc/uvc_control.c
+++ b/host/class/uvc/usb_host_uvc/uvc_control.c
@@ -74,8 +74,8 @@ static esp_err_t uvc_host_stream_control(uvc_host_stream_hdl_t stream_hdl, uvc_v
                 vs_control->dwFrameInterval = frame_desc->mjpeg_uncompressed.dwDefaultFrameInterval;
                 break;
             default:
-                assert(!"This subtype is not supported!");
-                return ESP_ERR_NOT_SUPPORTED;
+                vs_control->dwFrameInterval = 0; // Default value for unknown subtype
+                break;
             }
         } else {
             vs_control->dwFrameInterval = UVC_DESC_FPS_TO_DWFRAMEINTERVAL(vs_format->fps); // Implicit conversion from float to uint32_t

--- a/host/class/uvc/usb_host_uvc/uvc_control.c
+++ b/host/class/uvc/usb_host_uvc/uvc_control.c
@@ -139,18 +139,23 @@ static inline bool uvc_is_vs_format_equal(const uvc_host_stream_format_t *a, con
     return false;
 }
 
-esp_err_t uvc_host_stream_control_probe(uvc_host_stream_hdl_t stream_hdl, const uvc_host_stream_format_t *vs_format, uvc_vs_ctrl_t *vs_result_ret)
+esp_err_t uvc_host_stream_control_probe(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *requested_format, uvc_vs_ctrl_t *vs_result_ret)
 {
-    UVC_CHECK(stream_hdl && vs_format, ESP_ERR_INVALID_ARG);
+    UVC_CHECK(stream_hdl && requested_format, ESP_ERR_INVALID_ARG);
 
     esp_err_t ret;
     uvc_vs_ctrl_t vs_result = {0};
-    uvc_host_stream_format_t format_ignored;
+    uvc_host_stream_format_t default_format;
 
     // Notes: Some cameras require 'probe_get' to be the 1st negotiation call
-    uvc_control_probe_get(stream_hdl, &vs_result, &format_ignored);
-    uvc_control_probe_set(stream_hdl, &vs_result, vs_format);       // Set the desired frame format
-    ret = uvc_control_probe_get(stream_hdl, &vs_result, &format_ignored); // Get back the format (not checked yet)
+    // It returns 'default' format and frame settings which will be used if requested format is UVC_VS_FORMAT_DEFAULT
+    uvc_control_probe_get(stream_hdl, &vs_result, &default_format);
+    if (requested_format->format == UVC_VS_FORMAT_DEFAULT) {
+        memcpy(requested_format, &default_format, sizeof(uvc_host_stream_format_t));
+    }
+
+    uvc_control_probe_set(stream_hdl, &vs_result, requested_format); // Set the requested frame format
+    ret = uvc_control_probe_get(stream_hdl, &vs_result, requested_format); // Get back the format
 
     // Pass the result to user
     if (vs_result_ret) {
@@ -177,7 +182,8 @@ esp_err_t uvc_host_stream_control_commit(uvc_host_stream_hdl_t stream_hdl, const
         // Notes: Some cameras require 'probe_get' to be the 1st negotiation call
         // It returns 'default' format and frame settings. It is ignored for now.
         // We can reuse the returned value, if we wanted to implement 'negotiate default frame format' feature.
-        uvc_host_stream_control_probe(stream_hdl, vs_format, NULL);
+        memcpy(&format_set, vs_format, sizeof(uvc_host_stream_format_t));
+        uvc_host_stream_control_probe(stream_hdl, &format_set, NULL);
 
         // We do this to mimic Windows driver: The Min/Max values are ignored by this driver.
         // These values can be used if we wanted to negotiate advanced parameters, such as wCompQuality to select JPEG encoding quality

--- a/host/class/uvc/usb_host_uvc/uvc_descriptor_parsing.c
+++ b/host/class/uvc/usb_host_uvc/uvc_descriptor_parsing.c
@@ -226,8 +226,7 @@ static bool uvc_desc_format_is_equal(const uvc_frame_desc_t *frame_desc, const u
             }
             break;
         default:
-            assert(!"This subtype is not supported!");
-            return false;
+            return true; // Unknown frame type, assume it is equal;
         }
     }
     return false;

--- a/host/class/uvc/usb_host_uvc/uvc_descriptor_parsing.c
+++ b/host/class/uvc/usb_host_uvc/uvc_descriptor_parsing.c
@@ -169,6 +169,11 @@ static bool uvc_desc_format_is_equal(const uvc_frame_desc_t *frame_desc, const u
     UVC_CHECK(uvc_desc_is_frame_desc((const usb_standard_desc_t *)frame_desc), false);
 
     if (frame_desc->wWidth == vs_format->h_res && frame_desc->wHeight == vs_format->v_res) {
+        if (vs_format->fps == 0) {
+            return true; // Default FPS requested
+        }
+
+        // Check if this frame descriptor supports requested FPS
         uint8_t bFrameIntervalType;
         uint32_t dwMinFrameInterval, dwMaxFrameInterval, dwFrameIntervalStep;
 

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -841,7 +841,7 @@ esp_err_t uvc_host_stream_start(uvc_host_stream_hdl_t stream_hdl)
     return ESP_OK;
 }
 
-esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *format)
+esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, const uvc_host_stream_format_t *format)
 {
     esp_err_t ret = ESP_OK;
     UVC_CHECK(stream_hdl && format, ESP_ERR_INVALID_ARG);
@@ -861,6 +861,15 @@ esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, uvc_ho
         ret = uvc_host_stream_start(stream_hdl);
     }
     return ret;
+}
+
+esp_err_t uvc_host_stream_format_get(uvc_host_stream_hdl_t stream_hdl, uvc_host_stream_format_t *format)
+{
+    UVC_CHECK(stream_hdl && format, ESP_ERR_INVALID_ARG);
+    UVC_ENTER_CRITICAL();
+    memcpy(format, &stream_hdl->dynamic.vs_format, sizeof(uvc_host_stream_format_t));
+    UVC_EXIT_CRITICAL();
+    return ESP_OK;
 }
 
 esp_err_t uvc_host_stream_stop(uvc_host_stream_hdl_t stream_hdl)

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -723,6 +723,7 @@ esp_err_t uvc_host_stream_open(const uvc_host_stream_config_t *stream_config, in
         err, TAG,);
 
     // Save info
+    //@todo fps can be 0 here. Update the format with negotiated FPS
     uvc_format_save(uvc_stream, &stream_config->vs_format, frame_buffer_size);
     uvc_stream->constant.stream_cb = stream_config->event_cb;
     uvc_stream->constant.frame_cb = stream_config->frame_cb;
@@ -863,7 +864,7 @@ esp_err_t uvc_host_stream_format_select(uvc_host_stream_hdl_t stream_hdl, const 
     ESP_GOTO_ON_ERROR(
         uvc_host_stream_control_probe(stream_hdl, format, &vs_result),
         bailout, TAG, "Failed to negotiate requested Video Stream format");
-
+    //@todo fps can be 0 here. Update the format with negotiated FPS
     uvc_format_save(stream_hdl, format, vs_result.dwMaxVideoFrameSize);
 
 bailout:


### PR DESCRIPTION
## UVC driver updates for esp_video binding
Espressif's [esp_video](https://components.espressif.com/components/espressif/esp_video) component provides video pipeline and simulates V4L2 API. This MR updates UVC driver so it can be used in UVC video

### Notable changes
* Added `uvc_host_stream_format_get()` and `uvc_host_buf_info_get()` functions that are needed for esp_video_uvc binding
* Added option to request default FPS and/or default format during format change
* Fixed minor bugs
