### PR TITLE
feat(usb_host): USB Component overriding in IDF service releases

### DIFF
--- a/.github/ci/.idf-build-examples-rules.yml
+++ b/.github/ci/.idf-build-examples-rules.yml
@@ -1,0 +1,20 @@
+# Manifest file for build_idf_examples.yml CI workflow
+
+# TODO: Uncomment the below lines to run esp-idf USB Device examples in CI. See issue IDF-13618 for tracking.
+#examples/peripherals/usb/device:
+#  disable:
+#    - if: SOC_USB_OTG_SUPPORTED != 1
+
+examples/peripherals/usb/host:
+  enable:
+    - if: (IDF_VERSION >= "5.4.0")
+      reason: Run USB Host examples with overridden (esp-usb) USB component only for service releases
+  disable:
+    - if: SOC_USB_OTG_SUPPORTED != 1
+
+examples/peripherals/usb/host/uvc:
+  enable:
+    - if: (IDF_VERSION >= "5.5.0")
+      reason: Run UVC example starts using UVC driver 2.0 only on IDF version 5.5
+  disable:
+    - if: SOC_USB_OTG_SUPPORTED != 1

--- a/.github/ci/.idf_build_examples_config.toml
+++ b/.github/ci/.idf_build_examples_config.toml
@@ -1,0 +1,15 @@
+# Config file for build_idf_examples.yml workflow
+
+paths = [
+    # TODO: Uncomment the below line to run esp-idf USB Device examples in CI. See issue IDF-13618 for tracking.
+    #"examples/peripherals/usb/device",     # USB Device examples
+    "examples/peripherals/usb/host",        # USB Host examples
+]
+
+recursive = true
+check_warnings = true
+target = "all"
+
+# build related options
+build_dir = "build_@t_@w"
+work_dir = "@f_@t_@w"

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -1,8 +1,6 @@
 name: Build and Run USB Test Application
 
 on:
-  schedule:
-    - cron: '0 0 * * 0' # Every Sunday at midnight
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -1,11 +1,21 @@
+# This workflow builds esp-idf examples:
+#
+#   - usb device examples: with overridden esp_tinyusb from esp-usb/device/esp_tinyusb
+#     - All (service + maintenance IDF releases)
+#
+#   - usb host examples: with overridden usb component from esp-usb/host/usb
+#     - Only service IDF releases
+
 name: Build ESP-IDF USB examples
 
 on:
-  workflow_call: # TODO: Only runs when called explicitly from another workflow. See issue IDF-13618 for tracking.
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:
     strategy:
+      fail-fast: true
       matrix:
         idf_ver:
           [
@@ -18,20 +28,27 @@ jobs:
           ]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
+    env:
+      CONFIG_PATH: ${{ github.workspace }}/.github/ci/.idf_build_examples_config.toml
+      MANIFEST_PATH: ${{ github.workspace }}/.github/ci/.idf-build-examples-rules.yml
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "true"
-      - name: Build ESP-IDF USB examples
+      - name: Install Python deps
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install idf-component-manager>=2.1.2 idf-build-apps==2.4.3 pyyaml  --upgrade
-          python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
+          pip install idf-component-manager>=2.1.2 idf-build-apps==2.4.3 pyyaml --upgrade
+      - name: Build ESP-IDF ${{ matrix.idf_ver }} USB examples
+        shell: bash
+        run: |
+          . ${IDF_PATH}/export.sh
+
+          # TODO: Uncomment the below line to run esp-idf USB Device examples in CI. See issue IDF-13618 for tracking.
+          #python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/*
+          python .github/ci/override_managed_component.py usb host/usb ${IDF_PATH}/examples/peripherals/usb/host/*
           cd ${IDF_PATH}
 
-          # don't use esp-idf default .idf_build_apps.toml, as it contains configs we don't want to use in following commands
-          # create a dummy config .toml and use it instead
-          touch .dummy.toml
-          idf-build-apps find --config-file .dummy.toml --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
-          idf-build-apps build --config-file .dummy.toml --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
+          idf-build-apps find --config-file ${CONFIG_PATH} --manifest-file ${MANIFEST_PATH}
+          idf-build-apps build --config-file ${CONFIG_PATH} --manifest-file ${MANIFEST_PATH}

--- a/host/usb/CMakeLists.txt
+++ b/host/usb/CMakeLists.txt
@@ -17,6 +17,11 @@ if(${target} STREQUAL "esp32p4")
     list(APPEND priv_requires esp_psram)
 endif()
 
+if(${IDF_VERSION_MAJOR} LESS 6)
+    # usb_phy driver is present in USB component only in IDF 5.x
+    list(APPEND priv_requires esp_driver_gpio)      # usb_phy driver relies on gpio driver API
+endif()
+
 if(CONFIG_SOC_USB_OTG_SUPPORTED)
     list(APPEND srcs "src/hcd_dwc.c"
                      "src/enum.c"
@@ -28,6 +33,23 @@ if(CONFIG_SOC_USB_OTG_SUPPORTED)
                      )
     list(APPEND include "include")
     list(APPEND priv_includes "private_include")
+
+    if(${IDF_VERSION_MAJOR} LESS 6)
+        # usb_phy driver is present in USB component only in IDF 5.x
+        # If we want to override usb component from esp-idf with managed usb component from esp-usb, we must provide
+        # usb_phy driver for the managed usb component separately by taking src usb_phy.c and
+        # include esp_private/usb_phy.h from the native usb component in esp-idf
+
+        # Get path to usb component inside esp-idf
+        idf_component_get_property(esp_idf_usb_dir usb COMPONENT_OVERRIDEN_DIR)
+
+        # Explicitly add usb_phy.c and usb_phy.h from overridden usb component in esp-idf
+        list(APPEND srcs "${esp_idf_usb_dir}/usb_phy.c")
+
+        # This append must be under the first "include" append,
+        # so usb_host.h (and the rest of the files in /include/usb/) are used from esp-usb, not from esp-idf
+        list(APPEND include "${esp_idf_usb_dir}/include")
+    endif()
 endif()
 
 if(CONFIG_USB_HOST_HUBS_SUPPORTED)

--- a/host/usb/idf_component.yml
+++ b/host/usb/idf_component.yml
@@ -3,9 +3,10 @@ description: USB Host library
 version: "1.0.0-rc0"
 url: https://github.com/espressif/esp-usb/tree/master/host/usb
 dependencies:
-  idf: ">=6.0"
+  idf: ">=5.4"
 targets:
   - esp32s2
   - esp32s3
   - esp32p4
+  - esp32h4
   - linux

--- a/host/usb/src/hcd_dwc.c
+++ b/host/usb/src/hcd_dwc.c
@@ -18,7 +18,6 @@
 #include "esp_log.h"
 
 #include "soc/soc_caps.h"
-#include "soc/usb_periph.h"
 #include "hal/usb_dwc_hal.h"
 #include "hcd.h"
 #include "usb_private.h"
@@ -26,6 +25,14 @@
 
 #include "esp_cache.h"
 #include "esp_private/esp_cache_private.h"
+
+#include "esp_idf_version.h"
+// For USB PHY Compatibility in IDF 5.x
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+#include "soc/usb_dwc_periph.h"
+#else
+#include "soc/usb_periph.h"
+#endif
 
 // ----------------------------------------------------- Macros --------------------------------------------------------
 

--- a/host/usb/src/usb_host.c
+++ b/host/usb/src/usb_host.c
@@ -17,7 +17,6 @@ Warning: The USB Host Library API is still a beta version and may be subject to 
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "esp_private/critical_section.h"
-#include "soc/usb_periph.h"
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
@@ -28,6 +27,14 @@ Warning: The USB Host Library API is still a beta version and may be subject to 
 #include "hcd.h"
 #include "esp_private/usb_phy.h"
 #include "usb/usb_host.h"
+
+#include "esp_idf_version.h"
+// For USB PHY Compatibility in IDF 5.x
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+#include "soc/usb_dwc_periph.h"
+#else
+#include "soc/usb_periph.h"
+#endif
 
 DEFINE_CRIT_SECTION_LOCK_STATIC(host_lock);
 #define HOST_ENTER_CRITICAL_ISR()       esp_os_enter_critical_isr(&host_lock)


### PR DESCRIPTION
## Description

This MR adds support for usb component overriding.
In case users want to use the managed `usb` component  from `esp-usb` instead of the native `usb` component present in `esp-idf v5.x` service release. 

- USB component overriding is only possible in IDF Service releases: `IDF 5.4 and IDF 5.5`
- Run esp-idf host examples in CI with the current usb component

## CI tests run in this MR

- `build_idf_examples.yml` only built `USB Device` examples from `esp-idf` with overriden version of `esp_tinyusb` component
- the workflow is extended to run `USB Host` examples with the overridden `usb` component from `esp-usb/host/usb/`

#### USB from esp-idf
- USB Component: esp-idf USB located in `esp-idf/components/usb`
- USB Mocks: esp-idf USB Mocks in `esp-idf/tools/mocks/usb`

| IDF    | Class Tests        | USB Component tests| idf examples (host)| esp-usb examples   | All linux tests    |
|--------|--------------------|--------------------|--------------------|--------------------|--------------------|
| latest | :x:                | :x:                | :x:                | :x:                | :x:                |
| 5.5    | :heavy_check_mark: | :x: | :x:                | :heavy_check_mark: | :x:                |
| 5.4    | :heavy_check_mark: | :x: | :x:                | :heavy_check_mark: | :x:                |
| 5.3    | :heavy_check_mark: | :x: | :x:                | :heavy_check_mark: | :x:                |
| 5.2    | :heavy_check_mark: | :x: | :x:                | :x:                | :x:                |
| 5.1    | :heavy_check_mark: | :x: | :x:                | :x:                | :x:                |

*note: no tests using esp-idf USB component will be run on IDF Latest (in future), because there will not be USB component in esp-idf anymore

#### USB from esp-usb
- USB Component: esp-usb USB located in `esp-usb/host/usb/`
- USB Mocks: esp-usb USB Mocks in `esp-usb/host/usb/test/mocks`

| IDF    | Class Tests        | USB Component tests| idf examples (host)| esp-usb examples   | All linux tests    |
|--------|--------------------|--------------------|--------------------|--------------------|--------------------|
| latest | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: :new:                | :heavy_check_mark: | :heavy_check_mark: |
| 5.5    | :soon:                | :soon:                | :heavy_check_mark: :new:                | :soon:                | :x:                |
| 5.4    | :soon:                | :soon:                | :heavy_check_mark: :new:                | :soon:                | :x:                |
| 5.3    | :x:                | :x:                | :x:                | :x:                | :x:                |
| 5.2    | :x:                | :x:                | :x:                | :x:                | :x:                |
| 5.1    | :x:                | :x:                | :x:                | :x:                | :x:                |

*note: IDF 5.0 is EOL, thus removed from CI run.

Tests explanation:
- Class tests: `esp-usb/host/class/**/test_app`
- USB Component tests: `esp-usb/host/usb/test/target_test`
- IDF examples (host): `esp-idf/examples/usb/host/*`
- All linux tests:
    - Class Linux tests: `esp-usb/host/class/**/host_test`
    - USB Component Linux tests: `esp-usb/host/usb/test/host_test`


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
