### PR TITLE
fix(ci): Use latest idf-component-manager from esp-idf docker image

### DIFF
--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install idf-component-manager==2.1.2 idf-build-apps==2.4.3 pyyaml  --upgrade
+          pip install idf-component-manager>=2.1.2 idf-build-apps==2.4.3 pyyaml  --upgrade
           python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
           cd ${IDF_PATH}
           idf-build-apps find --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w


### PR DESCRIPTION
Failing job https://github.com/espressif/esp-usb/actions/runs/15542561481/job/43756569788?pr=183