### PR TITLE
feat(mock): Extend device_info mock with speed

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_device_interaction.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_device_interaction.cpp
@@ -32,27 +32,27 @@ static void _add_mocked_devices(void)
 
     // ASIX Electronics Corp. AX88772A Fast Ethernet (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(0, (const usb_device_desc_t *)premium_cord_device_desc_fs,
-                                               (const usb_config_desc_t *)premium_cord_config_desc_fs));
+                                               (const usb_config_desc_t *)premium_cord_config_desc_fs, USB_SPEED_FULL));
 
     // ASIX Electronics Corp. AX88772B (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(1, (const usb_device_desc_t *)i_tec_device_desc_fs,
-                                               (const usb_config_desc_t *)i_tec_config_desc_fs));
+                                               (const usb_config_desc_t *)i_tec_config_desc_fs, USB_SPEED_FULL));
 
     // FTDI chip dual (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(2, (const usb_device_desc_t *)ftdi_device_desc_fs_hs,
-                                               (const usb_config_desc_t *)ftdi_config_desc_fs));
+                                               (const usb_config_desc_t *)ftdi_config_desc_fs, USB_SPEED_FULL));
 
     // TTL232RG (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(3, (const usb_device_desc_t *)ttl232_device_desc,
-                                               (const usb_config_desc_t *)ttl232_config_desc));
+                                               (const usb_config_desc_t *)ttl232_config_desc, USB_SPEED_FULL));
 
     // CP210x (FS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(4, (const usb_device_desc_t *)cp210x_device_desc,
-                                               (const usb_config_desc_t *)cp210x_config_desc));
+                                               (const usb_config_desc_t *)cp210x_config_desc, USB_SPEED_FULL));
 
     // tusb_serial_device (HS descriptor)
     REQUIRE(ESP_OK == usb_host_mock_add_device(5, (const usb_device_desc_t *)tusb_serial_device_device_desc_fs_hs,
-                                               (const usb_config_desc_t *)tusb_serial_device_config_desc_hs));
+                                               (const usb_config_desc_t *)tusb_serial_device_config_desc_hs, USB_SPEED_HIGH));
 }
 
 /**

--- a/host/usb/test/mocks/usb_host_full_mock/usb/CMakeLists.txt
+++ b/host/usb/test/mocks/usb_host_full_mock/usb/CMakeLists.txt
@@ -27,4 +27,4 @@ target_sources(${COMPONENT_LIB} PRIVATE "${original_usb_dir}/src/usb_helpers.c")
 target_sources(${COMPONENT_LIB} PRIVATE "${original_usb_dir}/src/usb_private.c")
 
 # Add the extra src files for USB device mocking
-target_sources(${COMPONENT_LIB} PRIVATE "mock_add_usb_device.c")
+target_sources(${COMPONENT_LIB} PRIVATE "mock_add_usb_device.cpp")

--- a/host/usb/test/mocks/usb_host_full_mock/usb/include/mock_add_usb_device.h
+++ b/host/usb/test/mocks/usb_host_full_mock/usb/include/mock_add_usb_device.h
@@ -9,22 +9,19 @@
 #include <stdint.h>
 #include "usb_host.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @brief Add mocked USB device to device list
  *
  * @param[in] dev_address device address
  * @param[in] dev_desc device descriptor
  * @param[in] config_desc configuration descriptor
+ * @param[in] speed device speed (default is USB_SPEED_HIGH)
  *
  * @return
  *    - ESP_OK: Mocked device added successfully
  *    - ESP_ERR_INVALID_ARG: Invalid input argument(s)
  */
-esp_err_t usb_host_mock_add_device(uint8_t dev_address, const usb_device_desc_t *dev_desc, const usb_config_desc_t *config_desc);
+esp_err_t usb_host_mock_add_device(uint8_t dev_address, const usb_device_desc_t *dev_desc, const usb_config_desc_t *config_desc, usb_speed_t speed = USB_SPEED_HIGH);
 
 /**
  * @brief Get number of mocked USB devices in device list
@@ -350,7 +347,3 @@ esp_err_t usb_host_transfer_submit_control_timeout_mock_callback(usb_host_client
  *    - ESP_ERR_INVALID_ARG: Invalid argument
  */
 esp_err_t usb_host_device_info_mock_callback(usb_device_handle_t dev_hdl, usb_device_info_t *dev_info, int call_count);
-
-#ifdef __cplusplus
-}
-#endif

--- a/host/usb/test/mocks/usb_host_full_mock/usb/mock_add_usb_device.cpp
+++ b/host/usb/test/mocks/usb_host_full_mock/usb/mock_add_usb_device.cpp
@@ -47,6 +47,7 @@ struct client_s {
 typedef struct {
     int address;                            /*!< Device address */
     unsigned opened;                        /*!< Device opened status */
+    usb_speed_t speed;                      /*!< Device speed */
     const usb_device_desc_t *dev_desc;      /*!< Device descriptor */
     const usb_config_desc_t *config_desc;   /*!< Config descriptor */
 } device_list_t;
@@ -59,6 +60,7 @@ void usb_host_mock_dev_list_init(void)
     for (int index = 0; index < MAX_DEV_COUNT; index++) {
         device_list[index].address = 0xFF;
         device_list[index].opened = 0;
+        device_list[index].speed = USB_SPEED_HIGH;
         device_list[index].dev_desc = NULL;
         device_list[index].config_desc = NULL;
     }
@@ -70,7 +72,7 @@ int usb_host_mock_get_devs_count(void)
     return mocked_devices_count;
 }
 
-esp_err_t usb_host_mock_add_device(uint8_t dev_address, const usb_device_desc_t *dev_desc, const usb_config_desc_t *config_desc)
+esp_err_t usb_host_mock_add_device(uint8_t dev_address, const usb_device_desc_t *dev_desc, const usb_config_desc_t *config_desc, usb_speed_t speed)
 {
     MOCK_CHECK(dev_address < MAX_DEV_COUNT && dev_desc != NULL && config_desc != NULL, ESP_ERR_INVALID_ARG);
 
@@ -82,6 +84,7 @@ esp_err_t usb_host_mock_add_device(uint8_t dev_address, const usb_device_desc_t 
     // Fill device_list with new device parameters
     device_list[dev_address].address = dev_address;
     device_list[dev_address].opened = 0;
+    device_list[dev_address].speed = speed;
     device_list[dev_address].dev_desc = dev_desc;
     device_list[dev_address].config_desc = config_desc;
 
@@ -420,8 +423,9 @@ esp_err_t usb_host_device_info_mock_callback(usb_device_handle_t dev_hdl, usb_de
 
     const device_list_t *current_device = (const device_list_t *) dev_hdl;
     memset(dev_info, 0, sizeof(usb_device_info_t));
-    dev_info->dev_addr = current_device->address;
-    dev_info->bMaxPacketSize0 = current_device->dev_desc->bMaxPacketSize0;
+    dev_info->speed               = current_device->speed;
+    dev_info->dev_addr            = current_device->address;
+    dev_info->bMaxPacketSize0     = current_device->dev_desc->bMaxPacketSize0;
     dev_info->bConfigurationValue = 1;
     return ESP_OK;
 }


### PR DESCRIPTION
* Extend mocked device list with 'speed' parameter. This will be useful for class driver tests that have different behavior for full and high speed devices.

* The mock implementation was changed to C++ so we could use default parameter values. This way we can extend the API without modifying all the existing tests