### PR TITLE
fix(test_apps): Added two attempts of waiting for tud_connect_cb()

### DIFF
--- a/device/esp_tinyusb/test_apps/msc_storage/main/device_common.c
+++ b/device/esp_tinyusb/test_apps/msc_storage/main/device_common.c
@@ -40,8 +40,12 @@ void test_device_release(void)
 
 void test_device_wait(void)
 {
-    // Wait for tud_mount_cb() to be called
-    TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(wait_mount, pdMS_TO_TICKS(TUSB_DEVICE_DELAY_MS)), "No tusb_mount_cb() in time");
+    // Wait for tud_mount_cb() to be called (first timeout)
+    if (xSemaphoreTake(wait_mount, pdMS_TO_TICKS(TUSB_DEVICE_DELAY_MS)) != pdTRUE) {
+        ESP_LOGW("device timeout!", "Device did not appear in first %d ms, waiting again...", TUSB_DEVICE_DELAY_MS);
+        // Wait for the second timeout
+        TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(wait_mount, pdMS_TO_TICKS(TUSB_DEVICE_DELAY_MS)), "No tusb_mount_cb() after second timeout");
+    }
     // Delay to allow finish the enumeration
     // Disable this delay could lead to potential race conditions when the tud_task() is pinned to another CPU
     vTaskDelay(pdMS_TO_TICKS(250));


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

In some cases, `tud_mount_cb()` is not called within 5000 ms. (For example: https://github.com/espressif/esp-usb/actions/runs/17772807754/job/50515316959?pr=255#step:7:923)

As the reason is unknown, the warning debug output was added if the first iteration of waiting ended with negative result. 

Changed the logic to the two iterations of device connection callback waiting: 
1. Wait for 5000 ms
2. If yes, goto 6.
3. If no, wait another 5000 ms
4. If yes, goto 6.
5. If no - abort the test with error
6. Proceed the test

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

- Relates to https://github.com/espressif/esp-usb/pull/258
- Relates to https://github.com/espressif/esp-usb/pull/255

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
