### PR TITLE
feat: Add ESP32-H4 support to USB Host class drivers

### DIFF
--- a/clang_tidy/CMakeLists.txt
+++ b/clang_tidy/CMakeLists.txt
@@ -15,7 +15,6 @@ set(EXTRA_COMPONENT_DIRS
     ../host/class/hid/usb_host_hid
     ../host/class/msc/usb_host_msc
     ../host/class/uvc/usb_host_uvc
-    ../host/usb
 )
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Added support for ESP32-H4
+
 ## 2.1.0
 
 - Added option to implement custom CDC-ACM like devices with C API

--- a/host/class/cdc/usb_host_cdc_acm/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/CMakeLists.txt
@@ -1,3 +1,12 @@
+# 1. IDF version >= 6.0 does not have usb component: usb from IDF component manager will be used
+# 2. For linux target, we can't use IDF component manager to get usb component, we need to add it 'the old way'
+#    with EXTRA_COMPONENT_DIRS because mocking of managed components is not supported yet.
+#    This is acceptable workaround for testing.
+set(requires "")
+if((${IDF_VERSION_MAJOR} LESS 6) OR ("${IDF_TARGET}" STREQUAL "linux"))
+    list(APPEND requires usb)
+endif()
+
 idf_component_register(SRCS
                         "cdc_acm_host.c"                # Contains driver and transfers code
                         "cdc_host_descriptor_parsing.c" # Only descriptor parsing code, no CDC device handling
@@ -5,5 +14,5 @@ idf_component_register(SRCS
                         "cdc_host_ops.c"                # Implementation of CDC ACM host operations
                        INCLUDE_DIRS "include" "interface"
                        PRIV_INCLUDE_DIRS "private_include" "include/esp_private"
-                       REQUIRES usb
+                       REQUIRES "${requires}"
                        )

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRC_DIRS .
-                        REQUIRES cmock usb
+                        REQUIRES cmock
                         INCLUDE_DIRS "../../" .
                         PRIV_INCLUDE_DIRS "../../../private_include"
                         WHOLE_ARCHIVE)

--- a/host/class/cdc/usb_host_cdc_acm/host_test/parsing_tests/main/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/parsing_tests/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRC_DIRS .
-                        REQUIRES cmock usb
+                        REQUIRES cmock
                         INCLUDE_DIRS "../../" .
                         PRIV_INCLUDE_DIRS "../../../private_include"
                         WHOLE_ARCHIVE)

--- a/host/class/cdc/usb_host_cdc_acm/idf_component.yml
+++ b/host/class/cdc/usb_host_cdc_acm/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.1.0"
+version: "2.1.1"
 description: USB Host CDC-ACM driver
 tags:
   - usb
@@ -8,3 +8,20 @@ tags:
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_cdc_acm
 dependencies:
   idf: ">=4.4"
+  usb:
+    version: "^1.0.0"
+    public: true
+    override_path: "../../../usb"
+    rules:
+     - if: "idf_version >=6.0"
+     - if: target not in ["linux"]
+targets:
+  - esp32s2
+  - esp32s3
+  - esp32p4
+  - esp32h4
+  - linux
+files:
+  exclude:
+    - "test_app"
+    - "host_test"

--- a/host/class/hid/usb_host_hid/CHANGELOG.md
+++ b/host/class/hid/usb_host_hid/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.4
+- Added support for ESP32-H4
+
 ## 1.0.3
 - Fixed a bug with interface mismatch on EP IN transfer complete while several HID devices are present.
 - Fixed a bug during device freeing, while detaching one of several attached HID devices.

--- a/host/class/hid/usb_host_hid/CMakeLists.txt
+++ b/host/class/hid/usb_host_hid/CMakeLists.txt
@@ -1,3 +1,13 @@
-idf_component_register( SRCS "hid_host.c"
-                        INCLUDE_DIRS "include"
-                        PRIV_REQUIRES usb )
+# 1. IDF version >= 6.0 does not have usb component: usb from IDF component manager will be used
+# 2. For linux target, we can't use IDF component manager to get usb component, we need to add it 'the old way'
+#    with EXTRA_COMPONENT_DIRS because mocking of managed components is not supported yet.
+#    This is acceptable workaround for testing.
+set(requires "")
+if((${IDF_VERSION_MAJOR} LESS 6) OR ("${IDF_TARGET}" STREQUAL "linux"))
+    list(APPEND requires usb)
+endif()
+
+idf_component_register(SRCS "hid_host.c"
+                       INCLUDE_DIRS "include"
+                       REQUIRES "${requires}"
+                       )

--- a/host/class/hid/usb_host_hid/host_test/main/CMakeLists.txt
+++ b/host/class/hid/usb_host_hid/host_test/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRC_DIRS .
-                        REQUIRES cmock usb
+                        REQUIRES cmock
                         INCLUDE_DIRS .
                         WHOLE_ARCHIVE)
 

--- a/host/class/hid/usb_host_hid/idf_component.yml
+++ b/host/class/hid/usb_host_hid/idf_component.yml
@@ -1,6 +1,23 @@
 ## IDF Component Manager Manifest File
-version: "1.0.3"
+version: "1.0.4"
 description: USB Host HID driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/hid/usb_host_hid
 dependencies:
   idf: ">=4.4"
+  usb:
+    version: "^1.0.0"
+    public: true
+    override_path: "../../../usb"
+    rules:
+      - if: "idf_version >=6.0"
+      - if: target not in ["linux"]
+targets:
+  - esp32s2
+  - esp32s3
+  - esp32p4
+  - esp32h4
+  - linux
+files:
+  exclude:
+    - "test_app"
+    - "host_test"

--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -1,6 +1,7 @@
-## [Unreleased]
+## 1.1.4
 
 - Added public API support for formatting
+- Added support for ESP32-H4
 
 ## 1.1.3
 

--- a/host/class/msc/usb_host_msc/CMakeLists.txt
+++ b/host/class/msc/usb_host_msc/CMakeLists.txt
@@ -1,10 +1,20 @@
+# 1. IDF version >= 6.0 does not have usb component: usb from IDF component manager will be used
+# 2. For linux target, we can't use IDF component manager to get usb component, we need to add it 'the old way'
+#    with EXTRA_COMPONENT_DIRS because mocking of managed components is not supported yet.
+#    This is acceptable workaround for testing.
+set(requires "fatfs")
+if((${IDF_VERSION_MAJOR} LESS 6) OR ("${IDF_TARGET}" STREQUAL "linux"))
+    list(APPEND requires usb)
+endif()
+
 set(sources src/msc_scsi_bot.c
             src/diskio_usb.c
             src/msc_host.c
             src/msc_host_vfs.c)
 
-idf_component_register( SRCS ${sources}
-                        INCLUDE_DIRS include include/usb # 'include/usb' is here for backwards compatibility
-                        PRIV_INCLUDE_DIRS private_include include/esp_private
-                        REQUIRES usb fatfs
-                        PRIV_REQUIRES heap )
+idf_component_register(SRCS ${sources}
+                       INCLUDE_DIRS include include/usb # 'include/usb' is here for backwards compatibility
+                       PRIV_INCLUDE_DIRS private_include include/esp_private
+                       REQUIRES ${requires}
+                       PRIV_REQUIRES heap
+                       )

--- a/host/class/msc/usb_host_msc/idf_component.yml
+++ b/host/class/msc/usb_host_msc/idf_component.yml
@@ -1,10 +1,21 @@
 ## IDF Component Manager Manifest File
-version: "1.1.3"
+version: "1.1.4"
 description: USB Host MSC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/msc/usb_host_msc
 dependencies:
   idf: ">=4.4.1"
+  usb:
+    version: "^1.0.0"
+    public: true
+    override_path: "../../../usb"
+    rules:
+      - if: "idf_version >=6.0"
+      - if: target not in ["linux"]
 targets:
   - esp32s2
   - esp32s3
   - esp32p4
+  - esp32h4
+files:
+  exclude:
+    - "test_app"

--- a/host/class/uac/usb_host_uac/CHANGELOG.md
+++ b/host/class/uac/usb_host_uac/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for USB Host UAC
 
+## 1.3.1
+
+1. Added support for ESP32-H4
+
 ## 1.3.0
 
 1. Added Linux target build for the UAC component, host tests (https://github.com/espressif/esp-usb/issues/143)

--- a/host/class/uac/usb_host_uac/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/CMakeLists.txt
@@ -1,6 +1,17 @@
-idf_component_register( SRCS "uac_descriptors.c" "uac_host.c"
-                        INCLUDE_DIRS "include"
-                        PRIV_REQUIRES usb esp_ringbuf )
+# 1. IDF version >= 6.0 does not have usb component: usb from IDF component manager will be used
+# 2. For linux target, we can't use IDF component manager to get usb component, we need to add it 'the old way'
+#    with EXTRA_COMPONENT_DIRS because mocking of managed components is not supported yet.
+#    This is acceptable workaround for testing.
+set(requires "")
+if((${IDF_VERSION_MAJOR} LESS 6) OR ("${IDF_TARGET}" STREQUAL "linux"))
+    list(APPEND requires usb)
+endif()
+
+idf_component_register(SRCS "uac_descriptors.c" "uac_host.c"
+                       INCLUDE_DIRS "include"
+                       PRIV_REQUIRES esp_ringbuf
+                       REQUIRES "${requires}"
+                       )
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/host/class/uac/usb_host_uac/host_test/main/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/host_test/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRC_DIRS .
-                        REQUIRES cmock usb
+                        REQUIRES cmock
                         INCLUDE_DIRS .
                         WHOLE_ARCHIVE)
 

--- a/host/class/uac/usb_host_uac/idf_component.yml
+++ b/host/class/uac/usb_host_uac/idf_component.yml
@@ -1,7 +1,24 @@
 ## IDF Component Manager Manifest File
-version: "1.3.0"
+version: "1.3.1"
 description: USB Host UAC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uac/usb_host_uac
 dependencies:
   idf: ">=4.4"
   cmake_utilities: "0.5.*"
+  usb:
+    version: "^1.0.0"
+    public: true
+    override_path: "../../../usb"
+    rules:
+      - if: "idf_version >=6.0"
+      - if: target not in ["linux"]
+targets:
+  - esp32s2
+  - esp32s3
+  - esp32p4
+  - esp32h4
+  - linux
+files:
+  exclude:
+    - "test_app"
+    - "host_test"

--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+- Added support for ESP32-H4
+
 ## 2.3.0
 
 - Added `uvc_host_stream_format_get()` function that returns current stream's format

--- a/host/class/uvc/usb_host_uvc/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/CMakeLists.txt
@@ -1,3 +1,12 @@
+# 1. IDF version >= 6.0 does not have usb component: usb from IDF component manager will be used
+# 2. For linux target, we can't use IDF component manager to get usb component, we need to add it 'the old way'
+#    with EXTRA_COMPONENT_DIRS because mocking of managed components is not supported yet.
+#    This is acceptable workaround for testing.
+set(requires "")
+if((${IDF_VERSION_MAJOR} LESS 6) OR ("${IDF_TARGET}" STREQUAL "linux"))
+    list(APPEND requires usb)
+endif()
+
 idf_component_register(SRCS
                         "uvc_host.c"
                         "uvc_descriptor_parsing.c"
@@ -9,5 +18,5 @@ idf_component_register(SRCS
                        INCLUDE_DIRS include
                        PRIV_INCLUDE_DIRS private_include include/esp_private
                        PRIV_REQUIRES heap
-                       REQUIRES usb
+                       REQUIRES ${requires}
                        )

--- a/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRC_DIRS . parsing streaming opening
-                        REQUIRES cmock usb
+                        REQUIRES cmock
                         INCLUDE_DIRS . parsing streaming opening
                         PRIV_INCLUDE_DIRS "../../private_include"
                         WHOLE_ARCHIVE)

--- a/host/class/uvc/usb_host_uvc/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/idf_component.yml
@@ -1,6 +1,23 @@
 ## IDF Component Manager Manifest File
-version: "2.3.0"
+version: "2.3.1"
 description: USB Host UVC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uvc/usb_host_uvc
 dependencies:
   idf: ">=5.0"
+  usb:
+    version: "^1.0.0"
+    public: true
+    override_path: "../../../usb"
+    rules:
+      - if: "idf_version >=6.0"
+      - if: target not in ["linux"]
+targets:
+  - esp32s2
+  - esp32s3
+  - esp32p4
+  - esp32h4
+  - linux
+files:
+  exclude:
+    - "test_app"
+    - "host_test"


### PR DESCRIPTION
This is minimal PR for H4 host support, so our esp-idf CI can pass.

We will probably have to update other drivers in similar way

Closes #263 