### PR TITLE
fix(esp_tinyusb): Make migration link absolute

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -6,17 +6,17 @@
 ### Breaking changes
 
 - esp_tinyusb: External PHY is no longer initialized automatically. If an external PHY is required, it must be explicitly initialized by the user with configuration parameter `phy.skip_setup = true`
-- esp_tinyusb: Added run-time configuration for peripheral port selection, task settings, and descriptors. For more details, refer to the [Espressif's Addition to TinyUSB Mirgation guide v2](/docs/device/migration-guides/v2/tinyusb.md)
-- esp_tinyusb: Added USB Device event callback to handle different USB Device events. For the list of supported USB Device events, refer to to [Espressif's Addition to TinyUSB - README](/device/esp_tinyusb/README.md)
+- esp_tinyusb: Added run-time configuration for peripheral port selection, task settings, and descriptors. For more details, refer to the [Espressif's Addition to TinyUSB Mirgation guide v2](../../docs/device/migration-guides/v2/tinyusb.md)
+- esp_tinyusb: Added USB Device event callback to handle different USB Device events. For the list of supported USB Device events, refer to to [Espressif's Addition to TinyUSB - README](../esp_tinyusb/README.md)
 - esp_tinyusb: Removed configuration option to handle TinyUSB events outside of this driver
 - NCM: Added possibility to deinit the driver
-- NCM: Updated public API; refer to the [NCM Class Migration guide v2](/docs/device/migration-guides/v2/tinyusb_ncm.md)
+- NCM: Updated public API; refer to the [NCM Class Migration guide v2](../../docs/device/migration-guides/v2/tinyusb_ncm.md)
 - MSC: Removed dedicated callbacks; introduced a single callback with an event ID for each storage
 - MSC: Added storage format support
 - MSC: Added dual storage support (SPI/Flash and SD/MMC)
-- MSC: Updated public API; refer to the [MSC Class Migration guide v2](/docs/device/migration-guides/v2/tinyusb_msc.md)
-- Console: Updated public API; refer to the [Console Class Migration guide v2](/docs/device/migration-guides/v2/tinyusb_console.md)
-- CDC-ACM: Updated public API; refer to the [CDC-ACM Class Migration guide v2](/docs/device/migration-guides/v2/tinyusb_cdc_acm.md)
+- MSC: Updated public API; refer to the [MSC Class Migration guide v2](../../docs/device/migration-guides/v2/tinyusb_msc.md)
+- Console: Updated public API; refer to the [Console Class Migration guide v2](../../docs/device/migration-guides/v2/tinyusb_console.md)
+- CDC-ACM: Updated public API; refer to the [CDC-ACM Class Migration guide v2](../../docs/device/migration-guides/v2/tinyusb_cdc_acm.md)
 
 ## 1.7.6~1
 

--- a/device/esp_tinyusb/README.md
+++ b/device/esp_tinyusb/README.md
@@ -55,7 +55,7 @@ idf.py add-dependency esp_tinyusb~2.0.0
 
 ## Breaking changes migration guides
 
-- [v2.0.0](/docs/device/migration-guides/v2)
+- [v2.0.0](../../docs/device/migration-guides/v2/)
 
 ## USB Device Stack: usage, installation & configuration
 


### PR DESCRIPTION
## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

Use absolute link to the migration guide for esp_tinyusb v2.0.0

## Related

- Closes https://github.com/espressif/esp-usb/issues/253

## Testing

N/A

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
