### PR TITLE
refactor(hub, ext_port): Removed not relevant IDF tickets

### DIFF
--- a/host/usb/src/ext_port.c
+++ b/host/usb/src/ext_port.c
@@ -649,7 +649,6 @@ static void handle_port_connection(ext_port_t *ext_port)
         }
         break;
     case USB_PORT_STATE_ENABLED:
-        // TODO: IDF-10071 Port debounce mechanism
         if (ext_port->dev_state == PORT_DEV_PRESENT) {
             ext_port->flags.waiting_recycle = 1;
         }
@@ -795,7 +794,6 @@ static void handle_port_state(ext_port_t *ext_port)
                 }
                 need_handling = true;
             } else {
-                // TODO: IDF-10071 Port debounce mechanism
                 ESP_LOGE(EXT_PORT_TAG, "[%d:%d] Enabled, but doesn't have connection",
                          ext_port->constant.parent_dev_addr,
                          ext_port->constant.port_num);

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -184,7 +184,6 @@ static esp_err_t dev_tree_node_new(usb_device_handle_t parent_dev_hdl, uint8_t p
     ret = usbh_devs_add(&params);
     if (ret != ESP_OK) {
         // Device registration may fail if there are no available HCD channels.
-        // TODO: IDF-10044 Implement hub recovery mechanism for running out of HCD channels.
         goto fail;
     }
 


### PR DESCRIPTION


<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

- (IDF-10071) Port debounce mechanism do not need, as the hub does the debounce in a hardware
- (IDF-10044) Hub recovery already implmented by disabling the port, when error occured (no HCD channels, unable to get speed etc.)

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

- Closes IDF-10071
- Closes IDF-10044

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
N/A

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
