### PR TITLE
fix: Use ESP_INTR_FLAG_LOWMED for interrupt priority

### DIFF
--- a/host/class/cdc/esp_modem_usb_dte/esp_modem_usb.cpp
+++ b/host/class/cdc/esp_modem_usb_dte/esp_modem_usb.cpp
@@ -55,7 +55,7 @@ public:
         if (usb_config->install_usb_host && !usb_host_lib_task) {
             usb_host_config_t host_config = {};
             host_config.skip_phy_setup = false;
-            host_config.intr_flags = ESP_INTR_FLAG_LEVEL1;
+            host_config.intr_flags = ESP_INTR_FLAG_LOWMED;
 
             ESP_MODEM_THROW_IF_ERROR(usb_host_install(&host_config), "USB Host install failed");
             ESP_LOGD(TAG, "USB Host installed");

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.c
@@ -90,7 +90,7 @@ void usb_lib_task(void *arg)
     // Install USB Host driver. Should only be called once in entire application
     const usb_host_config_t host_config = {
         .skip_phy_setup = skip_phy_setup,
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
     };
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_install(&host_config));
     printf("USB Host installed\n");

--- a/host/class/hid/usb_host_hid/test_app/main/test_hid_basic.c
+++ b/host/class/hid/usb_host_hid/test_app/main/test_hid_basic.c
@@ -505,7 +505,7 @@ static void usb_lib_task(void *arg)
     const bool skip_phy_setup = install_phy();
     const usb_host_config_t host_config = {
         .skip_phy_setup = skip_phy_setup,
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
     };
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_install(&host_config) );
     printf("USB Host installed\n");

--- a/host/class/msc/usb_host_msc/test_app/main/test_msc.c
+++ b/host/class/msc/usb_host_msc/test_app/main/test_msc.c
@@ -223,7 +223,7 @@ static void msc_test_init(void)
     const bool skip_phy_setup = install_phy();
     const usb_host_config_t host_config = {
         .skip_phy_setup = skip_phy_setup,
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
     };
     ESP_OK_ASSERT( usb_host_install(&host_config) );
     task_created = xTaskCreatePinnedToCore(handle_usb_events, "usb_events", 2 * 2048, NULL, 2, NULL, 0);

--- a/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c
+++ b/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c
@@ -186,7 +186,7 @@ static void usb_lib_task(void *arg)
     const bool skip_phy_setup = install_phy();
     const usb_host_config_t host_config = {
         .skip_phy_setup = skip_phy_setup,
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
     };
 
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_install(&host_config));

--- a/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/basic_uvc_stream.c
+++ b/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/basic_uvc_stream.c
@@ -297,7 +297,7 @@ void app_main(void)
     ESP_LOGI(TAG, "Installing USB Host");
     const usb_host_config_t host_config = {
         .skip_phy_setup = false,
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
     };
     ESP_ERROR_CHECK(usb_host_install(&host_config));
 

--- a/host/class/uvc/usb_host_uvc/examples/camera_display/main/camera_display.c
+++ b/host/class/uvc/usb_host_uvc/examples/camera_display/main/camera_display.c
@@ -187,7 +187,7 @@ void app_main(void)
     ESP_LOGI(TAG, "Installing USB Host");
     const usb_host_config_t host_config = {
         .skip_phy_setup = false,
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
     };
     ESP_ERROR_CHECK(usb_host_install(&host_config));
 

--- a/host/class/uvc/usb_host_uvc/test_app/main/test_uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/test_app/main/test_uvc_host.c
@@ -24,7 +24,7 @@ void usb_lib_task(void *arg)
 {
     const usb_host_config_t host_config = {
         .skip_phy_setup = false,
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
     };
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_install(&host_config));
     printf("USB Host installed\n");

--- a/host/usb/test/target_test/common/hcd_common.c
+++ b/host/usb/test/target_test/common/hcd_common.c
@@ -171,7 +171,7 @@ hcd_port_handle_t test_hcd_setup(void)
     TEST_ASSERT_NOT_NULL(port_evt_queue);
     // Install HCD
     hcd_config_t hcd_config = {
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
         .peripheral_map = TEST_PERIPHERAL_MAP,
     };
     TEST_ASSERT_EQUAL(ESP_OK, hcd_install(&hcd_config));

--- a/host/usb/test/target_test/usb_host/main/test_app_main.c
+++ b/host/usb/test/target_test/usb_host/main/test_app_main.c
@@ -41,7 +41,7 @@ void setUp(void)
     usb_host_config_t host_config = {
         .skip_phy_setup = true,
         .root_port_unpowered = false,
-        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
         .peripheral_map = TEST_PERIPHERAL_MAP,
     };
     ESP_ERROR_CHECK(usb_host_install(&host_config));


### PR DESCRIPTION
This initialization code is often reused or copy-pasted by users. To prevent situations when the user's system runs out of priority 1 interrupts, we can allow priorities 1 to 3. This results in easier to port code.

Related to https://github.com/espressif/esp-idf/issues/17525