### PR TITLE
chore: esp-idf pre-commit all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v1.0.5
     hooks:
     -   id: astyle_py
-        args: ['--style=otbs', '--attach-namespaces', '--attach-classes', '--indent=spaces=4', '--convert-tabs', '--align-pointer=name', '--align-reference=name', '--keep-one-line-statements', '--pad-header', '--pad-oper']
+        args: ['--style=otbs', '--attach-namespaces', '--attach-classes', '--indent=spaces=4', '--convert-tabs', '--align-pointer=name', '--align-reference=name', '--keep-one-line-statements', '--pad-header', '--pad-oper', '--max-continuation-indent=120']
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
@@ -29,3 +29,21 @@ repos:
         args: ['--fix=lf']
         description: Forces to replace line ending by the UNIX 'lf' character
         exclude: '.*\.uxf'
+    -   id: check-yaml
+
+- repo: https://github.com/espressif/esp-idf-kconfig.git
+  rev: v2.5.0
+  hooks:
+    - id: check-kconfig-files
+    - id: check-deprecated-kconfig-options
+
+- repo: local
+  hooks:
+      - id: cmake-lint
+        name: Check CMake Files Format
+        entry: cmakelint --linelength=120 --spaces=4 --filter=-whitespace/indent
+        language: python
+        additional_dependencies:
+          - cmakelint==1.4.1
+        files: 'CMakeLists.txt$|\.cmake$'
+        exclude: '\/third_party\/'

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -188,22 +188,22 @@ menu "TinyUSB Stack"
 
         menu "TinyUSB FAT Format Options"
             choice TINYUSB_FAT_FORMAT_TYPE
-               prompt "FatFS Format Type"
+                prompt "FatFS Format Type"
                 default TINYUSB_FAT_FORMAT_ANY
                 help
                     Select the FAT filesystem type used when formatting storage.
 
-            config TINYUSB_FAT_FORMAT_ANY
-                bool "FM_ANY - Automatically select from FAT12/FAT16/FAT32"
+                config TINYUSB_FAT_FORMAT_ANY
+                    bool "FM_ANY - Automatically select from FAT12/FAT16/FAT32"
 
-            config TINYUSB_FAT_FORMAT_FAT
-                bool "FM_FAT - Allow only FAT12/FAT16"
+                config TINYUSB_FAT_FORMAT_FAT
+                    bool "FM_FAT - Allow only FAT12/FAT16"
 
-            config TINYUSB_FAT_FORMAT_FAT32
-                bool "FM_FAT32 - Force FAT32 only"
+                config TINYUSB_FAT_FORMAT_FAT32
+                    bool "FM_FAT32 - Force FAT32 only"
 
-            config TINYUSB_FAT_FORMAT_EXFAT
-                bool "FM_EXFAT - Force exFAT (requires exFAT enabled)"
+                config TINYUSB_FAT_FORMAT_EXFAT
+                    bool "FM_EXFAT - Force exFAT (requires exFAT enabled)"
 
             endchoice
 
@@ -213,7 +213,7 @@ menu "TinyUSB Stack"
                 help
                     Format as a Super Floppy Disk (no partition table).
                     This is typical for USB flash drives and small volumes.
-            endmenu
+        endmenu
 
     endmenu # "Massive Storage Class"
 
@@ -348,11 +348,11 @@ menu "TinyUSB Stack"
             default 3200
             range 1600 10240
             help
-              Size of NTB buffers on the reception side. The minimum size used by Linux is 2048 bytes.
-              NTB buffer size must be significantly larger than the MTU (Maximum Transmission Unit).
-              The typical default MTU size for Ethernet is 1500 bytes, plus an additional packet overhead.
-              To improve performance, the NTB buffer size should be large enough to fit multiple MTU-sized
-              frames in a single NTB buffer and it's length should be multiple of 4.
+                Size of NTB buffers on the reception side. The minimum size used by Linux is 2048 bytes.
+                NTB buffer size must be significantly larger than the MTU (Maximum Transmission Unit).
+                The typical default MTU size for Ethernet is 1500 bytes, plus an additional packet overhead.
+                To improve performance, the NTB buffer size should be large enough to fit multiple MTU-sized
+                frames in a single NTB buffer and it's length should be multiple of 4.
 
         config TINYUSB_NCM_IN_NTB_BUFF_MAX_SIZE
             int "NCM NTB Buffer size for transmission size"
@@ -360,11 +360,11 @@ menu "TinyUSB Stack"
             default 3200
             range 1600 10240
             help
-              Size of NTB buffers on the transmission side. The minimum size used by Linux is 2048 bytes.
-              NTB buffer size must be significantly larger than the MTU (Maximum Transmission Unit).
-              The typical default MTU size for Ethernet is 1500 bytes, plus an additional packet overhead.
-              To improve performance, the NTB buffer size should be large enough to fit multiple MTU-sized
-              frames in a single NTB buffer and it's length should be multiple of 4.
+                Size of NTB buffers on the transmission side. The minimum size used by Linux is 2048 bytes.
+                NTB buffer size must be significantly larger than the MTU (Maximum Transmission Unit).
+                The typical default MTU size for Ethernet is 1500 bytes, plus an additional packet overhead.
+                To improve performance, the NTB buffer size should be large enough to fit multiple MTU-sized
+                frames in a single NTB buffer and it's length should be multiple of 4.
 
     endmenu # "Network driver (ECM/NCM/RNDIS)"
 

--- a/device/esp_tinyusb/include/tusb_cdc_acm.h
+++ b/device/esp_tinyusb/include/tusb_cdc_acm.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -130,8 +130,8 @@ esp_err_t tusb_cdc_acm_deinit(int itf);
  * @return esp_err_t - ESP_OK or ESP_ERR_INVALID_ARG
  */
 esp_err_t tinyusb_cdcacm_register_callback(tinyusb_cdcacm_itf_t itf,
-        cdcacm_event_type_t event_type,
-        tusb_cdcacm_callback_t callback);
+                                           cdcacm_event_type_t event_type,
+                                           tusb_cdcacm_callback_t callback);
 
 /**
  * @brief Unregister a callback invoking on CDC event

--- a/device/esp_tinyusb/test/local/libusb_test.c
+++ b/device/esp_tinyusb/test/local/libusb_test.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -62,8 +62,8 @@ int main()
     rc = libusb_init(&context);
     assert(rc == 0);
     libusb_device_handle *dev_handle = libusb_open_device_with_vid_pid(context,
-                                       TINYUSB_VENDOR,
-                                       TINYUSB_PRODUCT);
+                                                                       TINYUSB_VENDOR,
+                                                                       TINYUSB_PRODUCT);
 
     if (dev_handle != NULL) {
         printf("TinyUSB Device has been found\n");

--- a/device/esp_tinyusb/test_apps/cdc/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/cdc/sdkconfig.defaults
@@ -5,8 +5,7 @@ CONFIG_TINYUSB_CDC_COUNT=2
 CONFIG_TINYUSB_HID_COUNT=0
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/device/esp_tinyusb/test_apps/configuration_desc/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/configuration_desc/sdkconfig.defaults
@@ -3,8 +3,7 @@ CONFIG_TINYUSB_CDC_ENABLED=y
 CONFIG_TINYUSB_CDC_COUNT=2
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/device/esp_tinyusb/test_apps/dconn_detection/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/dconn_detection/sdkconfig.defaults
@@ -5,8 +5,7 @@ CONFIG_TINYUSB_CDC_COUNT=0
 CONFIG_TINYUSB_HID_COUNT=0
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/device/esp_tinyusb/test_apps/default_task/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/default_task/sdkconfig.defaults
@@ -3,8 +3,7 @@ CONFIG_TINYUSB_NO_DEFAULT_TASK=n
 CONFIG_TINYUSB_INIT_IN_DEFAULT_TASK=n
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/device/esp_tinyusb/test_apps/default_task_with_init/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/default_task_with_init/sdkconfig.defaults
@@ -3,8 +3,7 @@ CONFIG_TINYUSB_NO_DEFAULT_TASK=n
 CONFIG_TINYUSB_INIT_IN_DEFAULT_TASK=y
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/device/esp_tinyusb/test_apps/external_task/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/external_task/sdkconfig.defaults
@@ -3,8 +3,7 @@ CONFIG_TINYUSB_NO_DEFAULT_TASK=y
 CONFIG_TINYUSB_INIT_IN_DEFAULT_TASK=n
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/device/esp_tinyusb/test_apps/teardown_device/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/teardown_device/sdkconfig.defaults
@@ -3,8 +3,7 @@ CONFIG_TINYUSB_CDC_ENABLED=y
 CONFIG_TINYUSB_CDC_COUNT=1
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/device/esp_tinyusb/test_apps/vendor/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/vendor/sdkconfig.defaults
@@ -2,8 +2,7 @@
 CONFIG_TINYUSB_VENDOR_COUNT=2
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/device/esp_tinyusb/tusb_cdc_acm.c
+++ b/device/esp_tinyusb/tusb_cdc_acm.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -139,8 +139,8 @@ void tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char)
 }
 
 esp_err_t tinyusb_cdcacm_register_callback(tinyusb_cdcacm_itf_t itf,
-        cdcacm_event_type_t event_type,
-        tusb_cdcacm_callback_t callback)
+                                           cdcacm_event_type_t event_type,
+                                           tusb_cdcacm_callback_t callback)
 {
     esp_tusb_cdcacm_t *acm = get_acm(itf);
     if (acm) {
@@ -176,7 +176,7 @@ esp_err_t tinyusb_cdcacm_register_callback(tinyusb_cdcacm_itf_t itf,
 }
 
 esp_err_t tinyusb_cdcacm_unregister_callback(tinyusb_cdcacm_itf_t itf,
-        cdcacm_event_type_t event_type)
+                                             cdcacm_event_type_t event_type)
 {
     esp_tusb_cdcacm_t *acm = get_acm(itf);
     if (!acm) {

--- a/device/esp_tinyusb/tusb_msc_storage.c
+++ b/device/esp_tinyusb/tusb_msc_storage.c
@@ -204,9 +204,9 @@ static esp_err_t _write_sector_sdmmc(size_t sector_size,
 #endif
 
 static esp_err_t _msc_storage_read_sector(uint32_t lba,
-        uint32_t offset,
-        size_t size,
-        void *dest)
+                                          uint32_t offset,
+                                          size_t size,
+                                          void *dest)
 {
     assert(s_storage_handle);
     size_t sector_size = tinyusb_msc_storage_get_sector_size();
@@ -214,9 +214,9 @@ static esp_err_t _msc_storage_read_sector(uint32_t lba,
 }
 
 static esp_err_t _msc_storage_write_sector(uint32_t lba,
-        uint32_t offset,
-        size_t size,
-        const void *src)
+                                           uint32_t offset,
+                                           size_t size,
+                                           const void *src)
 {
     assert(s_storage_handle);
     if (s_storage_handle->is_fat_mounted) {

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_device_interaction.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_device_interaction.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,27 +32,27 @@ static void _add_mocked_devices(void)
 
     // ASIX Electronics Corp. AX88772A Fast Ethernet (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(0, (const usb_device_desc_t *)premium_cord_device_desc_fs,
-            (const usb_config_desc_t *)premium_cord_config_desc_fs));
+                                               (const usb_config_desc_t *)premium_cord_config_desc_fs));
 
     // ASIX Electronics Corp. AX88772B (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(1, (const usb_device_desc_t *)i_tec_device_desc_fs,
-            (const usb_config_desc_t *)i_tec_config_desc_fs));
+                                               (const usb_config_desc_t *)i_tec_config_desc_fs));
 
     // FTDI chip dual (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(2, (const usb_device_desc_t *)ftdi_device_desc_fs_hs,
-            (const usb_config_desc_t *)ftdi_config_desc_fs));
+                                               (const usb_config_desc_t *)ftdi_config_desc_fs));
 
     // TTL232RG (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(3, (const usb_device_desc_t *)ttl232_device_desc,
-            (const usb_config_desc_t *)ttl232_config_desc));
+                                               (const usb_config_desc_t *)ttl232_config_desc));
 
     // CP210x (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(4, (const usb_device_desc_t *)cp210x_device_desc,
-            (const usb_config_desc_t *)cp210x_config_desc));
+                                               (const usb_config_desc_t *)cp210x_config_desc));
 
     // tusb_serial_device (HS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(5, (const usb_device_desc_t *)tusb_serial_device_device_desc_fs_hs,
-            (const usb_config_desc_t *)tusb_serial_device_config_desc_hs));
+                                               (const usb_config_desc_t *)tusb_serial_device_config_desc_hs));
 }
 
 /**

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_opening_device.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_opening_device.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,7 +29,7 @@ static void _add_mocked_devices(void)
     // Fill mocked devices list
     // CP210x (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(5, (const usb_device_desc_t *)cp210x_device_desc,
-            (const usb_config_desc_t *)cp210x_config_desc));
+                                               (const usb_config_desc_t *)cp210x_config_desc));
 }
 
 

--- a/host/class/cdc/usb_host_cdc_acm/test_app/sdkconfig.defaults
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/sdkconfig.defaults
@@ -5,8 +5,7 @@ CONFIG_TINYUSB_CDC_COUNT=2
 CONFIG_TINYUSB_HID_COUNT=0
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_COMPILER_STACK_CHECK_MODE_STRONG=y

--- a/host/class/cdc/usb_host_vcp/CMakeLists.txt
+++ b/host/class/cdc/usb_host_vcp/CMakeLists.txt
@@ -2,7 +2,7 @@ idf_component_register(SRCS "usb_host_vcp.cpp"
                     INCLUDE_DIRS "include")
 
 # TODO IDF-10802
-if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 13.2)  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116070
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 13.2)  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116070
     set_target_properties(${COMPONENT_LIB} PROPERTIES
         CXX_STANDARD 14
         CXX_STANDARD_REQUIRED ON

--- a/host/class/hid/usb_host_hid/CMakeLists.txt
+++ b/host/class/hid/usb_host_hid/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register( SRCS "hid_host.c"
                         INCLUDE_DIRS "include"
-					    PRIV_REQUIRES usb )
+                        PRIV_REQUIRES usb )

--- a/host/class/hid/usb_host_hid/hid_host.c
+++ b/host/class/hid/usb_host_hid/hid_host.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -135,8 +135,8 @@ static hid_driver_t *s_hid_driver;                              /**< Internal po
 // ----------------------- Private Prototypes ----------------------------------
 
 static esp_err_t hid_host_install_device(uint8_t dev_addr,
-        usb_device_handle_t dev_hdl,
-        hid_device_t **hid_device);
+                                         usb_device_handle_t dev_hdl,
+                                         hid_device_t **hid_device);
 
 
 static esp_err_t hid_host_uninstall_device(hid_device_t *hid_device);
@@ -253,7 +253,7 @@ static hid_iface_t *get_iface_by_handle(hid_host_device_handle_t hid_dev_handle)
  * @return usb_ep_desc_t Pointer to EP IN Descriptor
  */
 static inline const usb_ep_desc_t *get_iface_ep_in(const usb_intf_desc_t *iface_desc,
-        const size_t total_length)
+                                                   const size_t total_length)
 {
     assert(iface_desc);
     const usb_ep_desc_t *ep_desc = NULL;
@@ -297,7 +297,7 @@ static bool hid_interface_present(const usb_config_desc_t *config_desc)
  * @param[in] event   HID Interface event
  */
 static inline void hid_host_user_interface_callback(hid_iface_t *iface,
-        const hid_host_interface_event_t event)
+                                                    const hid_host_interface_event_t event)
 {
     assert(iface);
 
@@ -317,7 +317,7 @@ static inline void hid_host_user_interface_callback(hid_iface_t *iface,
  * @param[in] event   HID Device event
  */
 static inline void hid_host_user_device_callback(hid_iface_t *iface,
-        const hid_host_driver_event_t event)
+                                                 const hid_host_driver_event_t event)
 {
     assert(iface);
 
@@ -438,7 +438,7 @@ static void hid_host_notify_interface_connected(hid_device_t *hid_device)
  * @return esp_err_t
  */
 static esp_err_t hid_host_interface_list_create(hid_device_t *hid_device,
-        const usb_config_desc_t *config_desc)
+                                                const usb_config_desc_t *config_desc)
 {
     assert(hid_device);
     assert(config_desc);
@@ -465,9 +465,9 @@ static esp_err_t hid_host_interface_list_create(hid_device_t *hid_device,
                 ep_in_desc = get_iface_ep_in(iface_desc, total_length);
                 if (ep_in_desc) {
                     HID_RETURN_ON_ERROR( hid_host_add_interface(hid_device,
-                                         iface_desc,
-                                         hid_desc,
-                                         ep_in_desc),
+                                                                iface_desc,
+                                                                hid_desc,
+                                                                ep_in_desc),
                                          "Unable to add HID Interface to the RAM list");
                 }
             }
@@ -574,8 +574,8 @@ static void client_event_cb(const usb_host_client_event_msg_t *event, void *arg)
 static esp_err_t hid_host_interface_claim_and_prepare_transfer(hid_iface_t *iface)
 {
     HID_RETURN_ON_ERROR( usb_host_interface_claim( s_hid_driver->client_handle,
-                         iface->parent->dev_hdl,
-                         iface->dev_params.iface_num, 0),
+                                                   iface->parent->dev_hdl,
+                                                   iface->dev_params.iface_num, 0),
                          "Unable to claim Interface");
 
     HID_RETURN_ON_ERROR( usb_host_transfer_alloc(iface->ep_in_mps, 0, &iface->in_xfer),
@@ -602,8 +602,8 @@ static esp_err_t hid_host_interface_release_and_free_transfer(hid_iface_t *iface
                         "Interface handle not found");
 
     HID_RETURN_ON_ERROR( usb_host_interface_release(s_hid_driver->client_handle,
-                         iface->parent->dev_hdl,
-                         iface->dev_params.iface_num),
+                                                    iface->parent->dev_hdl,
+                                                    iface->dev_params.iface_num),
                          "Unable to release HID Interface");
 
     ESP_ERROR_CHECK( usb_host_transfer_free(iface->in_xfer) );
@@ -793,8 +793,8 @@ static esp_err_t usb_class_request_get_descriptor(hid_device_t *hid_device, cons
 
         usb_host_transfer_free(hid_device->ctrl_xfer);
         HID_RETURN_ON_ERROR( usb_host_transfer_alloc(USB_SETUP_PACKET_SIZE + req->wLength,
-                             0,
-                             &hid_device->ctrl_xfer),
+                                                     0,
+                                                     &hid_device->ctrl_xfer),
                              "Unable to allocate transfer buffer for EP0");
     }
 
@@ -955,7 +955,7 @@ static esp_err_t hid_class_request_get(hid_device_t *hid_device,
 
 // ---------------------------- Private ---------------------------------------
 static esp_err_t hid_host_string_descriptor_copy(wchar_t *dest,
-        const usb_str_desc_t *src)
+                                                 const usb_str_desc_t *src)
 {
     if (dest == NULL) {
         return ESP_ERR_INVALID_ARG;
@@ -1028,7 +1028,7 @@ esp_err_t hid_host_uninstall_device(hid_device_t *hid_device)
     HID_RETURN_ON_ERROR( usb_host_transfer_free(hid_device->ctrl_xfer),
                          "Unable to free transfer buffer for EP0");
     HID_RETURN_ON_ERROR( usb_host_device_close(s_hid_driver->client_handle,
-                         hid_device->dev_hdl),
+                                               hid_device->dev_hdl),
                          "Unable to close USB host");
 
     if (hid_device->ctrl_xfer_done) {
@@ -1095,7 +1095,7 @@ esp_err_t hid_host_install(const hid_host_driver_config_t *config)
                       "Unable to create semaphore");
 
     HID_GOTO_ON_ERROR( usb_host_client_register(&client_config,
-                       &driver->client_handle),
+                                                &driver->client_handle),
                        "Unable to register USB Host client");
 
     HID_ENTER_CRITICAL();
@@ -1273,9 +1273,9 @@ esp_err_t hid_host_device_get_params(hid_host_device_handle_t hid_dev_handle,
 }
 
 esp_err_t hid_host_device_get_raw_input_report_data(hid_host_device_handle_t hid_dev_handle,
-        uint8_t *data,
-        size_t data_length_max,
-        size_t *data_length)
+                                                    uint8_t *data,
+                                                    size_t data_length_max,
+                                                    size_t *data_length)
 {
     hid_iface_t *iface = get_iface_by_handle(hid_dev_handle);
 
@@ -1444,7 +1444,7 @@ esp_err_t hid_class_request_get_idle(hid_host_device_handle_t hid_dev_handle,
 }
 
 esp_err_t hid_class_request_get_protocol(hid_host_device_handle_t hid_dev_handle,
-        hid_report_protocol_t *protocol)
+                                         hid_report_protocol_t *protocol)
 {
     hid_iface_t *iface = get_iface_by_handle(hid_dev_handle);
 
@@ -1509,7 +1509,7 @@ esp_err_t hid_class_request_set_idle(hid_host_device_handle_t hid_dev_handle,
 }
 
 esp_err_t hid_class_request_set_protocol(hid_host_device_handle_t hid_dev_handle,
-        hid_report_protocol_t protocol)
+                                         hid_report_protocol_t protocol)
 {
     hid_iface_t *iface = get_iface_by_handle(hid_dev_handle);
 

--- a/host/class/hid/usb_host_hid/include/usb/hid_host.h
+++ b/host/class/hid/usb_host_hid/include/usb/hid_host.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -79,8 +79,8 @@ typedef struct {
  * @param[in] arg         User argument from HID driver configuration structure
 */
 typedef void (*hid_host_driver_event_cb_t)(hid_host_device_handle_t hid_device_handle,
-        const hid_host_driver_event_t event,
-        void *arg);
+                                           const hid_host_driver_event_t event,
+                                           void *arg);
 
 /**
  * @brief USB HID Interface event callback.
@@ -90,8 +90,8 @@ typedef void (*hid_host_driver_event_cb_t)(hid_host_device_handle_t hid_device_h
  * @param[in] arg                   User argument
 */
 typedef void (*hid_host_interface_event_cb_t)(hid_host_device_handle_t hid_device_handle,
-        const hid_host_interface_event_t event,
-        void *arg);
+                                              const hid_host_interface_event_t event,
+                                              void *arg);
 
 // ----------------------------- Public ---------------------------------------
 /**
@@ -183,9 +183,9 @@ esp_err_t hid_host_device_get_params(hid_host_device_handle_t hid_dev_handle,
  * @return esp_err_t
  */
 esp_err_t hid_host_device_get_raw_input_report_data(hid_host_device_handle_t hid_dev_handle,
-        uint8_t *data,
-        size_t data_length_max,
-        size_t *data_length);
+                                                    uint8_t *data,
+                                                    size_t data_length_max,
+                                                    size_t *data_length);
 
 // ------------------------ USB HID Host driver API ----------------------------
 
@@ -267,7 +267,7 @@ esp_err_t hid_class_request_get_idle(hid_host_device_handle_t hid_dev_handle,
  * @return esp_err_t
  */
 esp_err_t hid_class_request_get_protocol(hid_host_device_handle_t hid_dev_handle,
-        hid_report_protocol_t *protocol);
+                                         hid_report_protocol_t *protocol);
 
 /**
 * @brief HID class specific request SET REPORT
@@ -306,7 +306,7 @@ esp_err_t hid_class_request_set_idle(hid_host_device_handle_t hid_dev_handle,
  * @return esp_err_t
  */
 esp_err_t hid_class_request_set_protocol(hid_host_device_handle_t hid_dev_handle,
-        hid_report_protocol_t protocol);
+                                         hid_report_protocol_t protocol);
 
 #ifdef __cplusplus
 }

--- a/host/class/hid/usb_host_hid/test_app/main/test_hid_basic.c
+++ b/host/class/hid/usb_host_hid/test_app/main/test_hid_basic.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -132,9 +132,9 @@ void hid_host_test_interface_callback(hid_host_device_handle_t hid_device_handle
                dev_params.iface_num);
 
         hid_host_device_get_raw_input_report_data(hid_device_handle,
-                data,
-                64,
-                &data_length);
+                                                  data,
+                                                  64,
+                                                  &data_length);
 
         for (int i = 0; i < data_length; i++) {
             printf("%02x ", data[i]);
@@ -220,8 +220,8 @@ void hid_host_test_concurrent(hid_host_device_handle_t hid_device_handle,
 }
 
 void hid_host_test_device_callback_to_queue(hid_host_device_handle_t hid_device_handle,
-        const hid_host_driver_event_t event,
-        void *arg)
+                                            const hid_host_driver_event_t event,
+                                            void *arg)
 {
     const hid_host_test_event_queue_t evt_queue = {
         .hid_device_handle = hid_device_handle,
@@ -269,7 +269,7 @@ void hid_host_test_requests_callback(hid_host_device_handle_t hid_device_handle,
         // // HID Device info
         hid_host_dev_info_t hid_dev_info;
         TEST_ASSERT_EQUAL(ESP_OK, hid_host_get_device_info(hid_device_handle,
-                          &hid_dev_info) );
+                                                           &hid_dev_info) );
 
         printf("\t VID: 0x%04X\n", hid_dev_info.VID);
         printf("\t PID: 0x%04X\n", hid_dev_info.PID);
@@ -282,7 +282,7 @@ void hid_host_test_requests_callback(hid_host_device_handle_t hid_device_handle,
             rep_len = sizeof(tmp);
             // For testing with ESP32 we used ReportID = 0x01 (Keyboard ReportID)
             if (ESP_OK == hid_class_request_get_report(hid_device_handle,
-                    HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len)) {
+                                                       HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len)) {
                 printf("HID Get Report, type %d, id %d, length: %d:\n",
                        HID_REPORT_TYPE_INPUT, 0, rep_len);
                 for (int i = 0; i < rep_len; i++) {
@@ -294,7 +294,7 @@ void hid_host_test_requests_callback(hid_host_device_handle_t hid_device_handle,
             rep_len = sizeof(tmp);
             // For testing with ESP32 we used ReportID = 0x02 (Mouse ReportID)
             if (ESP_OK == hid_class_request_get_report(hid_device_handle,
-                    HID_REPORT_TYPE_INPUT, 0x02, tmp, &rep_len)) {
+                                                       HID_REPORT_TYPE_INPUT, 0x02, tmp, &rep_len)) {
                 printf("HID Get Report, type %d, id %d, length: %d:\n",
                        HID_REPORT_TYPE_INPUT, 0, rep_len);
                 for (int i = 0; i < rep_len; i++) {
@@ -313,19 +313,19 @@ void hid_host_test_requests_callback(hid_host_device_handle_t hid_device_handle,
                 uint8_t idle_rate;
                 // hid_class_request_get_idle
                 if (ESP_OK == hid_class_request_get_idle(hid_device_handle,
-                        0, &idle_rate)) {
+                                                         0, &idle_rate)) {
                     printf("HID idle rate: %d\n", idle_rate);
                 }
                 // hid_class_request_set_idle
                 if (ESP_OK == hid_class_request_set_idle(hid_device_handle,
-                        0, 0)) {
+                                                         0, 0)) {
                     printf("HID idle rate set to 0\n");
                 }
 
                 // hid_class_request_get_report
                 rep_len = sizeof(tmp);
                 if (ESP_OK == hid_class_request_get_report(hid_device_handle,
-                        HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len)) {
+                                                           HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len)) {
                     printf("HID get report type %d, id %d, length: %d\n",
                            HID_REPORT_TYPE_INPUT, 0x00, rep_len);
                 }
@@ -333,7 +333,7 @@ void hid_host_test_requests_callback(hid_host_device_handle_t hid_device_handle,
                 // hid_class_request_set_report
                 uint8_t rep[1] = { 0x00 };
                 if (ESP_OK == hid_class_request_set_report(hid_device_handle,
-                        HID_REPORT_TYPE_OUTPUT, 0x01, rep, 1)) {
+                                                           HID_REPORT_TYPE_OUTPUT, 0x01, rep, 1)) {
                     printf("HID set report type %d, id %d\n", HID_REPORT_TYPE_OUTPUT, 0x00);
                 }
             }
@@ -342,7 +342,7 @@ void hid_host_test_requests_callback(hid_host_device_handle_t hid_device_handle,
                 // hid_class_request_get_report
                 rep_len = sizeof(tmp);
                 if (ESP_OK == hid_class_request_get_report(hid_device_handle,
-                        HID_REPORT_TYPE_INPUT, 0x02, tmp, &rep_len)) {
+                                                           HID_REPORT_TYPE_INPUT, 0x02, tmp, &rep_len)) {
                     printf("HID get report type %d, id %d, length: %d\n",
                            HID_REPORT_TYPE_INPUT, 0x00, rep_len);
                 }
@@ -350,7 +350,7 @@ void hid_host_test_requests_callback(hid_host_device_handle_t hid_device_handle,
 
             // hid_class_request_set_protocol
             if (ESP_OK == hid_class_request_set_protocol(hid_device_handle,
-                    HID_REPORT_PROTOCOL_BOOT)) {
+                                                         HID_REPORT_PROTOCOL_BOOT)) {
                 printf("HID protocol change to BOOT: %d\n", proto);
             }
         }
@@ -405,7 +405,7 @@ static void test_hid_host_device_touch(hid_host_dev_params_t *dev_params,
         // For testing with ESP32 we used ReportID = 0x01 (Keyboard ReportID)
         if (HID_HOST_TEST_TOUCH_WAY_ASSERT == touch_way) {
             TEST_ASSERT_EQUAL(ESP_OK, hid_class_request_get_report(global_hdl,
-                              HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len));
+                                                                   HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len));
         } else {
             hid_class_request_get_report(global_hdl,
                                          HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len);
@@ -419,7 +419,7 @@ static void test_hid_host_device_touch(hid_host_dev_params_t *dev_params,
             rep_len = sizeof(tmp);
             if (HID_HOST_TEST_TOUCH_WAY_ASSERT == touch_way) {
                 TEST_ASSERT_EQUAL(ESP_OK, hid_class_request_get_report(global_hdl,
-                                  HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len));
+                                                                       HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len));
             } else {
                 hid_class_request_get_report(global_hdl,
                                              HID_REPORT_TYPE_INPUT, 0x01, tmp, &rep_len);
@@ -429,7 +429,7 @@ static void test_hid_host_device_touch(hid_host_dev_params_t *dev_params,
             rep_len = sizeof(tmp);
             if (HID_HOST_TEST_TOUCH_WAY_ASSERT == touch_way) {
                 TEST_ASSERT_EQUAL(ESP_OK, hid_class_request_get_report(global_hdl,
-                                  HID_REPORT_TYPE_INPUT, 0x02, tmp, &rep_len));
+                                                                       HID_REPORT_TYPE_INPUT, 0x02, tmp, &rep_len));
             } else {
                 hid_class_request_get_report(global_hdl,
                                              HID_REPORT_TYPE_INPUT, 0x02, tmp, &rep_len);
@@ -555,10 +555,10 @@ void test_hid_setup(hid_host_driver_event_cb_t device_callback,
                     hid_test_event_handle_t hid_test_event_handle)
 {
     TEST_ASSERT_EQUAL(pdTRUE, xTaskCreatePinnedToCore(usb_lib_task,
-                      "usb_events",
-                      4096,
-                      xTaskGetCurrentTaskHandle(),
-                      2, NULL, 0));
+                                                      "usb_events",
+                                                      4096,
+                                                      xTaskGetCurrentTaskHandle(),
+                                                      2, NULL, 0));
     // Wait for notification from usb_lib_task
     ulTaskNotifyTake(false, 1000);
 

--- a/host/class/hid/usb_host_hid/test_app/main/test_hid_err_handling.c
+++ b/host/class/hid/usb_host_hid/test_app/main/test_hid_err_handling.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,8 +25,8 @@
  *
  */
 static void test_hid_host_interface_event_close(hid_host_device_handle_t hid_device_handle,
-        const hid_host_interface_event_t event,
-        void *arg)
+                                                const hid_host_interface_event_t event,
+                                                void *arg)
 {
     switch (event) {
     case HID_HOST_INTERFACE_EVENT_INPUT_REPORT:
@@ -48,8 +48,8 @@ static void test_hid_host_interface_event_close(hid_host_device_handle_t hid_dev
  *
  */
 static void test_hid_host_event_callback_stub(hid_host_device_handle_t hid_device_handle,
-        const hid_host_driver_event_t event,
-        void *arg)
+                                              const hid_host_driver_event_t event,
+                                              void *arg)
 {
     if (event == HID_HOST_DRIVER_EVENT_CONNECTED) {
         // Device connected
@@ -66,8 +66,8 @@ static void test_hid_host_event_callback_stub(hid_host_device_handle_t hid_devic
  *
  */
 static void test_hid_host_event_callback_open(hid_host_device_handle_t hid_device_handle,
-        const hid_host_driver_event_t event,
-        void *arg)
+                                              const hid_host_driver_event_t event,
+                                              void *arg)
 {
     if (event == HID_HOST_DRIVER_EVENT_CONNECTED) {
         const hid_host_device_config_t dev_config = {

--- a/host/class/hid/usb_host_hid/test_app/sdkconfig.defaults
+++ b/host/class/hid/usb_host_hid/test_app/sdkconfig.defaults
@@ -5,8 +5,7 @@ CONFIG_TINYUSB_CDC_COUNT=0
 CONFIG_TINYUSB_HID_COUNT=2
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/host/class/msc/usb_host_msc/test_app/sdkconfig.defaults
+++ b/host/class/msc/usb_host_msc/test_app/sdkconfig.defaults
@@ -5,8 +5,7 @@ CONFIG_TINYUSB_CDC_COUNT=0
 CONFIG_TINYUSB_HID_COUNT=0
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set
 
 # Run-time checks of Heap and Stack
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y

--- a/host/class/uac/usb_host_uac/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register( SRCS "uac_descriptors.c" "uac_host.c"
                         INCLUDE_DIRS "include"
-                        PRIV_REQUIRES usb esp_ringbuf)
+                        PRIV_REQUIRES usb esp_ringbuf )
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/host/class/uac/usb_host_uac/Kconfig
+++ b/host/class/uac/usb_host_uac/Kconfig
@@ -1,5 +1,5 @@
 menu "USB Host UAC"
-    config PRINTF_UAC_CONFIGURATION_DESCRIPTOR
+    config UAC_PRINTF_CONFIGURATION_DESCRIPTOR
         bool "Print UAC Configuration Descriptor"
         default n
         help

--- a/host/class/uac/usb_host_uac/host_test/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/host_test/CMakeLists.txt
@@ -6,7 +6,8 @@ set(COMPONENTS main)
 list(APPEND EXTRA_COMPONENT_DIRS
      "$ENV{IDF_PATH}/tools/mocks/usb/usb_host_full_mock/usb/"    # Full USB Host stack mock (all the layers are mocked)
 
-     # The following line would be needed to include the freertos mock component if this test used mocked FreeRTOS. (missing Ringbuffer mock)
+     # The following line would be needed to include the freertos mock component if this test used mocked FreeRTOS.
+     # Freertos mock for Ringbuffer is missing, thus we can't use the freertos mock
      #"$ENV{IDF_PATH}/tools/mocks/freertos/"
     )
 

--- a/host/class/uac/usb_host_uac/include/usb/uac_host.h
+++ b/host/class/uac/usb_host_uac/include/usb/uac_host.h
@@ -67,7 +67,7 @@ typedef enum {
  * @param[in] arg         User argument from UAC driver configuration structure
 */
 typedef void (*uac_host_driver_event_cb_t)(uint8_t addr, uint8_t iface_num,
-        const uac_host_driver_event_t event, void *arg);
+                                           const uac_host_driver_event_t event, void *arg);
 
 /**
  * @brief USB UAC logic device/interface event callback.
@@ -77,7 +77,7 @@ typedef void (*uac_host_driver_event_cb_t)(uint8_t addr, uint8_t iface_num,
  * @param[in] arg                   User argument
 */
 typedef void (*uac_host_device_event_cb_t)(uac_host_device_handle_t uac_device_handle,
-        const uac_host_device_event_t event, void *arg);
+                                           const uac_host_device_event_t event, void *arg);
 
 /**
  * @brief Interface parameters for USB UAC host class descriptor print callback
@@ -237,7 +237,7 @@ esp_err_t uac_host_device_open(const uac_host_device_config_t *config, uac_host_
  * - ESP_ERR_NOT_FOUND if the device is not found
  */
 esp_err_t uac_host_device_open_with_vid_pid(uint16_t vid, uint16_t pid, const uac_host_device_config_t *config,
-        uac_host_device_handle_t *uac_dev_handle);
+                                            uac_host_device_handle_t *uac_dev_handle);
 
 /**
  * @brief Close a UAC logic device/interface

--- a/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c
+++ b/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c
@@ -236,10 +236,10 @@ void test_uac_setup(void)
     static TaskHandle_t uac_task_handle = NULL;
     // create USB lib task, pass the current task handle to notify when the task is created
     TEST_ASSERT_EQUAL(pdTRUE, xTaskCreatePinnedToCore(usb_lib_task,
-                      "usb_events",
-                      4096,
-                      xTaskGetCurrentTaskHandle(),
-                      5, &uac_task_handle, 0));
+                                                      "usb_events",
+                                                      4096,
+                                                      xTaskGetCurrentTaskHandle(),
+                                                      5, &uac_task_handle, 0));
 
     // install uac host driver
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);

--- a/host/class/uac/usb_host_uac/test_app/sdkconfig.defaults
+++ b/host/class/uac/usb_host_uac/test_app/sdkconfig.defaults
@@ -8,5 +8,4 @@ CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE=2048
 CONFIG_USB_HOST_HW_BUFFER_BIAS_PERIODIC_OUT=y
 
 # Disable watchdogs, they'd get triggered during unity interactive menu
-CONFIG_ESP_INT_WDT=n
-CONFIG_ESP_TASK_WDT=n
+# CONFIG_ESP_TASK_WDT_INIT is not set

--- a/host/class/uvc/usb_host_uvc/Kconfig
+++ b/host/class/uvc/usb_host_uvc/Kconfig
@@ -1,6 +1,6 @@
 menu "USB HOST UVC"
 
-    config PRINTF_UVC_CONFIGURATION_DESCRIPTOR
+    config UVC_PRINTF_CONFIGURATION_DESCRIPTOR
         bool "Print UVC Configuration Descriptor"
         default n
         help

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -121,9 +121,9 @@ static esp_err_t uvc_host_device_connected(uint8_t addr)
 
     // Create UAC interfaces list in RAM, connected to the particular USB dev
     if (is_uvc_device) {
-#ifdef CONFIG_PRINTF_UVC_CONFIGURATION_DESCRIPTOR
+#ifdef CONFIG_UVC_PRINTF_CONFIGURATION_DESCRIPTOR
         usb_print_config_descriptor(config_desc, &uvc_print_desc);
-#endif
+#endif // CONFIG_UVC_PRINTF_CONFIGURATION_DESCRIPTOR
         // Create Interfaces list for a possibility to claim Interface
         ESP_RETURN_ON_ERROR(uvc_host_interface_check(addr, config_desc), TAG, "uvc stream interface not found");
     } else {


### PR DESCRIPTION
## Description

This MR adds pre-commit checks from esp-idf, to ease usb-related code migration from esp-idf to esp-usb.

## Related

Added pre-commit checks from esp-idf pre-commit settings:
- `astyle_py` added `--max-continuation-indent=120` option
- `kconfig` files checks: `check-kconfig-files` and `check-deprecated-kconfig-options`
- Cmake lists checks: `cmake-lint`
- `check-yaml` pre-commit hook

## Testing

Run pre-commit on all files by `pre-commit run --all-files`

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
