### PR TITLE
fix(esp_tinyusb): Remove usb component private requirement for idf v6 (v1)

### DIFF
--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -33,5 +33,9 @@ jobs:
           pip install idf-component-manager>=2.1.2 idf-build-apps==2.4.3 pyyaml  --upgrade
           python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
           cd ${IDF_PATH}
-          idf-build-apps find --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
-          idf-build-apps build --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
+
+          # don't use esp-idf default .idf_build_apps.toml, as it contains configs we don't want to use in following commands
+          # create a dummy config .toml and use it instead
+          touch .dummy.toml
+          idf-build-apps find --config-file .dummy.toml --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w
+          idf-build-apps build --config-file .dummy.toml --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml --build-dir build_@t_@w --work-dir @f_@t_@w

--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.6~2 [Unreleased]
+
+- esp_tinyusb: Added support for IDF 6.0 after removal of the USB component
+
 ## 1.7.6~1
 
 - esp_tinyusb: Added documentation to README.md

--- a/device/esp_tinyusb/CMakeLists.txt
+++ b/device/esp_tinyusb/CMakeLists.txt
@@ -4,6 +4,12 @@ set(srcs
     "usb_descriptors.c"
     )
 
+set(priv_req "")
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND priv_req "usb")
+endif()
+
 if(NOT CONFIG_TINYUSB_NO_DEFAULT_TASK)
     list(APPEND srcs "tusb_tasks.c")
 endif() # CONFIG_TINYUSB_NO_DEFAULT_TASK
@@ -36,7 +42,7 @@ endif() # CONFIG_TINYUSB_NET_MODE_NCM
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"
                        PRIV_INCLUDE_DIRS "include_private"
-                       PRIV_REQUIRES usb
+                       PRIV_REQUIRES ${priv_req}
                        REQUIRES fatfs vfs
                        )
 


### PR DESCRIPTION
## Description

Removed usb component dependency for esp-idf v6 and greater. 
For esp-idf major version less than 6, the private requirement of usb component (from esp-idf) is being set. 

### Additional changes

- Cherry-picked https://github.com/espressif/esp-usb/pull/231

## Related

- Relates to IDF-14022

## Testing

N/A

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
