### PR TITLE
fix(usb_host): Fix clang tidy security warnings

### DIFF
--- a/host/usb/src/enum.c
+++ b/host/usb/src/enum.c
@@ -733,7 +733,6 @@ static esp_err_t control_request(enum_stage_t stage)
         control_request_string(stage);
         break;
     default:    // Should never occur
-        ret = ESP_ERR_INVALID_STATE;
         abort();
         break;
     }
@@ -832,7 +831,6 @@ static esp_err_t control_response_handling(enum_stage_t stage)
         break;
     default:
         // Should never occurred
-        ret = ESP_ERR_INVALID_STATE;
         abort();
         break;
     }

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -43,6 +43,7 @@ implement the bare minimum to control the root HCD port.
  * @brief Hub driver action flags
  */
 typedef enum {
+    HUB_DRIVER_ACTION_NONE                = 0,
     HUB_DRIVER_ACTION_ROOT_EVENT          = (1 << 0),
     HUB_DRIVER_ACTION_ROOT_REQ            = (1 << 1),
 #if ENABLE_USB_HUBS
@@ -835,7 +836,7 @@ esp_err_t hub_process(void)
 {
     HUB_DRIVER_ENTER_CRITICAL();
     uint32_t action_flags = p_hub_driver_obj->dynamic.flags.actions;
-    p_hub_driver_obj->dynamic.flags.actions = 0;
+    p_hub_driver_obj->dynamic.flags.actions = HUB_DRIVER_ACTION_NONE;
     HUB_DRIVER_EXIT_CRITICAL();
 
     while (action_flags) {
@@ -856,7 +857,7 @@ esp_err_t hub_process(void)
 
         HUB_DRIVER_ENTER_CRITICAL();
         action_flags = p_hub_driver_obj->dynamic.flags.actions;
-        p_hub_driver_obj->dynamic.flags.actions = 0;
+        p_hub_driver_obj->dynamic.flags.actions = HUB_DRIVER_ACTION_NONE;
         HUB_DRIVER_EXIT_CRITICAL();
     }
 


### PR DESCRIPTION
## Description

Fixing clang tidy security warnings in the USB component introduced by #223 

## Related

- fixes #223 

## Warnings fixed

- [Value stored to 'ret' is never read [clang-analyzer-deadcode.DeadStores]](https://github.com/espressif/esp-usb/security/code-scanning/1591)
- [Value stored to 'ret' is never read [clang-analyzer-deadcode.DeadStores]](https://github.com/espressif/esp-usb/security/code-scanning/1592)
- [The value '0' provided to the cast expression is not in the valid range of values for the enum [clang-analyzer-optin.core.EnumCastOutOfRange]](https://github.com/espressif/esp-usb/security/code-scanning/1590)
- [The value '0' provided to the cast expression is not in the valid range of values for the enum [clang-analyzer-optin.core.EnumCastOutOfRange]](https://github.com/espressif/esp-usb/security/code-scanning/1589)
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
