### PR TITLE
feature(tinyusb_msc): Added storage format logic

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -10,6 +10,7 @@
 - esp_tinyusb: Added USB Device event callback to handle different USB Device events. For the list of supported USB Device events, refer to to [Espressif's Addition to TinyUSB - README](/device/esp_tinyusb/README.md)
 - esp_tinyusb: Removed configuration option to handle TinyUSB events outside of this driver
 - MSC: Removed dedicated callbacks; introduced a single callback with an event ID for each storage
+- MSC: Added storage format support
 - MSC: Updated public API; refer to the [MSC Class Migration guide v2](/docs/device/migration-guides/v2/tinyusb_msc.md)
 - Console: Updated public API; refer to the [Console Class Migration guide v2](/docs/device/migration-guides/v2/tinyusb_console.md)
 - CDC-ACM: Updated public API; refer to the [CDC-ACM Class Migration guide v2](/docs/device/migration-guides/v2/tinyusb_cdc_acm.md)

--- a/device/esp_tinyusb/include/tinyusb_msc.h
+++ b/device/esp_tinyusb/include/tinyusb_msc.h
@@ -42,6 +42,7 @@ typedef enum {
     TINYUSB_MSC_EVENT_MOUNT_COMPLETE,            /*!< Called AFTER the mount or unmount operation is complete */
     TINYUSB_MSC_EVENT_MOUNT_FAILED,              /*!< Called if the mount operation failed */
     TINYUSB_MSC_EVENT_FORMAT_REQUIRED,           /*!< Called when the storage needs to be formatted */
+    TINYUSB_MSC_EVENT_FORMAT_FAILED,             /*!< Called if the format operation failed */
 } tinyusb_msc_event_id_t;
 
 /**
@@ -236,7 +237,10 @@ esp_err_t tinyusb_msc_set_storage_callback(tusb_msc_callback_t callback, void *a
  * @param[in] handle    Storage handle, obtained during storage creation.
  *
  * @return
- *   - ESP_ERR_NOT_SUPPORTED: Formatting is not supported
+ *   - ESP_ERR_INVALID_STATE: MSC driver is not initialized or storage is not initialized
+ *   - ESP_ERR_INVALID_ARG: Storage must be mounted to APP to format it
+ *   - ESP_ERR_NOT_FOUND: Unexpected filesystem found on the drive
+ *   - ESP_OK: Storage formatted successfully
  */
 esp_err_t tinyusb_msc_format_storage(tinyusb_msc_storage_handle_t handle);
 

--- a/device/esp_tinyusb/test_apps/msc_storage/main/storage_common.c
+++ b/device/esp_tinyusb/test_apps/msc_storage/main/storage_common.c
@@ -123,6 +123,13 @@ void storage_init_sdmmc(sdmmc_card_t **card)
     printf("\tSector Size: %u\n", sd_card->csd.sector_size);
 }
 
+void storage_erase_sdmmc(sdmmc_card_t *card)
+{
+    // Erase the SDMMC card
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, sdmmc_full_erase(card), "Failed to erase SDMMC card");
+    printf("SDMMC Card erased successfully\n");
+}
+
 void storage_deinit_sdmmc(sdmmc_card_t *card)
 {
     // Deinit the host

--- a/device/esp_tinyusb/test_apps/msc_storage/main/storage_common.h
+++ b/device/esp_tinyusb/test_apps/msc_storage/main/storage_common.h
@@ -45,6 +45,15 @@ void storage_deinit_spiflash(wl_handle_t wl_handle);
 void storage_init_sdmmc(sdmmc_card_t **card);
 
 /**
+ * @brief Erase the SDMMC storage
+ *
+ * This function erases the entire SDMMC card.
+ *
+ * @param[in] card Pointer to the sdmmc_card_t structure that was initialized in storage_init_sdmmc
+ */
+void storage_erase_sdmmc(sdmmc_card_t *card);
+
+/**
  * @brief Deinitialize the SDMMC storage
  *
  * @param[in] card Pointer to the sdmmc_card_t structure that was initialized in storage_init_sdmmc


### PR DESCRIPTION
## Description

Now it is possible to format the storage with desirable flags (and file system type) either from the APP or from the USB Host.  

### Feature update 
- Adding storage format.

### Test application refactoring
- Removed the descriptors for TinyUSB configuration. Now the default config is used. 

## Related

- Closes [IEC-319](https://jira.espressif.com:8443/browse/IEC-319)

## Testing

Additional test cases were added to `msc_storage` test application: 
- `MSC: format storage SPI Flash, mounted to APP`
- `MSC: format storage SPI Flash, mounted to USB`
- `MSC: format storage SD/MMC, mounted to APP`

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
