### PR TITLE
fix(uac): Wait until requested bytes are read

### DIFF
--- a/host/class/uac/usb_host_uac/CHANGELOG.md
+++ b/host/class/uac/usb_host_uac/CHANGELOG.md
@@ -1,36 +1,45 @@
 # Changelog for USB Host UAC
 
-## 1.3.1
+All notable changes to this component will be documented in this file.
 
-1. Added support for ESP32-H4
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.3.0
+## [1.3.2] - 2025-10-21
 
-1. Added Linux target build for the UAC component, host tests (https://github.com/espressif/esp-usb/issues/143)
+### Changed
 
-## 1.2.0 2024-09-27
+- uac_host_device_read() now waits for the full timeout duration until the required amount of data is read, preventing premature returns with partial data (https://github.com/espressif/esp-usb/issues/248)
+
+## [1.3.1] - 2025-09-24
+
+- Added support for ESP32-H4
+
+## [1.3.0] - 2025-03-28
+
+- Added Linux target build for the UAC component, host tests (https://github.com/espressif/esp-usb/issues/143)
+
+## [1.2.0] - 2024-10-10
 
 ### Breaking Changes:
 
-1. Changed the parameter type of `uac_host_device_set_volume_db` from uint32_t to int16_t
-
+- Changed the parameter type of `uac_host_device_set_volume_db` from uint32_t to int16_t
 
 ### Improvements:
 
-1. Support get current volume and mute status
+- Support get current volume and mute status
 
 ### Bugfixes:
 
-1. Fixed incorrect volume conversion. Using actual device volume range.
-2. Fixed concurrency issues when suspend/stop during read/write
+- Fixed incorrect volume conversion. Using actual device volume range.
+- Fixed concurrency issues when suspend/stop during read/write
 
-## 1.1.0
+## [1.1.0] - 2024-07-08
 
 ### Improvements
 
 - Added add `uac_host_device_open_with_vid_pid` to open connected audio devices with known VID and PID
 - Print component version message `uac-host: Install Succeed, Version: 1.1.0` in `uac_host_install` function
 
-## 1.0.0
+## [1.0.0] - 2024-05-23
 
 - Initial version

--- a/host/class/uac/usb_host_uac/README.md
+++ b/host/class/uac/usb_host_uac/README.md
@@ -1,6 +1,8 @@
 # USB Host UAC Driver
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_uac/badge.svg)](https://components.espressif.com/components/espressif/usb_host_uac)
+![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
+![changelog](https://img.shields.io/badge/Keep_a_Changelog-blue?logo=keepachangelog&logoColor=E05735)
 
 This directory contains an implementation of a USB UAC Driver implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
 

--- a/host/class/uac/usb_host_uac/idf_component.yml
+++ b/host/class/uac/usb_host_uac/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.3.1"
+version: "1.3.2"
 description: USB Host UAC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uac/usb_host_uac
 dependencies:


### PR DESCRIPTION
Closes https://github.com/espressif/esp-usb/issues/248

Previously `uac_host_device_read()` would return early it there was data in the ringbuffer, but less than what was requested.

Now, the function waits the entire timout until all data is received

## ToDo

- [x] Update changelog

