### PR TITLE
fix(ci): Fixing build_idf_examples CI run

### DIFF
--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -29,5 +29,9 @@ jobs:
           pip install idf-component-manager>=2.1.2 idf-build-apps==2.4.3 pyyaml  --upgrade
           python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
           cd ${IDF_PATH}
-          idf-build-apps find --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
-          idf-build-apps build --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
+
+          # don't use esp-idf default .idf_build_apps.toml, as it contains configs we don't want to use in following commands
+          # create a dummy config .toml and use it instead
+          touch .dummy.toml
+          idf-build-apps find --config-file .dummy.toml --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
+          idf-build-apps build --config-file .dummy.toml --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w


### PR DESCRIPTION
## Description

Fixing CI run of `Build ESP-IDF USB examples` job, which has been failing for a while on master branch.

<details>
<summary>Build ESP-IDF USB examples CI Job error log</summary>

```
  idf.py build
WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
[Info] Processing app /opt/esp/idf/examples/peripherals/usb/device/tusb_composite_msc_serialdevice
[Info] Processing app /opt/esp/idf/examples/peripherals/usb/device/tusb_console
[Info] Processing app /opt/esp/idf/examples/peripherals/usb/device/tusb_hid
[Info] Processing app /opt/esp/idf/examples/peripherals/usb/device/tusb_midi
[Info] Processing app /opt/esp/idf/examples/peripherals/usb/device/tusb_msc
[Info] Processing app /opt/esp/idf/examples/peripherals/usb/device/tusb_ncm
[Info] Processing app /opt/esp/idf/examples/peripherals/usb/device/tusb_serial_device
Traceback (most recent call last):
  File "/opt/esp/python_env/idf6.0_py3.12_env/bin/idf-build-apps", line 7, in <module>
    sys.exit(main.main())
             ^^^^^^^^^^^
  File "/opt/esp/python_env/idf6.0_py3.12_env/lib/python3.12/site-packages/idf_build_apps/main.py", line 850, in main
Using config file: /opt/esp/idf/.idf_build_apps.toml
    apps = find_apps(args.paths, args.target, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/esp/python_env/idf6.0_py3.12_env/lib/python3.12/site-packages/idf_build_apps/main.py", line 178, in find_apps
    raise ValueError('Only Support "make" and "cmake"')
ValueError: Only Support "make" and "cmake"
```

</details>

Recently a `.idf_build_apps.toml` file was introduced into the `esp-idf` root directory.

In the `build_idf_examples.yml` we are calling `idf-build-apps` from esp-idf root dir `cd ${IDF_PATH}`, the `.idf_build_apps.toml` is picked up automatically. 

The `toml` file was setting some extra paths, which was causing the `idf-build-apps` call to fail together with the extra CLI options we use with the `idf-build-apps` call.

This fix creates a dummy `.idf_build_apps.toml` which is then used as a config file instead of the esp-idf's one.

The CI run of the `build_idf_examples.yml` was disabled due to TinyUSB v 2.0, but this fix fixes the CI on other MRs were this job is not yet disabled.

## Testing

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
