### PR TITLE
Update msc_host_vfs.c

### DIFF
--- a/host/class/msc/usb_host_msc/src/msc_host_vfs.c
+++ b/host/class/msc/usb_host_msc/src/msc_host_vfs.c
@@ -122,10 +122,10 @@ fail:
     if (diskio_registered) {
         ff_diskio_unregister(pdrv);
     }
-    esp_vfs_fat_unregister_path(base_path);
     if (fs) {
         f_mount(NULL, drive, 0);
     }
+    esp_vfs_fat_unregister_path(base_path);
     dealloc_msc_vfs(vfs);
     return ret;
 }


### PR DESCRIPTION
Fixed fail section of the msc_host_vfs_register function to prevent a write after free condition.

## Description

esp_vfs_fat_unregister_path(base_path) frees the memory allocated for the fatfs context. f_mount(NULL, drive, 0) depends on the fatfs context in it's call writing 0's in the process. If esp_vfs_fat_unregister_path(base_path) is called before f_mount(NULL, drive, 0) and the device failed to mount but there is a valid fs pointer, then the program will execute a write on freed memory causing heap corruption.

## Related
Fixes #218 - https://github.com/espressif/esp-usb/issues/218


## Testing
Using heap tracing the function can be shown to no longer write to a freed section of memory.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
