### PR TITLE
refactor(tinyusb): Added event specific data

### DIFF
--- a/device/esp_tinyusb/include/tinyusb.h
+++ b/device/esp_tinyusb/include/tinyusb.h
@@ -115,8 +115,11 @@ typedef enum {
  */
 typedef struct {
     tinyusb_event_id_t id;            /*!< Event ID */
+    uint8_t rhport;                   /*!< USB Peripheral hardware port number. Available when hardware has several available peripherals. */
     union {
-        uint8_t rhport;               /*!< USB Peripheral hardware port number. Available when hardware has several available peripherals. */
+        struct {
+            bool remote_wakeup;        /*!< Remote wakeup enabled flag */
+        } suspended;                   /*!< Specific event id data */
     };
 } tinyusb_event_t;
 


### PR DESCRIPTION
## Description

Prerequisites for adding the device suspend event.

`rhport` is a common data for all events. 

## Related

- Relates to [IDFGH-12837](https://jira.espressif.com:8443/browse/IDFGH-12837)

## Testing


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
