### PR TITLE
feat(ci): Remove CI build/run for usb native component in IDF latest

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -46,7 +46,9 @@ jobs:
             idf_ver: "release-v5.2"
           - test_app: host_managed
             idf_ver: "release-v5.3"
-          # TODO: Exclude native usb component for IDF Latest, once the USB component is removed from the esp-idf Jira issue IDF-14051
+            #Exclude native usb component for IDF Latest (usb component has been removed from esp-idf)
+          - test_app: host_native
+            idf_ver: "latest"
 
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
@@ -114,7 +116,9 @@ jobs:
             idf_ver: "release-v5.2"
           - test_app: host_managed
             idf_ver: "release-v5.3"
-          # TODO: Exclude native usb component for IDF Latest, once the USB component is removed from the esp-idf: Jira issue IDF-14051
+            #Exclude native usb component for IDF Latest (usb component has been removed from esp-idf)
+          - test_app: host_native
+            idf_ver: "latest"
 
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
     container:


### PR DESCRIPTION
## Description

Excluding CI build and run for native USB component (usb component located in esp-idf) for IDF latest. The USB component was removed from esp-idf.

## Related

- IDF-14051 Remove IDF Latest build and run from esp-usb CI for esp-idf USB component

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
