### PR TITLE
feat(h4): Add ESP32-H4 support in esp-usb

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.0.1 [unreleased]
 
+- esp_tinyusb: Added ESP32H4 support
 - esp_tinyusb: Fixed an assertion failure on the GetOtherSpeedDescriptor() request for ESP32P4 when the OTG1.1 port is used
 
 ## 2.0.0

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -98,9 +98,9 @@ menu "TinyUSB Stack"
         config TINYUSB_MSC_BUFSIZE
             depends on TINYUSB_MSC_ENABLED
             int "MSC FIFO size"
-            default 512 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+            default 512 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32H4
             default 8192 if IDF_TARGET_ESP32P4
-            range 64 8192 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+            range 64 8192 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32H4
             range 64 32768 if IDF_TARGET_ESP32P4
             help
                 MSC FIFO size, in bytes.

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -7,6 +7,7 @@ targets:
   - esp32s2
   - esp32s3
   - esp32p4
+  - esp32h4
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:


### PR DESCRIPTION
# feat(h4): add ESP32-H4 support in esp-usb

This PR enables **ESP32-H4** as a supported target in `esp-usb` with FS-appropriate defaults. It pairs with the TinyUSB PR that adds H4 support to the DCD path.

## What’s in here

- **Kconfig**
  - Treat H4 like S2/S3 (Full-Speed):
    `TINYUSB_MSC_BUFSIZE` default **512**, range **64..8192**
    (`IDF_TARGET_ESP32H4` added alongside S2/S3)
- **Component manifest**
  - `idf_component.yml`: add `esp32h4` to `targets`

_No behavior change for other targets;

## Related / Depends on

- **TinyUSB PR (Espressif fork):** Add ESP32-H4 support  
  espressif/tinyusb PR #<59> (branch `feat/tinyusb_esp32h4_support`)

> esp-usb builds/tests for H4 should be run after (or with) the TinyUSB H4 PR so the DCD is available.

## Why

- H4 is a FS-only SoC similar to S2/S3 for USB OTG usage. Reusing the same defaults keeps memory usage modest while providing solid MSC/CDC performance.

## How to use (quick start)

- Build any esp-usb example for target `esp32h4`; it should enumerate on the **pins** on the pinheader, not the usb connector.

## Testing done

- Build & run `esp-usb` examples on **ESP32-H4** with TinyUSB H4:
  - MSC: enumerates; read/write OK
- Sanity checks on S2/S3/P4 builds (no regressions)

## Known limitations / notes

- On current H4 bring-up boards, use the **header DP/DM** pins (not the on-board device connector) until board routing/straps are updated.
- If your board has both a **debug** (USB-Serial-JTAG) and a **device** (OTG) connection, ensure the device connection is routed to OTG DP/DM and has proper CC resistors (for USB-C).

## Files touched

- `device/esp_tinyusb/Kconfig`
- `device/esp_tinyusb/idf_component.yml`
- `device\esp_tinyusb\CHANGELOG.md`