### PR TITLE
fix(ci): Re-enable linux host tests for IDF 6.0

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -12,22 +12,19 @@ host/class/uvc/usb_host_uvc/examples/camera_display:
       reason: This example uses esp_lcd API introduced in v5.3
 
 # Host tests
-host/class/cdc/usb_host_cdc_acm/host_test:
+.host_test_enable_rules: &host_test_enable_rules
   enable:
-    - if: IDF_TARGET in ["linux"] and (IDF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 5)
+    - if: IDF_TARGET in ["linux"] and (IDF_VERSION >= "6.0.0")
       reason: USB mocks are run only for the latest version of IDF
+
+host/class/cdc/usb_host_cdc_acm/host_test:
+  <<: *host_test_enable_rules
 
 host/class/hid/usb_host_hid/host_test:
-  enable:
-    - if: IDF_TARGET in ["linux"] and (IDF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 5)
-      reason: USB mocks are run only for the latest version of IDF
+  <<: *host_test_enable_rules
 
 host/class/uvc/usb_host_uvc/host_test:
-  enable:
-    - if: IDF_TARGET in ["linux"] and (IDF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 5)
-      reason: USB mocks are run only for the latest version of IDF
+  <<: *host_test_enable_rules
 
 host/class/uac/usb_host_uac/host_test:
-  enable:
-    - if: IDF_TARGET in ["linux"] and (IDF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 5)
-      reason: USB mocks are run only for the latest version of IDF
+  <<: *host_test_enable_rules


### PR DESCRIPTION
## Description

This MR re-enables Linux host test run in CI. 
Combination of 2 following settings disabled host tests run in CI by accident:

`.build-test-rules.yml`
```yml
host/class/cdc/usb_host_cdc_acm/host_test:
  enable:
    - if: IDF_TARGET in ["linux"] and (IDF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 5)
      reason: USB mocks are run only for the latest version of IDF
```

`.build_and_run_host_test.yml`
```yml
jobs:
...
      matrix:
        idf_ver: ["latest"]
```

Where `DF_VERSION_MAJOR >= 5 and IDF_VERSION_MINOR >= 5` does not satisfy for `IDF Latest` being `IDF 6.0`

<details>
<summary> USB Host test CI log </summary>

```bash
Successfully installed idf-build-apps-2.4.3 iniconfig-2.1.0 pluggy-1.6.0 pytest-8.4.1
Using config file: /__w/esp-usb/esp-usb/.idf_build_apps.toml
Using config file: /__w/esp-usb/esp-usb/.idf_build_apps.toml
All host tests passed.
Post job cleanup.
```

</details>

## Testing

Successful CI run of Host test in another MR.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
