### PR TITLE
fix(esp_tinyusb): Migration guides link in README.md

### DIFF
--- a/device/esp_tinyusb/README.md
+++ b/device/esp_tinyusb/README.md
@@ -53,9 +53,9 @@ Or simply run:
 idf.py add-dependency esp_tinyusb~2.0.0
 ```
 
-## Breaking changes
+## Breaking changes migration guides
 
-- [v2.0.0](https://docs.espressif.com/projects/esp-usb/docs/device/migration-guide/v2)
+- [v2.0.0](/docs/device/migration-guides/v2)
 
 ## USB Device Stack: usage, installation & configuration
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -3,6 +3,10 @@ description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
 version: "2.0.0-rc0"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
+targets:
+  - esp32s2
+  - esp32s3
+  - esp32p4
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:


### PR DESCRIPTION
## Description

1. Fixed link to migration guides v2.0.0
2. Added supported targets in `idf_component.yml `

## Related

- https://github.com/espressif/esp-usb/pull/201

## Testing

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
