### PR TITLE
ci: Temporarily disable esp_modem_usb_dte to fix build issues

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/idf_component.yml
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/idf_component.yml
@@ -18,9 +18,10 @@ dependencies:
       - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
 
   # Following components are not needed, but this way we at least built them in CI
-  espressif/esp_modem_usb_dte:
-    version: "*"
-    override_path: "../../../esp_modem_usb_dte"
+  # Temporarily commented out due to esp_modem issues
+  # espressif/esp_modem_usb_dte:
+  #   version: "*"
+  #   override_path: "../../../esp_modem_usb_dte"
   espressif/usb_host_vcp:
     version: "*"
     override_path: "../../../usb_host_vcp"

--- a/host/class/msc/usb_host_msc/test_app/main/msc_device.c
+++ b/host/class/msc/usb_host_msc/test_app/main/msc_device.c
@@ -14,8 +14,7 @@
 #include "driver/gpio.h"
 #include "tinyusb_msc.h"
 #if SOC_SDMMC_HOST_SUPPORTED
-#include "diskio_impl.h"
-#include "diskio_sdmmc.h"
+#include "sdmmc_cmd.h"
 #endif /* SOC_SDMMC_HOST_SUPPORTED */
 
 #if SOC_USB_OTG_SUPPORTED


### PR DESCRIPTION
Temporarily disable esp_modem_usb_dte builds until esp_modem is updated for IDF6.0
