### PR TITLE
feat(usb_host): Class test component overriding

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -8,10 +8,11 @@ host/class:
 
 host/usb:
   enable:
-    - if: SOC_USB_OTG_SUPPORTED == 1
+    - if: SOC_USB_OTG_SUPPORTED == 1 and ENV_VAR_USB_COMP_MANAGED == "yes"
+      reason: USB Component tests with native USB component are already running in esp-idf CI
   disable:
-    - if: IDF_VERSION < "6.0.0"
-      reason: In 1st phase of USB component deployment, we will run USB Component tests only on IDF master with USB component from esp-usb
+    - if: IDF_VERSION < "5.4.0"
+      reason: We will support component overriding only in service releases
 
 host/class/uvc/usb_host_uvc/examples/camera_display:
   enable:

--- a/.github/workflows/build_and_run_main_ci.yml
+++ b/.github/workflows/build_and_run_main_ci.yml
@@ -1,0 +1,23 @@
+# This is the main workflow for:
+#
+#   - build_and_run_test_app_usb.yml
+#
+# It triggers reusable workflows with input arguments
+
+name: Build and Run Test apps
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+# Cancel previous runs of this workflow for the same PR when a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build_run:
+    uses: ./.github/workflows/build_and_run_test_app_usb.yml
+    with:
+      idf_releases: '["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]'
+      idf_targets: '["esp32s2", "esp32p4"]'

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -1,15 +1,53 @@
+# This is a reusable workflow which builds and runs target tests:
+#
+#   - device
+#     - esp_tinyusb test apps -> runner tag: usb_device
+#   - host
+#     - class drivers test apps -> runner tag: usb_host
+#     - class driver examples -> only build
+
 name: Build and Run USB Test Application
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+  workflow_call:
+    inputs:
+      idf_releases:
+        description: 'The JSON array of idf releases to build and run'
+        required: true
+        type: string
+      idf_targets:
+        description: 'The JSON array of targets for target runners'
+        required: true
+        type: string
 
 jobs:
   build:
-    name: Build USB TestApps
+    name: Build USB apps
     strategy:
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
+        idf_ver: ${{ fromJson(inputs.idf_releases) }}
+        test_app: ["device", "host_native", "host_managed"]
+        include:
+          # Add build paths
+          - test_app: device
+            path: device/esp_tinyusb
+            usb_comp_managed: "no"  # For the completeness
+          - test_app: host_native
+            path: host
+            usb_comp_managed: "no"
+          - test_app: host_managed
+            path: host
+            usb_comp_managed: "yes"
+        exclude:
+          # Exclude using managed usb component for older releases, only with service releases
+          - test_app: host_managed
+            idf_ver: "release-v5.1"
+          - test_app: host_managed
+            idf_ver: "release-v5.2"
+          - test_app: host_managed
+            idf_ver: "release-v5.3"
+          # TODO: Exclude native usb component for IDF Latest, once the USB component is removed from the esp-idf Jira issue IDF-14051
+
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
@@ -25,11 +63,13 @@ jobs:
           export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
           export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
           export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
-          idf-build-apps find
-          idf-build-apps build
+          export ENV_VAR_USB_COMP_MANAGED=${{ matrix.usb_comp_managed }}
+
+          idf-build-apps find --paths ${{ matrix.path }}
+          idf-build-apps build --paths ${{ matrix.path }}
       - uses: actions/upload-artifact@v4
         with:
-          name: usb_test_app_bin_${{ matrix.idf_ver }}
+          name: usb_${{ matrix.test_app }}_test_app_bin_${{ matrix.idf_ver }}
           path: |
             **/test_app*/**/build_esp*/bootloader/bootloader.bin
             **/test_app*/**/build_esp*/partition_table/partition-table.bin
@@ -39,21 +79,37 @@ jobs:
             **/test_app*/**/build_esp*/config/sdkconfig.json
           if-no-files-found: error
 
-  run-target:
-    name: Run USB Host and Device TestApps on target
+  run:
+    name: Run TestApps on target
     if: ${{ github.repository_owner == 'espressif' }}
     needs: build
     strategy:
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
-        idf_target: ["esp32s2", "esp32p4"]
-        runner_tag: ["usb_host", "usb_device"]
+        idf_ver: ${{ fromJson(inputs.idf_releases) }}
+        idf_target: ${{ fromJson(inputs.idf_targets) }}
+        test_app: ["device", "host_native", "host_managed"]
+        include:
+          # Link runner tag with test_app
+          - test_app: device
+            runner_tag: "usb_device"
+          - test_app: host_native
+            runner_tag: "usb_host"
+          - test_app: host_managed
+            runner_tag: "usb_host"
         exclude:
           # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
           - idf_ver: "release-v5.1"
             idf_target: "esp32p4"
           - idf_ver: "release-v5.2"
             idf_target: "esp32p4"
+          # Exclude using managed usb component for older releases, only with service releases
+          - test_app: host_managed
+            idf_ver: "release-v5.1"
+          - test_app: host_managed
+            idf_ver: "release-v5.2"
+          - test_app: host_managed
+            idf_ver: "release-v5.3"
+          # TODO: Exclude native usb component for IDF Latest, once the USB component is removed from the esp-idf: Jira issue IDF-14051
 
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
     container:
@@ -63,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: usb_test_app_bin_${{ matrix.idf_ver }}
+          name: usb_${{ matrix.test_app }}_test_app_bin_${{ matrix.idf_ver }}
       - name: ⚙️ Install System tools
         run: |
           apt update

--- a/docs/host/usb_host_lib/usb_component_manual_selection.md
+++ b/docs/host/usb_host_lib/usb_component_manual_selection.md
@@ -1,0 +1,57 @@
+# Explicitly selecting USB Host component
+
+If USB component is set as dependency in a `idf_component.yml` file, the component manager chooses the `usb` component automatically
+
+```yml
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/usb:
+    version: "*"
+```
+
+A test application, or an example can be explicitly built with:
+- a managed USB host component from [esp-usb](../../../host/usb/) (this repository)
+- a native USB component included in [esp-idf](https://github.com/espressif/esp-idf/tree/release/v5.5/components/usb)
+
+In some test apps and examples, within this repository, the selection is done manually to support CI builds with both USB components.
+
+An example of a `idf_component.yml` file with manual `usb` component selection:
+
+```yml
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/usb:
+    version: "*"
+    override_path: "../../../../../usb"
+    rules:
+      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+```
+
+The component selection is done by the environment variable `ENV_VAR_USB_COMP_MANAGED`, which must be explicitly set to `yes` or `no` before building. If the variable is not exported, the build will fail with an error similar to:
+
+```bash
+ERROR: Environment variable "ENV_VAR_USB_COMP_MANAGED" is not set
+```
+
+Note that the managed USB component can only be used with service [ESP-IDF](https://github.com/espressif/esp-idf?tab=readme-ov-file#esp-idf-release-support-schedule) releases
+
+| `ENV_VAR_USB_COMP_MANAGED` | USB Component used      | Note                        |
+| -------------------------- | ----------------------- | --------------------------- |
+| `yes`                      | managed `USB` component | Requires `IDF 5.4` or later |
+| `no`                       | native `USB` component  | Requires `IDF 5.x`          |
+
+### Exporting the environmental variable
+
+``` bash
+# Linux/macOS (lasts only in the current terminal session)
+export ENV_VAR_USB_COMP_MANAGED=yes
+idf.py set-target esp32s3 build
+
+# Windows (PowerShell, lasts only in the current terminal session)
+set ENV_VAR_USB_COMP_MANAGED=yes
+idf.py set-target esp32s3 build
+
+# Windows (PowerShell, persistent across sessions)
+setx ENV_VAR_USB_COMP_MANAGED yes
+
+```

--- a/host/class/cdc/usb_host_cdc_acm/test_app/README.md
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/README.md
@@ -13,3 +13,7 @@ This test requires two ESP32 development board with USB-OTG support. The develop
 one acting as host running CDC-ACM host driver and another CDC-ACM device driver (tinyusb).
 
 This test expects that TinyUSB dual CDC device with VID = 0x303A and PID = 0x4002 is connected to the USB host.
+
+## Selecting the USB Component
+
+To manually select which USB Component shall be used to build this test application, please refer to the following documentation page: [Manual USB component selection](../../../../../docs/host/usb_host_lib/usb_component_manual_selection.md).

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/idf_component.yml
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/idf_component.yml
@@ -13,8 +13,9 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../usb"
-    rules:
-      - if: "idf_version >=6.0" # Override native esp-idf/usb component only for 6.0 and above
+    rules:                                    # Both if clauses must be fulfilled to override the component
+      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
 
   # Following components are not needed, but this way we at least built them in CI
   espressif/esp_modem_usb_dte:

--- a/host/class/hid/usb_host_hid/test_app/README.md
+++ b/host/class/hid/usb_host_hid/test_app/README.md
@@ -11,3 +11,7 @@ Basic functionality such as HID device install/uninstall, class specific request
 
 This test requires two ESP32 development board with USB-OTG support. The development boards shall have interconnected USB peripherals,
 one acting as host running HID host driver and another HID device driver (tinyusb).
+
+## Selecting the USB Component
+
+To manually select which USB Component shall be used to build this test application, please refer to the following documentation page: [Manual USB component selection](../../../../../docs/host/usb_host_lib/usb_component_manual_selection.md).

--- a/host/class/hid/usb_host_hid/test_app/main/idf_component.yml
+++ b/host/class/hid/usb_host_hid/test_app/main/idf_component.yml
@@ -13,5 +13,6 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../usb"
-    rules:
-      - if: "idf_version >=6.0" # Override native esp-idf/usb component only for 6.0 and above
+    rules:                                      # Both if clauses must be fulfilled to override the component
+      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above

--- a/host/class/msc/usb_host_msc/test_app/README.md
+++ b/host/class/msc/usb_host_msc/test_app/README.md
@@ -12,3 +12,7 @@ raw access to MSC device and sudden disconnect is tested.
 
 This test requires two ESP32 development board with USB-OTG support. The development boards shall have interconnected USB peripherals,
 one acting as host running MSC host driver and another MSC device driver (tinyusb).
+
+## Selecting the USB Component
+
+To manually select which USB Component shall be used to build this test application, please refer to the following documentation page: [Manual USB component selection](../../../../../docs/host/usb_host_lib/usb_component_manual_selection.md).

--- a/host/class/msc/usb_host_msc/test_app/main/idf_component.yml
+++ b/host/class/msc/usb_host_msc/test_app/main/idf_component.yml
@@ -13,5 +13,6 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../usb"
-    rules:
-      - if: "idf_version >=6.0" # Override native esp-idf/usb component only for 6.0 and above
+    rules:                                      # Both if clauses must be fulfilled to override the component
+      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above

--- a/host/class/uac/usb_host_uac/test_app/README.md
+++ b/host/class/uac/usb_host_uac/test_app/README.md
@@ -1,4 +1,8 @@
-| Supported Targets | ESP32-S2 | ESP32-S3 |
-| ----------------- | -------- | -------- |
+| Supported Targets | ESP32-S2 | ESP32-S3 | ESP32-P4 |
+| ----------------- | -------- | -------- | -------- |
 
 # USB: UAC Class test application
+
+## Selecting the USB Component
+
+To manually select which USB Component shall be used to build this test application, please refer to the following documentation page: [Manual USB component selection](../../../../../docs/host/usb_host_lib/usb_component_manual_selection.md).

--- a/host/class/uac/usb_host_uac/test_app/main/idf_component.yml
+++ b/host/class/uac/usb_host_uac/test_app/main/idf_component.yml
@@ -8,5 +8,6 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../usb"
-    rules:
-      - if: "idf_version >=6.0" # Override native esp-idf/usb component only for 6.0 and above
+    rules:                                      # Both if clauses must be fulfilled to override the component
+      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above

--- a/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/README.md
+++ b/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/README.md
@@ -1,0 +1,8 @@
+| Supported Targets | ESP32-S2 | ESP32-S3 | ESP32-P4 |
+| ----------------- | -------- | -------- | -------- |
+
+# UVC driver example: Video stream
+
+## Selecting the USB Component
+
+To manually select which USB Component shall be used to build this example, please refer to the following documentation page: [Manual USB component selection](../../../../../../docs/host/usb_host_lib/usb_component_manual_selection.md).

--- a/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/idf_component.yml
@@ -7,5 +7,6 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../../usb"
-    rules:
-      - if: "idf_version >=6.0" # Override native esp-idf/usb component only for 6.0 and above
+    rules:                                      # Both if clauses must be fulfilled to override the component
+      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above

--- a/host/class/uvc/usb_host_uvc/examples/camera_display/README.md
+++ b/host/class/uvc/usb_host_uvc/examples/camera_display/README.md
@@ -1,0 +1,8 @@
+| Supported Targets | ESP32-S2 | ESP32-S3 | ESP32-P4 |
+| ----------------- | -------- | -------- | -------- |
+
+# UVC driver example: Camera and display
+
+## Selecting the USB Component
+
+To manually select which USB Component shall be used to build this example, please refer to the following documentation page: [Manual USB component selection](../../../../../../docs/host/usb_host_lib/usb_component_manual_selection.md).

--- a/host/class/uvc/usb_host_uvc/examples/camera_display/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/examples/camera_display/main/idf_component.yml
@@ -9,5 +9,6 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../../usb"
-    rules:
-      - if: "idf_version >=6.0" # Override native esp-idf/usb component only for 6.0 and above
+    rules:                                      # Both if clauses must be fulfilled to override the component
+      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above

--- a/host/class/uvc/usb_host_uvc/test_app/README.md
+++ b/host/class/uvc/usb_host_uvc/test_app/README.md
@@ -11,3 +11,7 @@ Target tests for USB Host UVC driver.
 
 A USB camera and USB enabled ESP SoC is needed. Connect the camera to USB host port on ESP.
 Format negotiation results are tested against values from Logitech C270 camera. These constants must be modified if different camera is used.
+
+## Selecting the USB Component
+
+To manually select which USB Component shall be used to build this test application, please refer to the following documentation page: [Manual USB component selection](../../../../../docs/host/usb_host_lib/usb_component_manual_selection.md).

--- a/host/class/uvc/usb_host_uvc/test_app/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/test_app/main/idf_component.yml
@@ -8,5 +8,6 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../usb"
-    rules:
-      - if: "idf_version >=6.0" # Override native esp-idf/usb component only for 6.0 and above
+    rules:                                      # Both if clauses must be fulfilled to override the component
+      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above

--- a/host/usb/README.md
+++ b/host/usb/README.md
@@ -1,6 +1,7 @@
 # USB Host Library
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb/badge.svg)](https://components.espressif.com/components/espressif/usb)
+![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 This directory contains an implementation of a USB Host Library [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
 

--- a/host/usb/test/target_test/common/idf_component.yml
+++ b/host/usb/test/target_test/common/idf_component.yml
@@ -3,5 +3,5 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../usb"
-    rules:
-      - if: "idf_version >=6.0" # Override native esp-idf/usb component only for 6.0 and above
+    matches:
+      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above


### PR DESCRIPTION
## Description

This MR enables managed USB component, to be used:
- In USB Host class drivers tests
- UVC Host Examples

## Environmental variable

Controlling which USB Component (esp-idf, or esp-usb) is used in CI Build is done using [environmental variable](https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/manifest_file.html#environment-variables) in the `idf_component.yml` file of each test app, or example.

The environmental variable `ENV_VAR_USB_COMP_MANAGED` must be exported to either `yes` or `no` prior to the test app build in both, the CI run or a local test app run.

In case the env. variable is not exported, the `idf.py set-target` command fails.
Even though, the test app build now requires one extra step, this is currently the only option how to control overriding of component in `idf_component.yml` file. 

## CI tests run in this MR

#### USB from esp-idf
- USB Component: esp-idf USB located in `esp-idf/components/usb`
- USB Mocks: esp-idf USB Mocks in `esp-idf/tools/mocks/usb`

| IDF    | Class Tests        | USB Component tests| idf examples (host)| esp-usb examples   | All linux tests    |
|--------|--------------------|--------------------|--------------------|--------------------|--------------------|
| latest | :x:                | :x:                | :x:                | :x:                | :x:                |
| 5.5    | :heavy_check_mark: | :x: | :x:                | :heavy_check_mark: | :x:                |
| 5.4    | :heavy_check_mark: | :x: | :x:                | :heavy_check_mark: | :x:                |
| 5.3    | :heavy_check_mark: | :x: | :x:                | :heavy_check_mark: | :x:                |
| 5.2    | :heavy_check_mark: | :x: | :x:                | :x:                | :x:                |
| 5.1    | :heavy_check_mark: | :x: | :x:                | :x:                | :x:                |

*note: no tests using esp-idf USB component will be run on IDF Latest (in future), because there will not be USB component in esp-idf anymore

#### USB from esp-usb
- USB Component: esp-usb USB located in `esp-usb/host/usb/`
- USB Mocks: esp-usb USB Mocks in `esp-usb/host/usb/test/mocks`

| IDF    | Class Tests        | USB Component tests| idf examples (host)| esp-usb examples   | All linux tests    |
|--------|--------------------|--------------------|--------------------|--------------------|--------------------|
| latest | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:                | :heavy_check_mark: | :heavy_check_mark: |
| 5.5    | :heavy_check_mark: :new:                | :heavy_check_mark: :new:                | :heavy_check_mark:                | :heavy_check_mark: :new:                | :x:                |
| 5.4    | :heavy_check_mark: :new:                | :heavy_check_mark: :new:                | :heavy_check_mark:                | :heavy_check_mark: :new:                | :x:                |
| 5.3    | :x:                | :x:                | :x:                | :x:                | :x:                |
| 5.2    | :x:                | :x:                | :x:                | :x:                | :x:                |
| 5.1    | :x:                | :x:                | :x:                | :x:                | :x:                |

*note: IDF 5.0 is EOL, thus removed from CI run.

Tests explanation:
- Class tests: `esp-usb/host/class/**/test_app`
- USB Component tests: `esp-usb/host/usb/test/target_test`
- IDF examples (host): `esp-idf/examples/usb/host/*`
- All linux tests:
    - Class Linux tests: `esp-usb/host/class/**/host_test`
    - USB Component Linux tests: `esp-usb/host/usb/test/host_test`

## Related

- Closes IDF-14053 Run USB Host tests in esp-usb CI with managed USB Component
- Relates to IDF-13476  Migrate usb host component from esp-idf to esp-usb

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
