### PR TITLE
refactor: Use esp_vfs_fat_register_cfg instead of esp_vfs_fat_register (IEC-381)

### DIFF
--- a/device/esp_tinyusb/tinyusb_msc.c
+++ b/device/esp_tinyusb/tinyusb_msc.c
@@ -363,7 +363,17 @@ esp_err_t msc_storage_mount(msc_storage_obj_t *storage)
     ESP_GOTO_ON_ERROR(storage->medium->mount(pdrv), fail, TAG, "Failed pdrv=%d", pdrv);
 
     char drv[3] = {(char)('0' + pdrv), ':', 0};
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    esp_vfs_fat_conf_t conf = {
+        .base_path = base_path,
+        .fat_drive = drv,
+        .max_files = max_files,
+    };
+    ret = esp_vfs_fat_register_cfg(&conf, &fs);
+#else
     ret = esp_vfs_fat_register(base_path, drv, max_files, &fs);
+#endif
     if (ret == ESP_ERR_INVALID_STATE) {
         ESP_LOGD(TAG, "VFS FAT already registered");
     } else if (ret != ESP_OK) {

--- a/host/class/msc/usb_host_msc/src/msc_host_vfs.c
+++ b/host/class/msc/usb_host_msc/src/msc_host_vfs.c
@@ -101,7 +101,16 @@ esp_err_t msc_host_vfs_register(msc_host_device_handle_t device,
     MSC_GOTO_ON_FALSE( vfs->base_path = strdup(base_path), ESP_ERR_NO_MEM );
     vfs->pdrv = pdrv;
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    esp_vfs_fat_conf_t conf = {
+        .base_path = base_path,
+        .fat_drive = drive,
+        .max_files = mount_config->max_files,
+    };
+    MSC_GOTO_ON_ERROR( esp_vfs_fat_register_cfg(&conf, &fs) );
+#else
     MSC_GOTO_ON_ERROR( esp_vfs_fat_register(base_path, drive, mount_config->max_files, &fs) );
+#endif
 
     FRESULT fresult = f_mount(fs, drive, 1);
 


### PR DESCRIPTION
## Description

The original `esp_vfs_fat_register` function prototype is getting changed for `esp_vfs_fat_register_cfg` in IDF v6.0 (breaking change), so `esp_vfs_fat_register_cfg` and `esp_vfs_fat_register` will be the same. `esp_vfs_fat_register_cfg` function will stay as an alias for `esp_vfs_fat_register` for now.

`esp_vfs_fat_register_cfg` is used everywhere in the IDF right now.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
