### PR TITLE
refactor(tinyusb_msc): Removed deprecated esp_vfs_fat_register_cfg API call (esp-idf v6.0)

### DIFF
--- a/device/esp_tinyusb/tinyusb_msc.c
+++ b/device/esp_tinyusb/tinyusb_msc.c
@@ -1132,7 +1132,16 @@ esp_err_t tinyusb_msc_format_storage(tinyusb_msc_storage_handle_t handle)
 
     // Register FAT FS with VFS component
     char drv[3] = {(char)('0' + pdrv), ':', 0}; // FATFS drive specificator; if only one drive is used, can be an empty string
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    esp_vfs_fat_conf_t conf = {
+        .base_path = base_path,
+        .fat_drive = drv,
+        .max_files = max_files,
+    };
+    ESP_RETURN_ON_ERROR(esp_vfs_fat_register_cfg(&conf, &fs), TAG, "VFS FAT register failed");
+#else
     ESP_RETURN_ON_ERROR(esp_vfs_fat_register(base_path, drv, max_files, &fs), TAG, "VFS FAT register failed");
+#endif
     // to make format, we need to mount the fs
     // Mount the FAT FS
     ret = vfs_fat_mount(drv, fs, true);


### PR DESCRIPTION
## Description

[Storage / FATFS] Function `esp_vfs_fat_register_cfg` has been deprecated and will be removed in the future.


## Related

- Relates [!41953](https://gitlab.espressif.cn:6688/espressif/esp-idf/-/merge_requests/41953)
- Unlocks esp-idf v6.0 CI

## Testing

N/A
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
