### PR TITLE
release(esp_tinyusb): v1.7.6

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.7.6 [Unreleased]
+## 1.7.6
 
 - MSC: Fixed the possibility to use SD/MMC storage with large capacity (more than 4 GB)
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.7.5"
+version: "1.7.6"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule


### PR DESCRIPTION
# esp_tinyusb component, [release v1.7.6](https://components.espressif.com/components/espressif/esp_tinyusb/versions/1.7.6) 

## Changes
- MSC: Fixed the possibility to use SD/MMC storage with large capacity (more than 4 GB) (https://github.com/espressif/esp-usb/pull/186)

## Related
- Closes https://github.com/espressif/esp-idf/issues/16085
