### PR TITLE
fix(usb_host): Compatibility of managed component idf maintenance

### DIFF
--- a/host/usb/CMakeLists.txt
+++ b/host/usb/CMakeLists.txt
@@ -42,6 +42,9 @@ if(CONFIG_SOC_USB_OTG_SUPPORTED)
 
         # Get path to usb component inside esp-idf
         idf_component_get_property(esp_idf_usb_dir usb COMPONENT_OVERRIDEN_DIR)
+        if(NOT esp_idf_usb_dir)
+            idf_component_get_property(esp_idf_usb_dir usb COMPONENT_DIR)
+        endif()
 
         # Explicitly add usb_phy.c and usb_phy.h from overridden usb component in esp-idf
         list(APPEND srcs "${esp_idf_usb_dir}/usb_phy.c")

--- a/host/usb/idf_component.yml
+++ b/host/usb/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 description: USB Host library
-version: "1.0.0"
+version: "1.0.1-rc0"
 url: https://github.com/espressif/esp-usb/tree/master/host/usb
 dependencies:
   idf: ">=5.4"


### PR DESCRIPTION
## Description

The usb component can't be used as a managed component in `IDF 5.5` and `IDF 5.4`. Even thought it can be used as overridden component in IDF 5.5 and IDF 5.4.

eg:

Using USB component like this is working
```
## IDF Component Manager Manifest File
dependencies:
  usb:
    override_path: "/local/path"
```

This is not working
```
## IDF Component Manager Manifest File
dependencies:
  usb: "*"
```

<details>
<summary> Error log </summary>

```
peter@peter ➜  ~/esp/esp-idf/examples/peripherals/usb/host/usb_host_lib git:(release/v5.5) ✗ idf.py set-target esp32p4    
...
-- Building ESP-IDF components for target esp32p4
NOTICE: Dependencies lock doesn't exist, solving dependencies.
..NOTICE: Updating lock file at /home/peter/esp/esp-idf/examples/peripherals/usb/host/usb_host_lib/dependencies.lock
NOTICE: Processing 2 dependencies:
NOTICE: [1/2] espressif/usb (1.0.0)
NOTICE: [2/2] idf (5.5.1)
NOTICE: espressif__usb overrides usb since "project_managed_components" type got higher priority than "idf_components"
...
CMake Error at /home/peter/esp/esp-idf/tools/cmake/component.cmake:319 (message):
  Include directory '/include' is not a directory.
Call Stack (most recent call first):
  /home/peter/esp/esp-idf/tools/cmake/component.cmake:494 (__component_add_include_dirs)
  managed_components/espressif__usb/CMakeLists.txt:60 (idf_component_register)


-- Configuring incomplete, errors occurred!
See also "/home/peter/esp/esp-idf/examples/peripherals/usb/host/usb_host_lib/build/CMakeFiles/CMakeOutput.log".
cmake failed with exit code 1, output of the command is in the /home/peter/esp/esp-idf/examples/peripherals/usb/host/usb_host_lib/build/log/idf_py_stderr_output_144148 and /home/peter/esp/esp-idf/examples/peripherals/usb/host/usb_host_lib/build/log/idf_py_stdout_output_144148
```

</details>

The IDF 6.0 release is not affected.
As there is no way how to debug it, we can release `1.0.1-rc01` version of USB component and see if this fixes it.

## Related


## Testing


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
