### PR TITLE
feat(usb_host): MSC Host add suspend/resume events

### DIFF
--- a/host/class/msc/usb_host_msc/include/usb/msc_host.h
+++ b/host/class/msc/usb_host_msc/include/usb/msc_host.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,7 @@
 #include <wchar.h>
 #include <stdint.h>
 #include "esp_err.h"
+#include "usb/usb_host.h"
 #include "freertos/FreeRTOS.h"
 
 #ifdef __cplusplus
@@ -23,6 +24,11 @@ extern "C" {
 
 #define MSC_STR_DESC_SIZE 32
 
+// For backward compatibility, remove after IDF 5.x EOL             TODO IDF version
+#ifdef USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND
+#define MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+#endif
+
 typedef struct msc_host_device *msc_host_device_handle_t;     /**< Handle to a Mass Storage Device */
 
 /**
@@ -32,10 +38,14 @@ typedef struct {
     enum {
         MSC_DEVICE_CONNECTED,       /**< MSC device has been connected to the system.*/
         MSC_DEVICE_DISCONNECTED,    /**< MSC device has been disconnected from the system.*/
+#ifdef MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+        MSC_DEVICE_SUSPENDED,       /**< MSC device has been suspended.*/
+        MSC_DEVICE_RESUMED,         /**< MSC device has been resumed.*/
+#endif // MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
     } event;
     union {
-        uint8_t address;                /**< Address of connected MSC device.*/
-        msc_host_device_handle_t handle; /**< MSC device handle to disconnected device.*/
+        uint8_t address;                 /**< Address of connected MSC device.*/
+        msc_host_device_handle_t handle; /**< MSC device handle to disconnected, suspended or resumed device.*/
     } device;
 } msc_host_event_t;
 

--- a/host/class/msc/usb_host_msc/src/msc_host.c
+++ b/host/class/msc/usb_host_msc/src/msc_host.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -375,7 +375,9 @@ static msc_device_t *find_msc_device(usb_device_handle_t device_handle)
 
 static void client_event_cb(const usb_host_client_event_msg_t *event, void *arg)
 {
-    if (event->event == USB_HOST_CLIENT_EVENT_NEW_DEV) {
+    switch (event->event) {
+    case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        ESP_LOGD(TAG, "New device connected");
         if (is_mass_storage_device(event->new_dev.address)) {
             const msc_host_event_t msc_event = {
                 .event = MSC_DEVICE_CONNECTED,
@@ -383,15 +385,47 @@ static void client_event_cb(const usb_host_client_event_msg_t *event, void *arg)
             };
             s_msc_driver->user_cb(&msc_event, s_msc_driver->user_arg);
         }
-    } else if (event->event == USB_HOST_CLIENT_EVENT_DEV_GONE) {
-        msc_device_t *msc_device = find_msc_device(event->dev_gone.dev_hdl);
-        if (msc_device) {
+        break;
+    case USB_HOST_CLIENT_EVENT_DEV_GONE:
+        ESP_LOGD(TAG, "Device suddenly disconnected");
+        msc_device_t *msc_device_gone = find_msc_device(event->dev_gone.dev_hdl);
+        if (msc_device_gone) {
             const msc_host_event_t msc_event = {
                 .event = MSC_DEVICE_DISCONNECTED,
-                .device.handle = msc_device,
+                .device.handle = msc_device_gone,
             };
             s_msc_driver->user_cb(&msc_event, s_msc_driver->user_arg);
         }
+        break;
+
+#ifdef MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+    case USB_HOST_CLIENT_EVENT_DEV_SUSPENDED:
+        ESP_LOGD(TAG, "Device suspended");
+        msc_device_t *msc_device_susp = find_msc_device(event->dev_gone.dev_hdl);
+        if (msc_device_susp) {
+            const msc_host_event_t msc_event = {
+                .event = MSC_DEVICE_SUSPENDED,
+                .device.handle = msc_device_susp,
+            };
+            s_msc_driver->user_cb(&msc_event, s_msc_driver->user_arg);
+        }
+        break;
+    case USB_HOST_CLIENT_EVENT_DEV_RESUMED:
+        ESP_LOGD(TAG, "Device resumed");
+        msc_device_t *msc_device_res = find_msc_device(event->dev_gone.dev_hdl);
+        if (msc_device_res) {
+            const msc_host_event_t msc_event = {
+                .event = MSC_DEVICE_RESUMED,
+                .device.handle = msc_device_res,
+            };
+            s_msc_driver->user_cb(&msc_event, s_msc_driver->user_arg);
+        }
+        break;
+#endif // MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+
+    default:
+        ESP_LOGW(TAG, "Unrecognized USB Host client event");
+        break;
     }
 }
 

--- a/host/class/msc/usb_host_msc/test_app/main/test_msc.c
+++ b/host/class/msc/usb_host_msc/test_app/main/test_msc.c
@@ -1,6 +1,6 @@
 
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,7 +34,6 @@ static QueueHandle_t app_queue;
 static SemaphoreHandle_t ready_to_deinit_usb;
 static msc_host_device_handle_t device;
 static msc_host_vfs_handle_t vfs_handle;
-static volatile bool waiting_for_sudden_disconnect;
 
 // usb_host_lib_set_root_port_power is used to force toggle connection, primary developed for esp32p4
 // esp32p4 is supported from IDF 5.3
@@ -94,22 +93,44 @@ static void delete_phy(void) {}
 
 static void msc_event_cb(const msc_host_event_t *event, void *arg)
 {
-    if (waiting_for_sudden_disconnect) {
-        waiting_for_sudden_disconnect = false;
-        TEST_ASSERT_EQUAL(MSC_DEVICE_DISCONNECTED, event->event);
-    }
-
-    if (event->event == MSC_DEVICE_CONNECTED) {
+    switch (event->event) {
+    case MSC_DEVICE_CONNECTED:
         printf("MSC_DEVICE_CONNECTED\n");
-    } else {
+        break;
+    case MSC_DEVICE_DISCONNECTED:
         printf("MSC_DEVICE_DISCONNECTED\n");
+        break;
+#ifdef MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+    case MSC_DEVICE_SUSPENDED:
+        printf("MSC_DEVICE_SUSPENDED\n");
+        TEST_ASSERT_EQUAL_PTR_MESSAGE(device, event->device.handle, "Device handles not matching");
+        break;
+    case MSC_DEVICE_RESUMED:
+        printf("MSC_DEVICE_RESUMED\n");
+        TEST_ASSERT_EQUAL_PTR_MESSAGE(device, event->device.handle, "Device handles not matching");
+        break;
+#endif // MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+    default:
+        printf("Unrecognized MSC Client event\n");
+        return;
     }
 
     xQueueSend(app_queue, event, 10);
 }
 
+static void wait_for_app_event(msc_host_event_t *expected_app_event, TickType_t ticks)
+{
+    msc_host_event_t app_event;
+    if (pdTRUE == xQueueReceive(app_queue, &app_event, ticks)) {
+        TEST_ASSERT_EQUAL_MESSAGE(expected_app_event->event, app_event.event, "Unexpected app event");
+    } else {
+        TEST_ASSERT_MESSAGE(false, "App event not generated on time");
+    }
+}
+
 static const char *TEST_STRING = "Hello World!";
 static const char *FILE_NAME = "/usb/ESP32.txt";
+static const char *BASE_PATH = "/usb";
 
 static void write_read_file(const char *file_path)
 {
@@ -164,6 +185,19 @@ static void handle_usb_events(void *args)
             xSemaphoreGive(ready_to_deinit_usb);
             break;
         }
+
+#ifdef MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+        if (event_flags & USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND) {
+            printf("USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND\n");
+            usb_host_lib_root_port_suspend();
+        }
+
+        if (event_flags & USB_HOST_LIB_EVENT_FLAGS_AUTO_RESUME) {
+            printf("USB_HOST_LIB_EVENT_FLAGS_AUTO_RESUME\n");
+            usb_host_lib_root_port_resume();
+        }
+#endif // MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+
     }
     vTaskDelete(NULL);
 }
@@ -189,7 +223,7 @@ static void check_sudden_disconnect(void)
     uint8_t data[512];
     const size_t DATA_SIZE = sizeof(data);
 
-    ESP_LOGI(TAG, "Creating test.tx");
+    ESP_LOGI(TAG, "Creating test.txt");
     FILE *file = fopen("/usb/test.txt", "w");
     TEST_ASSERT(file);
 
@@ -199,13 +233,10 @@ static void check_sudden_disconnect(void)
     TEST_ASSERT_EQUAL(0, fflush(file));
 
     ESP_LOGI(TAG, "Trigger a disconnect");
-    // Trigger a disconnect
-    waiting_for_sudden_disconnect = true;
     force_conn_state(false, 0);
 
-    // Make sure flag was leared in callback
-    vTaskDelay( pdMS_TO_TICKS(100) );
-    TEST_ASSERT_FALSE(waiting_for_sudden_disconnect);
+    msc_host_event_t expected_event = {.event = MSC_DEVICE_DISCONNECTED};
+    wait_for_app_event(&expected_event, 100);
 
     ESP_LOGI(TAG, "Write data after disconnect");
     TEST_ASSERT_NOT_EQUAL( DATA_SIZE, fwrite(data, 1, DATA_SIZE, file));
@@ -239,7 +270,7 @@ static void msc_test_wait_and_install_device(void)
     uint8_t device_addr = app_event.device.address;
 
     ESP_OK_ASSERT( msc_host_install_device(device_addr, &device) );
-    ESP_OK_ASSERT( msc_host_vfs_register(device, "/usb", &mount_config, &vfs_handle) );
+    ESP_OK_ASSERT( msc_host_vfs_register(device, BASE_PATH, &mount_config, &vfs_handle) );
 }
 
 static void msc_setup(void)
@@ -553,6 +584,159 @@ TEST_CASE("no_background_task_2", "[usb_msc]")
 
     msc_test_deinit();
 }
+
+#ifdef MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
+/**
+ * @brief USB MSC driver Suspend/Resume
+ *
+ * Purpose:
+ *     - Test global Suspend/Resume of the root port with MSC Driver
+ *
+ * Procedure:
+ *     - Install USB Host lib, Install MSC driver, open a device, register VFS
+ *     - Issue global suspend and verify, the MSC_DEVICE_SUSPENDED event is delivered
+ *     - Unregister VFS
+ *     - Issue global resume and verify, the MSC_DEVICE_RESUMED event is delivered
+ *     - Register VFS back, check that a file can be read/written after Suspend/Resume cycle
+ *     - Teardown
+ */
+TEST_CASE("suspend_resume", "[usb_msc]")
+{
+    msc_setup();
+    write_read_file(FILE_NAME);                     // Initial read write check
+    vTaskDelay(10);                                 // Wait some time to finish read_write
+
+    msc_host_event_t expected_event;
+    usb_host_lib_root_port_suspend();               // Suspend the root port
+    expected_event.event = MSC_DEVICE_SUSPENDED;    // Expect MSC device to be suspended
+    wait_for_app_event(&expected_event, 10);        // Expect app event
+
+    // MSC device suspended, unmount storage, verify that the file does not exist
+    TEST_ASSERT_EQUAL(ESP_OK, msc_host_vfs_unregister(vfs_handle));
+    TEST_ASSERT_FALSE(file_exists(FILE_NAME));
+
+    // Resume the device
+    usb_host_lib_root_port_resume();                // Resume the root port
+    expected_event.event = MSC_DEVICE_RESUMED;      // Expect MSC device to be resumed
+    wait_for_app_event(&expected_event, 10);        // Expect app event
+
+    // MSC Device is resumed, mount storage, verify that the file exist and can be read/written
+    TEST_ASSERT_EQUAL(ESP_OK, msc_host_vfs_register(device, BASE_PATH, &mount_config, &vfs_handle));
+    TEST_ASSERT(file_exists(FILE_NAME));
+    write_read_file(FILE_NAME);                     // Verify read write after suspend/resume cycle
+    msc_teardown();
+}
+
+#define MSC_TEST_AUTO_SUSP_RES_MS    2000
+/**
+ * @brief USB MSC driver automatic Suspend/Resume
+ *
+ * Purpose:
+ *     - Test automatic global Suspend/Resume of the root port with MSC Driver
+ *
+ * Procedure:
+ *     - Install USB Host lib, Install MSC driver, open a device, register VFS
+ *     - Set automatic suspend timer to 2000ms
+ *     - Simulate some USB traffic by reading/writing a file multiple times and regularly check that no USB_HOST_LIB event is delivered
+ *     - Once all the traffic is idle, verify the MSC_DEVICE_SUSPENDED event is delivered
+ *     - Measure time from issuing automatic suspend until the suspend event delivery
+ *         - The time shall be greater than, at least 3000 ms (2000ms auto suspend + some time for the USB bus traffic)
+ *     - Set automatic resume timer to 1000ms and verify that the MSC_DEVICE_RESUMED event is delivered
+ *     - Check that a file can be read/written after automatic Suspend/Resume cycle
+ *     - Set automatic suspend timer again, but immediately disable it and make sure no event is delivered
+ *     - Teardown
+ */
+TEST_CASE("auto_suspend_resume", "[usb_msc]")
+{
+    msc_setup();
+
+    // Set automatic suspend timer and start measuring ticks
+    usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND, MSC_TEST_AUTO_SUSP_RES_MS);
+    TickType_t auto_pm_suspend_tick_start = xTaskGetTickCount();
+    msc_host_event_t peek_event, expected_event;
+
+    // Simulate some traffic, so the root port would not suspend after MSC_TEST_AUTO_SUSP_RES_MS from now,
+    // but after MSC_TEST_AUTO_SUSP_RES_MS, once there is no traffic
+    // Regularly check, that there is no item in queue (check that the timer did not expire)
+    for (int i = 0; i < 5; i++) {
+        write_read_file(FILE_NAME);
+        TEST_ASSERT_EQUAL(pdFALSE, xQueuePeek(app_queue, &peek_event, 0));
+    }
+
+    // Expect MSC device to be suspended, expect app queue and block for MSC_TEST_AUTO_SUSP_RES_MS + some margin
+    expected_event.event = MSC_DEVICE_SUSPENDED;
+    wait_for_app_event(&expected_event, pdMS_TO_TICKS(MSC_TEST_AUTO_SUSP_RES_MS + 500));        // Expect app event
+
+    TickType_t auto_pm_suspend_tick_end = xTaskGetTickCount();      // App event received, stop measuring ticks
+    const uint32_t elapsed_ms = (auto_pm_suspend_tick_end - auto_pm_suspend_tick_start) * portTICK_PERIOD_MS;
+
+    // Check that, the time elapsed between setting the auto suspend timer and MSC_DEVICE_SUSPENDED event
+    // is more than MSC_TEST_AUTO_SUSP_RES_MS + some margin
+    TEST_ASSERT_GREATER_THAN_UINT32_MESSAGE(MSC_TEST_AUTO_SUSP_RES_MS + 500, elapsed_ms, "Auto suspend timer did not expire on time");
+
+    // Set automatic resume timer and expect MSC_DEVICE_RESUMED event
+    // Expect app queue and block for MSC_TEST_AUTO_SUSP_RES_MS + some margin
+    usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_RESUME, MSC_TEST_AUTO_SUSP_RES_MS);
+    expected_event.event = MSC_DEVICE_RESUMED;
+    wait_for_app_event(&expected_event, pdMS_TO_TICKS(MSC_TEST_AUTO_SUSP_RES_MS + 500));        // Expect app event
+
+    // MSC device resumed, verify read write after suspend/resume cycle
+    write_read_file(FILE_NAME);
+
+    // Set automatic suspend timer, but immediately disable the timer and expect no app event
+    usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND, MSC_TEST_AUTO_SUSP_RES_MS);
+    usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND, 0);
+    // Test that the automatic Suspend/Resume timer can be disabled
+    TEST_ASSERT_EQUAL(pdFALSE, xQueuePeek(app_queue, &peek_event, pdMS_TO_TICKS(MSC_TEST_AUTO_SUSP_RES_MS * 2)));
+    msc_teardown();
+}
+
+static void check_sudden_suspend(void)
+{
+    uint8_t data[512];
+    const size_t DATA_SIZE = sizeof(data);
+
+    ESP_LOGI(TAG, "Creating test.txt");
+    FILE *file = fopen("/usb/test.txt", "w");
+    TEST_ASSERT(file);
+
+    ESP_LOGI(TAG, "Write data");
+    TEST_ASSERT_EQUAL(DATA_SIZE, fwrite(data, 1, DATA_SIZE, file));
+    TEST_ASSERT_EQUAL(DATA_SIZE, fwrite(data, 1, DATA_SIZE, file));
+    TEST_ASSERT_EQUAL(0, fflush(file));
+
+    ESP_LOGI(TAG, "Trigger a suspend");
+    usb_host_lib_root_port_suspend();
+
+    msc_host_event_t expected_event = {.event = MSC_DEVICE_SUSPENDED};
+    wait_for_app_event(&expected_event, 100);
+
+    ESP_LOGI(TAG, "Write data after suspend");
+    TEST_ASSERT_NOT_EQUAL( DATA_SIZE, fwrite(data, 1, DATA_SIZE, file));
+
+    fclose(file);
+}
+
+/**
+ * @brief USB MSC sudden Suspend
+ *
+ * Purpose:
+ *     - Test global Suspend/Resume of the root port with MSC Driver
+ *
+ * Procedure:
+ *     - Install USB Host lib, Install MSC driver, open a device, register VFS
+ *     - Open a file and write some data
+ *     - Issue global suspend and verify, the MSC_DEVICE_SUSPENDED event is delivered
+ *     - Proceed with writing to a file and make sure the file can't be written anymore
+ *     - Teardown
+ */
+TEST_CASE("sudden_suspend", "[usb_msc]")
+{
+    msc_setup();
+    check_sudden_suspend();
+    msc_teardown();
+}
+#endif // MSC_HOST_SUSPEND_RESUME_API_SUPPORTED
 
 /**
  * @brief USB MSC Device Mock


### PR DESCRIPTION
## Description

This MR adds Suspend/Resume events for MSC class driver as a follow-up for the Global/Suspend resume MR in esp-idf

## Related

## Testing

Added new tests, which verify the class driver functionality with root port Suspend/Resume events
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
