### PR TITLE
refactor(tinyusb_net): Added deinit API

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -9,6 +9,8 @@
 - esp_tinyusb: Added run-time configuration for peripheral port selection, task settings, and descriptors. For more details, refer to the [Espressif's Addition to TinyUSB Mirgation guide v2](/docs/device/migration-guides/v2/tinyusb.md)
 - esp_tinyusb: Added USB Device event callback to handle different USB Device events. For the list of supported USB Device events, refer to to [Espressif's Addition to TinyUSB - README](/device/esp_tinyusb/README.md)
 - esp_tinyusb: Removed configuration option to handle TinyUSB events outside of this driver
+- NCM: Added possibility to deinit the driver
+- NCM: Updated public API; refer to the [NCM Class Migration guide v2](/docs/device/migration-guides/v2/tinyusb_ncm.md)
 - MSC: Removed dedicated callbacks; introduced a single callback with an event ID for each storage
 - MSC: Added storage format support
 - MSC: Added dual storage support (SPI/Flash and SD/MMC)

--- a/device/esp_tinyusb/include/tinyusb_net.h
+++ b/device/esp_tinyusb/include/tinyusb_net.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <stdint.h>
-#include "tinyusb_types.h"
 #include "esp_err.h"
 #include "sdkconfig.h"
 
@@ -52,11 +51,15 @@ typedef struct {
 /**
  * @brief Initialize TinyUSB NET driver
  *
- * @param[in] usb_dev USB device to use
  * @param[in] cfg     Configuration of the driver
  * @return esp_err_t
  */
-esp_err_t tinyusb_net_init(tinyusb_usbdev_t usb_dev, const tinyusb_net_config_t *cfg);
+esp_err_t tinyusb_net_init(const tinyusb_net_config_t *cfg);
+
+/**
+ * @brief Deinitialize TinyUSB NET driver
+ */
+void tinyusb_net_deinit(void);
 
 /**
  * @brief TinyUSB NET driver send data synchronously

--- a/device/esp_tinyusb/test_apps/ncm/CMakeLists.txt
+++ b/device/esp_tinyusb/test_apps/ncm/CMakeLists.txt
@@ -1,0 +1,9 @@
+# The following lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# "Trim" the build. Include the minimal set of components, main, and anything it depends on.
+idf_build_set_property(MINIMAL_BUILD ON)
+
+project(test_app_ncm)

--- a/device/esp_tinyusb/test_apps/ncm/main/CMakeLists.txt
+++ b/device/esp_tinyusb/test_apps/ncm/main/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRC_DIRS .
+                       INCLUDE_DIRS .
+                       REQUIRES unity
+                       WHOLE_ARCHIVE)

--- a/device/esp_tinyusb/test_apps/ncm/main/device_common.c
+++ b/device/esp_tinyusb/test_apps/ncm/main/device_common.c
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+//
+#include <stdio.h>
+#include <string.h>
+//
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+//
+#include "esp_system.h"
+#include "esp_log.h"
+#include "esp_err.h"
+//
+#include "unity.h"
+#include "tinyusb.h"
+
+static SemaphoreHandle_t wait_mount = NULL;
+
+#define TUSB_DEVICE_DELAY_MS        5000
+
+void test_device_setup(void)
+{
+    wait_mount = xSemaphoreCreateBinary();
+    TEST_ASSERT_NOT_NULL(wait_mount);
+}
+
+void test_device_release(void)
+{
+    TEST_ASSERT_NOT_NULL(wait_mount);
+    vSemaphoreDelete(wait_mount);
+}
+
+void test_device_wait(void)
+{
+    // Wait for tud_mount_cb() to be called
+    TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(wait_mount, pdMS_TO_TICKS(TUSB_DEVICE_DELAY_MS)), "No tusb_mount_cb() in time");
+    // Delay to allow finish the enumeration
+    // Disable this delay could lead to potential race conditions when the tud_task() is pinned to another CPU
+    vTaskDelay(pdMS_TO_TICKS(250));
+}
+
+/**
+ * @brief TinyUSB callback for device mount.
+ *
+ * @note
+ * For Linux-based Hosts: Reflects the SetConfiguration() request from the Host Driver.
+ * For Win-based Hosts: SetConfiguration() request is present only with available Class in device descriptor.
+ */
+void test_device_event_handler(tinyusb_event_t *event, void *arg)
+{
+    switch (event->id) {
+    case TINYUSB_EVENT_ATTACHED:
+        xSemaphoreGive(wait_mount);
+        break;
+    case TINYUSB_EVENT_DETACHED:
+        break;
+    default:
+        break;
+    }
+}
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/ncm/main/device_common.h
+++ b/device/esp_tinyusb/test_apps/ncm/main/device_common.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "tinyusb.h"
+
+/**
+ * @brief Test device setup
+ */
+void test_device_setup(void);
+
+/**
+ * @brief Test device release
+ */
+void test_device_release(void);
+
+/**
+ * @brief Test device wait
+ *
+ * Waits the tusb_mount_cb() which indicates the device connected to the Host and enumerated.
+ */
+void test_device_wait(void);
+
+/**
+ * @brief TinyUSB callback for device mount.
+ *
+ * @note
+ * For Linux-based Hosts: Reflects the SetConfiguration() request from the Host Driver.
+ * For Win-based Hosts: SetConfiguration() request is present only with available Class in device descriptor.
+ */
+void test_device_event_handler(tinyusb_event_t *event, void *arg);

--- a/device/esp_tinyusb/test_apps/ncm/main/idf_component.yml
+++ b/device/esp_tinyusb/test_apps/ncm/main/idf_component.yml
@@ -1,0 +1,5 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/esp_tinyusb:
+    version: "*"
+    override_path: "../../../"

--- a/device/esp_tinyusb/test_apps/ncm/main/test_app_main.c
+++ b/device/esp_tinyusb/test_apps/ncm/main/test_app_main.c
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "unity.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "unity_test_runner.h"
+#include "unity_test_utils_memory.h"
+#include "device_common.h"
+
+/* setUp runs before every test */
+void setUp(void)
+{
+    unity_utils_record_free_mem();
+    test_device_setup();
+}
+
+/* tearDown runs after every test */
+void tearDown(void)
+{
+    // Short delay to allow task to be cleaned up
+    vTaskDelay(10);
+    test_device_release();
+    unity_utils_evaluate_leaks();
+}
+
+
+void app_main(void)
+{
+    /*
+                     _   _                       _
+                    | | (_)                     | |
+      ___  ___ _ __ | |_ _ _ __  _   _ _   _ ___| |__
+     / _ \/ __| '_ \| __| | '_ \| | | | | | / __| '_ \
+    |  __/\__ \ |_) | |_| | | | | |_| | |_| \__ \ |_) |
+     \___||___/ .__/ \__|_|_| |_|\__, |\__,_|___/_.__/
+              | |______           __/ |
+              |_|______|         |___/
+      _____ _____ _____ _____
+     |_   _|  ___/  ___|_   _|
+      | | | |__ \ `--.  | |
+      | | |  __| `--. \ | |
+      | | | |___/\__/ / | |
+      \_/ \____/\____/  \_/
+    */
+
+    printf("                 _   _                       _     \n");
+    printf("                | | (_)                     | |    \n");
+    printf("  ___  ___ _ __ | |_ _ _ __  _   _ _   _ ___| |__  \n");
+    printf(" / _ \\/ __| '_ \\| __| | '_ \\| | | | | | / __| '_ \\ \n");
+    printf("|  __/\\__ \\ |_) | |_| | | | | |_| | |_| \\__ \\ |_) |\n");
+    printf(" \\___||___/ .__/ \\__|_|_| |_|\\__, |\\__,_|___/_.__/ \n");
+    printf("          | |______           __/ |               \n");
+    printf("          |_|______|         |___/                \n");
+    printf(" _____ _____ _____ _____                           \n");
+    printf("|_   _|  ___/  ___|_   _|                          \n");
+    printf("  | | | |__ \\ `--.  | |                            \n");
+    printf("  | | |  __| `--. \\ | |                            \n");
+    printf("  | | | |___/\\__/ / | |                            \n");
+    printf("  \\_/ \\____/\\____/  \\_/                            \n");
+
+    unity_utils_setup_heap_record(80);
+    unity_utils_set_leak_level(128);
+    unity_run_menu();
+}

--- a/device/esp_tinyusb/test_apps/ncm/main/test_ncm.c
+++ b/device/esp_tinyusb/test_apps/ncm/main/test_ncm.c
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+//
+#include <stdio.h>
+#include <string.h>
+//
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+//
+#include "esp_system.h"
+#include "esp_log.h"
+#include "esp_err.h"
+//
+#include "unity.h"
+#include "device_common.h"
+#include "tinyusb.h"
+#include "tinyusb_default_config.h"
+#include "tinyusb_net.h"
+
+//
+// ========================== Test Configuration Parameters =====================================
+//
+
+#define TEST_DEVICE_PRESENCE_TIMEOUT_MS     5000 // Timeout for checking device presence
+
+//
+// ========================== TinyUSB General Device Descriptors ===============================
+//
+
+
+//
+// ============================= TinyUSB NCM Initialization Tests =============================
+//
+
+static esp_err_t usb_recv_callback(void *buffer, uint16_t len, void *ctx)
+{
+    return ESP_OK;
+}
+
+static void wifi_pkt_free(void *eb, void *ctx)
+{
+
+}
+
+/**
+ * @brief Test case for installing TinyUSB NCM driver
+ *
+ * Scenario:
+ * 1. Install TinyUSB NCM.
+ * 3. Wait for the device to be recognized.
+ * 4. Uninstall TinyUSB driver and deinitialize the NCM driver.
+ */
+TEST_CASE("NCM: driver install & uninstall", "[ci][driver]")
+{
+    tinyusb_net_config_t net_config = {
+        .on_recv_callback = usb_recv_callback,
+        .free_tx_buffer = wifi_pkt_free,
+        .user_context = NULL,
+    };
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, tinyusb_net_init(&net_config), "Failed to initialize TinyUSB NCM driver");
+
+    // Install TinyUSB driver
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+    test_device_wait();
+    // Allow some time for the device to be recognized
+    vTaskDelay(pdMS_TO_TICKS(TEST_DEVICE_PRESENCE_TIMEOUT_MS));
+
+    tinyusb_net_deinit();
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+}
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/ncm/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/ncm/sdkconfig.defaults
@@ -1,0 +1,15 @@
+# Configure TinyUSB, it will be used to mock USB devices
+CONFIG_TINYUSB_NET_MODE_NCM=y
+
+# Disable watchdogs, they'd get triggered during unity interactive menu
+CONFIG_ESP_INT_WDT=n
+CONFIG_ESP_TASK_WDT=n
+
+# Run-time checks of Heap and Stack
+CONFIG_HEAP_POISONING_COMPREHENSIVE=y
+CONFIG_COMPILER_STACK_CHECK_MODE_STRONG=y
+CONFIG_COMPILER_STACK_CHECK=y
+
+CONFIG_UNITY_ENABLE_BACKTRACE_ON_FAIL=y
+
+CONFIG_COMPILER_CXX_EXCEPTIONS=y

--- a/device/esp_tinyusb/tinyusb_net.c
+++ b/device/esp_tinyusb/tinyusb_net.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -118,10 +118,8 @@ esp_err_t tinyusb_net_send_sync(void *buffer, uint16_t len, void *buff_free_arg,
     return ESP_ERR_TIMEOUT;
 }
 
-esp_err_t tinyusb_net_init(tinyusb_usbdev_t usb_dev, const tinyusb_net_config_t *cfg)
+esp_err_t tinyusb_net_init(const tinyusb_net_config_t *cfg)
 {
-    (void) usb_dev;
-
     ESP_RETURN_ON_FALSE(s_net_obj.initialized == false, ESP_ERR_INVALID_STATE, TAG, "TinyUSB Net class is already initialized");
 
     // the semaphore and event flags are initialized only if needed
@@ -140,6 +138,25 @@ esp_err_t tinyusb_net_init(tinyusb_usbdev_t usb_dev, const tinyusb_net_config_t 
     s_net_obj.initialized = true;
 
     return ESP_OK;
+}
+
+void tinyusb_net_deinit(void)
+{
+    if (s_net_obj.buffer_sema) {
+        vSemaphoreDelete(s_net_obj.buffer_sema);
+        s_net_obj.buffer_sema = NULL;
+    }
+    if (s_net_obj.tx_flags) {
+        vEventGroupDelete(s_net_obj.tx_flags);
+        s_net_obj.tx_flags = NULL;
+    }
+    s_net_obj.initialized = false;
+    s_net_obj.rx_cb = NULL;
+    s_net_obj.init_cb = NULL;
+    s_net_obj.tx_buff_free_cb = NULL;
+    s_net_obj.ctx = NULL;
+    s_net_obj.packet_to_send = NULL;
+    memset(s_net_obj.mac_str, 0, sizeof(s_net_obj.mac_str));
 }
 
 //--------------------------------------------------------------------+

--- a/docs/device/migration-guides/v2/tinyusb_ncm.md
+++ b/docs/device/migration-guides/v2/tinyusb_ncm.md
@@ -1,0 +1,66 @@
+# Migration guide to Espressif's TinyUSB addition: NCM
+
+## 1. Do I need to migrate?
+
+Update brings the consistency for the Espressif's TinyUSB addition extensions public API.
+
+## 2. Changes Required After Migration
+
+Update the function prototype of the NCM driver initialization.
+
+## 3. List of Changes
+
+### API Updates
+
+The following function prototypes have been updated:
+
+| Old Function Prototype                                                                 | New Function Prototype                                      |
+|----------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| `esp_err_t tinyusb_net_init(tinyusb_usbdev_t usb_dev, const tinyusb_net_config_t *cfg)` | `esp_err_t tinyusb_net_init(const tinyusb_net_config_t *cfg)` |
+
+Update your code to use the new function names as shown above.
+
+
+## 4. Common Migration Errors and Solutions
+
+**Possible error**
+
+```bash
+error: 'TINYUSB_USBDEV_0' undeclared (first use in this function)
+```
+
+**How to fix?**
+
+`TINYUSB_USBDEV_0` was removed.
+Please, update your code:
+
+```c
+    tinyusb_net_init(TINYUSB_USBDEV_0, &net_config);
+```
+
+to:
+
+```c
+    tinyusb_net_init(&net_config);
+```
+
+**Possible error**
+
+```bash
+error: too many arguments to function 'tinyusb_net_init'; expected 1, have 2
+```
+
+**How to fix?**
+
+TINYUSB_USBDEV_0 was removed.
+Please, update your code:
+
+```c
+    tinyusb_net_init(TINYUSB_USBDEV_0, &net_config);
+```
+
+to:
+
+```c
+    tinyusb_net_init(&net_config);
+```


### PR DESCRIPTION
## Description

Added `tinyusb_net_deinit()` public API call.

Based on the review comment: https://github.com/espressif/esp-usb/pull/201#discussion_r2266941849

## Related

- Closes IEC-352

## Testing

- Added test case to init and deinit TinyUSB NCM driver and verify memory leakage.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
