### PR TITLE
fix(esp_tinyusb): Stop using constants from deprecated usb_pins.h

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 1.7.4~1
+## 1.7.5
 
-- esp_tinyusb: Claim forward compatibility with IDF 6.0
+- esp_tinyusb: Provide forward compatibility with IDF 6.0
 
 ## 1.7.4
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.7.4~1"
+version: "1.7.5"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule


### PR DESCRIPTION
`usb_pins.h` file will be removed from IDFv6.0.
It contains constant ext.PHY IOs mapping to GPIOs. In reality the IOs can be mapped to any GPIOs, making these definitions redundant.

The constant definitions are now hard-coded in the esp_tinyusb to provide functional backward compatibility to IDFv6.x users