### PR TITLE
feat(ci): Re-enable USB Device examples build in CI

### DIFF
--- a/.github/ci/.idf-build-examples-rules.yml
+++ b/.github/ci/.idf-build-examples-rules.yml
@@ -1,9 +1,18 @@
 # Manifest file for build_idf_examples.yml CI workflow
 
-# TODO: Uncomment the below lines to run esp-idf USB Device examples in CI. See issue IDF-13618 for tracking.
-#examples/peripherals/usb/device:
-#  disable:
-#    - if: SOC_USB_OTG_SUPPORTED != 1
+examples/peripherals/usb/device:
+  enable:
+    - if: (IDF_VERSION >= "6.0.0")
+      reason: Device examples have been updated to use esp_tinyusb 2.x only on esp-idf latest for now, TODO IDF-14282
+  disable:
+    - if: SOC_USB_OTG_SUPPORTED != 1
+
+examples/peripherals/usb/device/tusb_ncm:
+  enable:
+    - if: (IDF_VERSION >= "6.0.0")
+      reason: Device examples have been updated to use esp_tinyusb 2.x only on esp-idf latest for now, TODO IDF-14282
+  disable:
+    - if: SOC_USB_OTG_SUPPORTED != 1 or SOC_WIFI_SUPPORTED != 1
 
 examples/peripherals/usb/host:
   enable:

--- a/.github/ci/.idf_build_examples_config.toml
+++ b/.github/ci/.idf_build_examples_config.toml
@@ -1,8 +1,7 @@
 # Config file for build_idf_examples.yml workflow
 
 paths = [
-    # TODO: Uncomment the below line to run esp-idf USB Device examples in CI. See issue IDF-13618 for tracking.
-    #"examples/peripherals/usb/device",     # USB Device examples
+    "examples/peripherals/usb/device",      # USB Device examples
     "examples/peripherals/usb/host",        # USB Host examples
 ]
 

--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -1,7 +1,7 @@
 # This workflow builds esp-idf examples:
 #
 #   - usb device examples: with overridden esp_tinyusb from esp-usb/device/esp_tinyusb
-#     - All (service + maintenance IDF releases)
+#     - Only IDF Latest
 #
 #   - usb host examples: with overridden usb component from esp-usb/host/usb
 #     - Only service IDF releases
@@ -45,8 +45,7 @@ jobs:
         run: |
           . ${IDF_PATH}/export.sh
 
-          # TODO: Uncomment the below line to run esp-idf USB Device examples in CI. See issue IDF-13618 for tracking.
-          #python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/*
+          python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${IDF_PATH}/examples/peripherals/usb/device/*
           python .github/ci/override_managed_component.py usb host/usb ${IDF_PATH}/examples/peripherals/usb/host/*
           cd ${IDF_PATH}
 


### PR DESCRIPTION
## Description

Enabling CI build of esp-idf device examples back. Only for idf latest for now. Examples changes will be backported to IDF 5.x releases.

## Related


## Testing


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
