### PR TITLE
release(esp_tinyusb): v1.7.6.1

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.7.7 [unreleased]
+## 1.7.6~1
 
 - esp_tinyusb: Added documentation to README.md
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.7.6"
+version: "1.7.6~1"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule


### PR DESCRIPTION
# esp_tinyusb component, [release v1.7.6~1](https://components.espressif.com/components/espressif/esp_tinyusb/versions/1.7.6~1) 

## Description

To have the API reference to the v1.x.x in the README.md file in ESP Component Registry.

## Changes
- esp_tinyusb: Added API reference and part of the documentation from `esp-idf` to the `esp-usb` repository, `esp_tinyusb` component. 

## Related
- Closes [IDF-13558](https://jira.espressif.com:8443/browse/IDF-13558)
