### PR TITLE
Add cp210x and ch34x PID autodetection (IEC-354)

### DIFF
--- a/host/class/cdc/usb_host_ch34x_vcp/CHANGELOG.md
+++ b/host/class/cdc/usb_host_ch34x_vcp/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+- Added PID autodetection
+
 ## 2.1.0
 - Added C API
 

--- a/host/class/cdc/usb_host_ch34x_vcp/idf_component.yml
+++ b/host/class/cdc/usb_host_ch34x_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.1.0"
+version: "2.2.0"
 description: USB Host driver for CH34x series of chips
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_ch34x_vcp
 dependencies:

--- a/host/class/cdc/usb_host_ch34x_vcp/include/usb/vcp_ch34x.h
+++ b/host/class/cdc/usb_host_ch34x_vcp/include/usb/vcp_ch34x.h
@@ -14,6 +14,9 @@
 #define CH340_PID_1                (0x7523)
 #define CH341_PID                  (0x5523)
 
+// Auto detect supported PIDs
+#define CH34X_PID_AUTO             (0)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/host/class/cdc/usb_host_ch34x_vcp/usb_host_ch34x_vcp.c
+++ b/host/class/cdc/usb_host_ch34x_vcp/usb_host_ch34x_vcp.c
@@ -196,7 +196,21 @@ static esp_err_t ch34x_line_coding_set(cdc_acm_dev_hdl_t cdc_hdl, const cdc_acm_
 
 esp_err_t ch34x_vcp_open(uint16_t pid, uint8_t interface_idx, const cdc_acm_host_device_config_t *dev_config, cdc_acm_dev_hdl_t *cdc_hdl_ret)
 {
-    esp_err_t ret = cdc_acm_host_open(NANJING_QINHENG_MICROE_VID, pid, interface_idx, dev_config, cdc_hdl_ret);
+    esp_err_t ret;
+    if (pid == CH34X_PID_AUTO) {
+        static const uint16_t supported_pids[] = {CH340_PID, CH340_PID_1, CH341_PID};
+        static const size_t num_pids = sizeof(supported_pids) / sizeof(supported_pids[0]);
+
+        ret = ESP_ERR_NOT_FOUND;
+        for (size_t i = 0; i < num_pids; i++) {
+            ret = cdc_acm_host_open(NANJING_QINHENG_MICROE_VID, supported_pids[i], interface_idx, dev_config, cdc_hdl_ret);
+            if (ret == ESP_OK) {
+                break;
+            }
+        }
+    } else {
+        ret = cdc_acm_host_open(NANJING_QINHENG_MICROE_VID, pid, interface_idx, dev_config, cdc_hdl_ret);
+    }
 
     // Set custom function for this driver
     if (ret == ESP_OK) {

--- a/host/class/cdc/usb_host_cp210x_vcp/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cp210x_vcp/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+- Added PID autodetection
+
 ## 2.1.0
 - Added C API
 

--- a/host/class/cdc/usb_host_cp210x_vcp/idf_component.yml
+++ b/host/class/cdc/usb_host_cp210x_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.1.0"
+version: "2.2.0"
 description: USB Host driver for CP210x series of chips
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_cp210x_vcp
 dependencies:

--- a/host/class/cdc/usb_host_cp210x_vcp/include/usb/vcp_cp210x.h
+++ b/host/class/cdc/usb_host_cp210x_vcp/include/usb/vcp_cp210x.h
@@ -14,6 +14,9 @@
 #define CP2105_PID       (0xEA70) // Dual
 #define CP2108_PID       (0xEA71) // Quad
 
+// Auto detect supported PIDs
+#define CP210X_PID_AUTO  (0)
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This PR adds support for PID autodetection of CP210x and CH34x devices. Feel free to close the PR, just a suggestion.

## Testing

Tested only CP2102 detection in [esp-serial-flasher](https://github.com/espressif/esp-serial-flasher), while adding support to flash through USB-UART converters.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
