### PR TITLE
fix(tinyusb_msc): Address calculation verification for SPI Flash

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.6 [Unreleased]
+
+- MSC: Fixed the possibility to use SD/MMC storage with large capacity (more than 4 GB)
+
 ## 1.7.5
 
 - esp_tinyusb: Provide forward compatibility with IDF 6.0


### PR DESCRIPTION
## Description
The verification of the address value (the value, which is used for Wear Levelling above SPI Flash storage) is done when WRITE(10) command is coming, for both storages: SPI Flash and SD/MMC.

This verification is not relevant, when SD/MMC storage is used, as SD/MMC storage works with LBA directly. 

## Related

- Closes https://github.com/espressif/esp-idf/issues/16085
- Relates to https://github.com/espressif/esp-usb/pull/178

## Testing

```
$ dd if=/dev/random of=/dev/sda bs=512 count=1 seek=124735487
$ dd if=/dev/sda iflag=direct bs=512 skip=124735487 count=1
```

1. After the change, the direct read/write of the last sector of the card with capacity of 64 GB completed successful and the data is valid. 
![image](https://github.com/user-attachments/assets/afa6ec0f-829f-484f-9589-2427af2e8123)

2. Without change, the direct read/write of the last sector of the uSD card with capacity of 64 GB completed successful, but the data has not been written correctly. 
![image](https://github.com/user-attachments/assets/2a176d51-4487-435d-b214-c110c73034a2)


Notes
1. The tests were done one by one, so the returning data in the case 2 (without changes of this PR) is equal to the random data, written in case 1. 
2. Different uSD cards with 64 GB could report different amounts of sectors. In case of tested uSD card, the card capacity was  `capacity=124735488`

## Limitation

1. Reporting that data has been written correctly, even if the data was not written. Will be fixed in https://github.com/espressif/esp-usb/pull/178 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
