### PR TITLE
feat(esp_tinyusb): Added suspend resume handling, possibilty to wake up Host

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1 [unreleased]
+
+- esp_tinyusb: Added TINYUSB_EVENT_SUSPENDED and TINYUSB_EVENT_RESUMED events
+- esp_tinyusb: Added public API to wake up the Host (via Remote Wakeup)
+
 ## 2.0.0
 
 - esp_tinyusb: Added USB Compliance Verification results

--- a/device/esp_tinyusb/include/tinyusb.h
+++ b/device/esp_tinyusb/include/tinyusb.h
@@ -105,6 +105,8 @@ typedef struct {
 typedef enum {
     TINYUSB_EVENT_ATTACHED,             /*!< USB device attached to the Host */
     TINYUSB_EVENT_DETACHED,             /*!< USB device detached from the Host */
+    TINYUSB_EVENT_SUSPENDED,            /*!< USB device suspended */
+    TINYUSB_EVENT_RESUMED,              /*!< USB device resumed */
 } tinyusb_event_id_t;
 
 /**
@@ -172,6 +174,17 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config);
  * @retval ESP_OK Uninstall driver, tinyusb stack and USB PHY successfully
  */
 esp_err_t tinyusb_driver_uninstall(void);
+
+/**
+ * @brief Send a remote wakeup signal to the USB host
+ *
+ * @note This function can be called only when the device is suspended and the host has enabled remote wakeup.
+ *
+ * @retval ESP_ERR_INVALID_STATE Remote wakeup is not enabled by the host
+ * @retval ESP_FAIL Remote wakeup request failed
+ * @retval ESP_OK Remote wakeup request sent successfully
+ */
+esp_err_t tinyusb_remote_wakeup(void);
 
 #ifdef __cplusplus
 }

--- a/docs/device/migration-guides/v2/tinyusb.md
+++ b/docs/device/migration-guides/v2/tinyusb.md
@@ -38,6 +38,12 @@ void device_event_handler(tinyusb_event_t *event, void *arg)
     case TINYUSB_EVENT_DETACHED:
         // Device has been detached from the USB Host
         break;
+    case TINYUSB_EVENT_SUSPENDED:
+        // Device has been suspended by the USB Host
+        break;
+    case TINYUSB_EVENT_RESUMED:
+        // Device has been resumed by the USB Host
+        break;
     default:
         break;
     }
@@ -424,7 +430,7 @@ config.port = TINYUSB_PORT_FULL_SPEED_0;
 **Possible error**
 
 ```bash
-multiple definition of `tud_umount_cb'; esp-idf/main/libmain.a(tusb_hid_example_main.c.obj):/esp-idf/examples/peripherals/usb/device/tusb_hid/main/tusb_hid_example_main.c:162: first defined here
+multiple definition of `tud_umount_cb'; esp-idf/main/libmain.a(tusb_hid_example_main.c.obj):/esp-idf/examples/peripherals/usb/device/tusb_hid/main/tusb_hid_example_main.c:156: first defined here
 collect2: error: ld returned 1 exit status
 ```
 
@@ -435,9 +441,29 @@ multiple definition of `tud_mount_cb'; esp-idf/main/libmain.a(tusb_hid_example_m
 collect2: error: ld returned 1 exit status
 ```
 
+or
+
+```bash
+multiple definition of `tud_suspend_cb'; esp-idf/main/libmain.a(tusb_hid_example_main.c.obj):/esp-idf/examples/peripherals/usb/device/tusb_hid/main/tusb_hid_example_main.c:156: first defined here
+collect2: error: ld returned 1 exit status
+```
+
+or
+
+```bash
+multiple definition of `tud_resume_cb'; esp-idf/main/libmain.a(tusb_hid_example_main.c.obj):/esp-idf/examples/peripherals/usb/device/tusb_hid/main/tusb_hid_example_main.c:156: first defined here
+collect2: error: ld returned 1 exit status
+```
+
 **How to fix**
 
-The `tud_mount_cb()` and `tud_umount_cb()` callbacks are now handled internally. To handle attach and detach events in your application, use the USB Device Event callback (`tinyusb_config_t::event_cb`).
+The following callbacks are now handled internally:
+- `tud_mount_cb()`
+- `tud_umount_cb()`
+- `tud_suspend_cb(bool remote_wakeup_en)`
+- `tud_resume_cb()`
+
+To handle such events in your application, use the USB Device Event callback (`tinyusb_config_t::event_cb`).
 
 Update your code from:
 
@@ -450,6 +476,16 @@ void tud_mount_cb(void)
 void tud_umount_cb(void)
 {
     ESP_LOGI(TAG, "USB device detached from the Host");
+}
+
+void tud_suspend_cb(bool remote_wakeup_en)
+{
+    ESP_LOGI(TAG, "USB device suspended, remote_wakeup_en=%d", remote_wakeup_en);
+}
+
+void tud_resume_cb(void)
+{
+    ESP_LOGI(TAG, "USB device resumed");
 }
 
 void main(void)
@@ -470,6 +506,12 @@ void device_event_handler(tinyusb_event_t *event, void *arg)
         break;
     case TINYUSB_EVENT_DETACHED:
         ESP_LOGI(TAG, "USB device detached from the Host");
+        break;
+    case TINYUSB_EVENT_SUSPENDED:
+        ESP_LOGI(TAG, "USB device suspended, remote_wakeup_en=%d", event->suspended.remote_wakeup);
+        break;
+    case TINYUSB_EVENT_RESUMED:
+        ESP_LOGI(TAG, "USB device resumed");
         break;
     default:
         break;


### PR DESCRIPTION
## Description

Wrapper to TinyUSB callbacks to enable the remote waking up the Host (when enabled).

Added handling of two callbacks: 
- `tusb_suspend_cb()`
- `tusb_resume_cb()`

Added public events: 
- `TINYUSB_EVENT_SUSPENDED`
- `TINYUSB_EVENT_RESUMED`

Added public API: 
- `tinyusb_remote_wakeup() `

## Related

- 

## Testing

N/A

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
