### PR TITLE
release(esp_tinyusb): v2.0.1

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 2.0.1 [unreleased]
+## 2.0.1
 
 - esp_tinyusb: Added ESP32H4 support
 - esp_tinyusb: Fixed an assertion failure on the GetOtherSpeedDescriptor() request for ESP32P4 when the OTG1.1 port is used
 - MSC: Added dynamic member and storage operation multitask protection
+- MSC: Used `esp_vfs_fat_register_cfg` function prototype for esp-idf v5.3 and higher
 
 ## 2.0.0
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "2.0.0"
+version: "2.0.1"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 targets:
   - esp32s2


### PR DESCRIPTION
# esp_tinyusb component, [2.0.1](https://components.espressif.com/components/espressif/esp_tinyusb/versions/2.0.1) 

## Changes

- esp_tinyusb: Added ESP32H4 support
- esp_tinyusb: Fixed an assertion failure on the GetOtherSpeedDescriptor() request for ESP32P4 when the OTG1.1 port is used
- MSC: Added dynamic member and storage operation multitask protection
- MSC: Used `esp_vfs_fat_register_cfg` function prototype for esp-idf v5.3 and higher

## Related
- https://github.com/espressif/esp-usb/pull/213
- https://github.com/espressif/esp-usb/pull/258
- https://github.com/espressif/esp-usb/pull/257
- https://github.com/espressif/esp-usb/pull/250
- https://github.com/espressif/esp-usb/pull/268

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary