### PR TITLE
fix(ci): Fix failed device enumeration in CI

### DIFF
--- a/host/usb/test/target_test/usb_host/main/ctrl_client_async_seq.c
+++ b/host/usb/test/target_test/usb_host/main/ctrl_client_async_seq.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -82,6 +82,7 @@ static void ctrl_client_event_cb(const usb_host_client_event_msg_t *event_msg, v
     ctrl_client_obj_t *ctrl_obj = (ctrl_client_obj_t *)arg;
     switch (event_msg->event) {
     case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        printf("\t-> New device\n");
         TEST_ASSERT_EQUAL(TEST_STAGE_WAIT_CONN, ctrl_obj->cur_stage);
         ctrl_obj->next_stage = TEST_STAGE_DEV_OPEN;
         ctrl_obj->dev_addr = event_msg->new_dev.address;
@@ -122,8 +123,14 @@ void ctrl_client_async_seq_task(void *arg)
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
     ESP_LOGD(CTRL_CLIENT_TAG, "Starting");
 
+    // Handle device enumeration separately, wait for 1000ms for the device to be enumerated
+    // Catch an error in case the device is not enumerated correctly
+    esp_err_t enum_ret = usb_host_client_handle_events(ctrl_obj.client_hdl, pdMS_TO_TICKS(1000));
+    TEST_ASSERT_EQUAL_MESSAGE(TEST_STAGE_DEV_OPEN, ctrl_obj.next_stage, "USB_HOST_CLIENT_EVENT_NEW_DEV not generated on time");
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, enum_ret, "Client handle events timed out");
+
     bool exit_loop = false;
-    bool skip_event_handling = false;
+    bool skip_event_handling = true;    // Skip first event handling (we have handled the new device event separately)
     while (!exit_loop) {
         if (!skip_event_handling) {
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_client_handle_events(ctrl_obj.client_hdl, portMAX_DELAY));

--- a/host/usb/test/target_test/usb_host/main/msc_client_async_dconn.c
+++ b/host/usb/test/target_test/usb_host/main/msc_client_async_dconn.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -107,11 +107,13 @@ static void msc_client_event_cb(const usb_host_client_event_msg_t *event_msg, vo
     msc_client_obj_t *msc_obj = (msc_client_obj_t *)arg;
     switch (event_msg->event) {
     case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        printf("\t-> New device\n");
         TEST_ASSERT_EQUAL(TEST_STAGE_WAIT_CONN, msc_obj->cur_stage);
         msc_obj->next_stage = TEST_STAGE_DEV_OPEN;
         msc_obj->dev_addr = event_msg->new_dev.address;
         break;
     case USB_HOST_CLIENT_EVENT_DEV_GONE:
+        printf("\t-> Device gone\n");
         msc_obj->event_count++;
         // If all transfers dequeued and device gone event occurred. Go to next stage
         if (msc_obj->event_count >= msc_obj->num_data_transfers + 1) {
@@ -167,8 +169,14 @@ void msc_client_async_dconn_task(void *arg)
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
     ESP_LOGD(MSC_CLIENT_TAG, "Starting");
 
+    // Handle device enumeration separately, wait for 1000ms for the device to be enumerated
+    // Catch an error in case the device is not enumerated correctly
+    esp_err_t enum_ret = usb_host_client_handle_events(msc_obj.client_hdl, pdMS_TO_TICKS(1000));
+    TEST_ASSERT_EQUAL_MESSAGE(TEST_STAGE_DEV_OPEN, msc_obj.next_stage, "USB_HOST_CLIENT_EVENT_NEW_DEV not generated on time");
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, enum_ret, "Client handle events timed out");
+
     bool exit_loop = false;
-    bool skip_event_handling = false;
+    bool skip_event_handling = true;    // Skip first event handling (we have handled the new device event separately)
     int dconn_iter = 0;
     while (!exit_loop) {
         if (!skip_event_handling) {

--- a/host/usb/test/target_test/usb_host/main/msc_client_async_enum.c
+++ b/host/usb/test/target_test/usb_host/main/msc_client_async_enum.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,6 +56,7 @@ static void msc_client_event_cb(const usb_host_client_event_msg_t *event_msg, vo
     msc_client_obj_t *msc_obj = (msc_client_obj_t *)arg;
     switch (event_msg->event) {
     case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        printf("\t-> New device\n");
         TEST_ASSERT_EQUAL(TEST_STAGE_WAIT_CONN, msc_obj->cur_stage);
         msc_obj->next_stage = TEST_STAGE_DEV_OPEN;
         msc_obj->dev_addr_to_open = event_msg->new_dev.address;
@@ -91,8 +92,14 @@ void msc_client_async_enum_task(void *arg)
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
     ESP_LOGD(MSC_CLIENT_TAG, "Starting");
 
+    // Handle device enumeration separately, wait for 1000ms for the device to be enumerated
+    // Catch an error in case the device is not enumerated correctly
+    esp_err_t enum_ret = usb_host_client_handle_events(msc_obj.client_hdl, pdMS_TO_TICKS(1000));
+    TEST_ASSERT_EQUAL_MESSAGE(TEST_STAGE_DEV_OPEN, msc_obj.next_stage, "USB_HOST_CLIENT_EVENT_NEW_DEV not generated on time");
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, enum_ret, "Client handle events timed out");
+
     bool exit_loop = false;
-    bool skip_event_handling = false;
+    bool skip_event_handling = true;    // Skip first event handling (we have handled the new device event separately)
     int enum_iter = 0;
     while (!exit_loop) {
         if (!skip_event_handling) {

--- a/host/usb/test/target_test/usb_host/main/msc_client_async_seq.c
+++ b/host/usb/test/target_test/usb_host/main/msc_client_async_seq.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -110,6 +110,7 @@ static void msc_client_event_cb(const usb_host_client_event_msg_t *event_msg, vo
     msc_client_obj_t *msc_obj = (msc_client_obj_t *)arg;
     switch (event_msg->event) {
     case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        printf("\t-> New device\n");
         TEST_ASSERT_EQUAL(TEST_STAGE_WAIT_CONN, msc_obj->cur_stage);
         msc_obj->next_stage = TEST_STAGE_DEV_OPEN;
         msc_obj->dev_addr = event_msg->new_dev.address;
@@ -157,8 +158,14 @@ void msc_client_async_seq_task(void *arg)
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
     ESP_LOGD(MSC_CLIENT_TAG, "Starting");
 
+    // Handle device enumeration separately, wait for 1000ms for the device to be enumerated
+    // Catch an error in case the device is not enumerated correctly
+    esp_err_t enum_ret = usb_host_client_handle_events(msc_obj.client_hdl, pdMS_TO_TICKS(1000));
+    TEST_ASSERT_EQUAL_MESSAGE(TEST_STAGE_DEV_OPEN, msc_obj.next_stage, "USB_HOST_CLIENT_EVENT_NEW_DEV not generated on time");
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, enum_ret, "Client handle events timed out");
+
     bool exit_loop = false;
-    bool skip_event_handling = false;
+    bool skip_event_handling = true;    // Skip first event handling (we have handled the new device event separately)
     while (!exit_loop) {
         if (!skip_event_handling) {
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_client_handle_events(msc_obj.client_hdl, portMAX_DELAY));

--- a/host/usb/test/target_test/usb_host/main/multiconf_client_async.c
+++ b/host/usb/test/target_test/usb_host/main/multiconf_client_async.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -66,6 +66,7 @@ static void multiconf_client_event_cb(const usb_host_client_event_msg_t *event_m
     multiconf_client_obj_t *multiconf_obj = (multiconf_client_obj_t *)arg;
     switch (event_msg->event) {
     case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        printf("\t-> New device\n");
         TEST_ASSERT_EQUAL(TEST_STAGE_WAIT_CONN, multiconf_obj->cur_stage);
         multiconf_obj->next_stage = TEST_STAGE_DEV_OPEN;
         multiconf_obj->dev_addr = event_msg->new_dev.address;
@@ -105,8 +106,14 @@ void multiconf_client_async_task(void *arg)
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
     ESP_LOGD(MULTICONF_CLIENT_TAG, "Starting");
 
+    // Handle device enumeration separately, wait for 1000ms for the device to be enumerated
+    // Catch an error in case the device is not enumerated correctly
+    esp_err_t enum_ret = usb_host_client_handle_events(multiconf_obj.client_hdl, pdMS_TO_TICKS(1000));
+    TEST_ASSERT_EQUAL_MESSAGE(TEST_STAGE_DEV_OPEN, multiconf_obj.next_stage, "USB_HOST_CLIENT_EVENT_NEW_DEV not generated on time");
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, enum_ret, "Client handle events timed out");
+
     bool exit_loop = false;
-    bool skip_event_handling = false;
+    bool skip_event_handling = true;    // Skip first event handling (we have handled the new device event separately)
     while (!exit_loop) {
         if (!skip_event_handling) {
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_client_handle_events(multiconf_obj.client_hdl, portMAX_DELAY));

--- a/host/usb/test/target_test/usb_host/main/test_usb_host_async.c
+++ b/host/usb/test/target_test/usb_host/main/test_usb_host_async.c
@@ -165,6 +165,7 @@ static void test_async_client_cb(const usb_host_client_event_msg_t *event_msg, v
 
     switch (event_msg->event) {
     case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        printf("\t-> New device\n");
         if (dev_addr == 0) {
             dev_addr = event_msg->new_dev.address;
         } else {
@@ -173,6 +174,7 @@ static void test_async_client_cb(const usb_host_client_event_msg_t *event_msg, v
         *stage = CLIENT_TEST_STAGE_CONN;
         break;
     case USB_HOST_CLIENT_EVENT_DEV_GONE:
+        printf("\t-> Device gone\n");
         *stage = CLIENT_TEST_STAGE_DCONN;
         break;
     default:
@@ -201,16 +203,25 @@ TEST_CASE("Test USB Host async API", "[usb_host][low_speed][full_speed][high_spe
     client_config.async.callback_arg = (void *)&client1_stage;
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_client_register(&client_config, &client1_hdl));
 
+    TickType_t timeout_ticks = pdMS_TO_TICKS(1000);
+    TimeOut_t enumeration_timeout;
+    vTaskSetTimeOutState(&enumeration_timeout);
+
     // Wait until the device connects and the clients receive the event
     while (!(client0_stage == CLIENT_TEST_STAGE_CONN && client1_stage == CLIENT_TEST_STAGE_CONN)) {
         usb_host_lib_handle_events(0, NULL);
         usb_host_client_handle_events(client0_hdl, 0);
         usb_host_client_handle_events(client1_hdl, 0);
         vTaskDelay(pdMS_TO_TICKS(10));
+
+        // Check if the device is enumerated within 1000 ms
+        if (xTaskCheckForTimeOut(&enumeration_timeout, &timeout_ticks) == pdTRUE) {
+            break;
+        }
     }
 
     // Check that both clients can open the device
-    TEST_ASSERT_NOT_EQUAL(0, dev_addr);
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(0, dev_addr, "Device not enumerated");
     usb_device_handle_t client0_dev_hdl;
     usb_device_handle_t client1_dev_hdl;
     printf("Opening device\n");


### PR DESCRIPTION
## Description

Error log from repeatedly failing CI run:

<details>
<summary> Error log </summary>

```
Hard resetting via RTS pin...
2025-09-26 10:00:36 ERROR Failed Cases:
2025-09-26 10:00:36 ERROR   - Test USB Host async client (multi client)
FAILED
------------------------------ live log teardown -------------------------------
2025-09-26 10:00:36 INFO Created unity output junit report: /tmp/pytest-embedded/2025-09-26_09-59-08-434961/test_usb_host/dut.xml


=================================== FAILURES ===================================
________________________________ test_usb_host _________________________________
/usr/local/lib/python3.11/site-packages/pytest_embedded/plugin.py:1378: in pytest_runtest_call
    self._raise_dut_failed_cases_if_exists(duts)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.11/site-packages/pytest_embedded/plugin.py:1264: in _raise_dut_failed_cases_if_exists
    raise AssertionError('Unity test failed')
E   AssertionError: Unity test failed
------------------------------ Captured log setup ------------------------------
INFO     root:serial.py:110 Target: esp32p4, Port: /dev/ttyUSB0
------------------------------ Captured log call -------------------------------
WARNING  root:unity_tester.py:291 unity test case not found, probably due to a timeout. Assume the current test case is "Test USB Host async client (multi client)"
ERROR    root:plugin.py:1261 Failed Cases:
ERROR    root:plugin.py:1263   - Test USB Host async client (multi client)
```

</details>

Where the log from the failed test case shows no log:

<details>
<summary> Error log </summary>

```
2025-09-26 09:59:55 Press ENTER to see the list of tests.
2025-09-26 09:59:55 2
2025-09-26 09:59:55 Running Test USB Host async client (multi client)...
2025-09-26 09:59:55 USB Host installed
Hard resetting via RTS pin...
Hard resetting via RTS pin...
Hard resetting via RTS pin...
-------------------------------- live log call ---------------------------------
2025-09-26 10:00:24 WARNING unity test case not found, probably due to a timeout. Assume the current test case is "Test USB Host async client (multi client)"
```

</details>



## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

This might be connected with device not being correctly enumerated. Adding this check, for the CI run to trigger appropriate error, not just a timeout error.

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
