### PR TITLE
feat(ci): Run target tests on usb_host_flash_disk runners

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -71,12 +71,12 @@ jobs:
         with:
           name: usb_${{ matrix.test_app }}_test_app_bin_${{ matrix.idf_ver }}
           path: |
-            **/test_app*/**/build_esp*/bootloader/bootloader.bin
-            **/test_app*/**/build_esp*/partition_table/partition-table.bin
-            **/test_app*/**/build_esp*/test_app_*.bin
-            **/test_app*/**/build_esp*/test_app_*.elf
-            **/test_app*/**/build_esp*/flasher_args.json
-            **/test_app*/**/build_esp*/config/sdkconfig.json
+            **/build_esp*/bootloader/bootloader.bin
+            **/build_esp*/partition_table/partition-table.bin
+            **/build_esp*/test_app_*.bin
+            **/build_esp*/test_app_*.elf
+            **/build_esp*/flasher_args.json
+            **/build_esp*/config/sdkconfig.json
           if-no-files-found: error
 
   run:
@@ -88,15 +88,20 @@ jobs:
         idf_ver: ${{ fromJson(inputs.idf_releases) }}
         idf_target: ${{ fromJson(inputs.idf_targets) }}
         test_app: ["device", "host_native", "host_managed"]
-        include:
-          # Link runner tag with test_app
-          - test_app: device
-            runner_tag: "usb_device"
-          - test_app: host_native
-            runner_tag: "usb_host"
-          - test_app: host_managed
-            runner_tag: "usb_host"
+        runner_tag: ["usb_device", "usb_host", "usb_host_flash_disk"]
+
         exclude:
+          # Exclude runner_tag <-> test_app combinations
+          - test_app: device
+            runner_tag: usb_host
+          - test_app: device
+            runner_tag: usb_host_flash_disk
+          - test_app: host_native
+            runner_tag: usb_device
+          - test_app: host_native
+            runner_tag: usb_host_flash_disk
+          - test_app: host_managed
+            runner_tag: usb_device
           # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
           - idf_ver: "release-v5.1"
             idf_target: "esp32p4"

--- a/host/usb/test/target_test/hcd/pytest_usb_hcd.py
+++ b/host/usb/test/target_test/hcd/pytest_usb_hcd.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: CC0-1.0
+
 import pytest
-from pytest_embedded import Dut
-from pytest_embedded_idf.utils import idf_parametrize
+from pytest_embedded_idf.dut import IdfDut
 
-
-# No runner usb_host_flash_disk yet, skip this test in CI
+@pytest.mark.esp32s2
+@pytest.mark.esp32s3
+@pytest.mark.esp32p4
 @pytest.mark.usb_host_flash_disk
 
 # No build for different configs yet, leaving this commented out
@@ -14,9 +15,9 @@ from pytest_embedded_idf.utils import idf_parametrize
 #    [('default', 'esp32s2'), ('default', 'esp32s3'), ('default', 'esp32p4'), ('esp32p4_psram', 'esp32p4')],
 #    indirect=['config', 'target'],
 #)
+#@idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
 
-@idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
-def test_usb_hcd(dut: Dut) -> None:
+def test_usb_hcd(dut: IdfDut) -> None:
     if dut.target == 'esp32p4':
         dut.run_all_single_board_cases(group='high_speed', reset=True)
     else:

--- a/host/usb/test/target_test/usb_host/pytest_usb_host.py
+++ b/host/usb/test/target_test/usb_host/pytest_usb_host.py
@@ -1,14 +1,18 @@
 # SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: CC0-1.0
+
 import pytest
-from pytest_embedded import Dut
-from pytest_embedded_idf.utils import idf_parametrize
+from pytest_embedded_idf.dut import IdfDut
 
-
-# No runner usb_host_flash_disk yet, skip this test in CI
+@pytest.mark.esp32s2
+@pytest.mark.esp32s3
+@pytest.mark.esp32p4
 @pytest.mark.usb_host_flash_disk
-@idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
-def test_usb_host(dut: Dut) -> None:
+
+# Skip the idf parametrize for now, keep this commented
+#@idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
+
+def test_usb_host(dut: IdfDut) -> None:
     if dut.target == 'esp32p4':
         dut.run_all_single_board_cases(group='high_speed', reset=True)
     else:


### PR DESCRIPTION
## Description

New `usb_host_flash_disk` runners were added to the `esp-usb` ci setup, allowing us to run USB Component target tests.
- BrnoRPIG015 `esp32p4` `usb_host_flash_disk`
- BrnoRPIG017 `esp32s2` `usb_host_flash_disk`

## Related

- closes IDF-14057: Add new target runners to esp-usb CI workflow

## Testing


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
