### PR TITLE
fix(esp_tinyusb): Remove usb component private requirement for idf v6 (v2)

### DIFF
--- a/device/esp_tinyusb/CMakeLists.txt
+++ b/device/esp_tinyusb/CMakeLists.txt
@@ -5,6 +5,12 @@ set(srcs
     "tinyusb_task.c"
     )
 
+set(priv_req "")
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND priv_req "usb")
+endif()
+
 if(CONFIG_TINYUSB_CDC_ENABLED)
     list(APPEND srcs
         "cdc.c"
@@ -40,7 +46,7 @@ endif() # CONFIG_TINYUSB_NET_MODE_NCM
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"
                        PRIV_INCLUDE_DIRS "include_private"
-                       PRIV_REQUIRES usb
+                       PRIV_REQUIRES ${priv_req}
                        REQUIRES fatfs vfs
                        )
 


### PR DESCRIPTION
## Description

Applying the logic from https://github.com/espressif/esp-usb/pull/243 for v2.0.0 release. 

## Related

N/A

## Testing

N/A

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
