### PR TITLE
refactor(usb_host): Removed parent_dev_hdl and parent_port_num from Enum Driver (part1/4)

### DIFF
--- a/host/usb/private_include/enum.h
+++ b/host/usb/private_include/enum.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -44,31 +44,9 @@ typedef enum {
 } enum_event_t;
 
 typedef struct {
-    enum_event_t event;                         /**< Enumerator driver event */
-    union {
-        struct {
-            unsigned int uid;                   /**< Device unique ID */
-            usb_device_handle_t parent_dev_hdl; /**< Parent of the enumerating device */
-            uint8_t parent_port_num;            /**< Parent port number of the enumerating device */
-        } started;                              /**< ENUM_EVENT_STARTED specific data */
-
-        struct {
-            usb_device_handle_t parent_dev_hdl; /**< Parent of the enumerating device */
-            uint8_t parent_port_num;            /**< Parent port number of the enumerating device */
-        } reset_req;                            /**< ENUM_EVENT_RESET_REQUIRED specific data */
-
-        struct {
-            usb_device_handle_t parent_dev_hdl; /**< Parent of the enumerating device */
-            uint8_t parent_port_num;            /**< Parent port number of the enumerating device */
-            usb_device_handle_t dev_hdl;        /**< Handle of the enumerating device */
-            uint8_t dev_addr;                   /**< Address of the enumerating device */
-        } complete;                             /**< ENUM_EVENT_COMPLETED specific data */
-
-        struct {
-            usb_device_handle_t parent_dev_hdl; /**< Parent of the enumerating device */
-            uint8_t parent_port_num;            /**< Parent port number of the enumerating device */
-        } canceled;                             /**< ENUM_EVENT_CANCELED specific data */
-    };
+    enum_event_t event;             /**< Enumerator driver event */
+    unsigned int node_uid;          /**< Unique node ID */
+    usb_device_handle_t dev_hdl;    /**< Handle of the enumerating device */
 } enum_event_data_t;
 
 // ---------------------------- Callbacks --------------------------------------

--- a/host/usb/private_include/hub.h
+++ b/host/usb/private_include/hub.h
@@ -192,66 +192,67 @@ esp_err_t hub_root_mark_resume(void);
 /**
  * @brief Indicate to the Hub driver that a device's port can be recycled
  *
- * The device connected to the port has been freed. The Hub driver can now recycled the port
+ * The device connected to the port has been freed.
+ * The Hub driver can now recycle the port, related to the node.
  *
  * @note This function should only be called from the Host Library task
  *
- * @param[in] parent_dev_hdl    Parent device handle (is used to get the External Hub handle)
- * @param[in] parent_port_num   Parent number (is used to specify the External Port)
- * @param[in] dev_uid Device's unique ID
+ * @param[in] node_uid  Device's node unique ID
  *
  * @return
- *    - ESP_OK: device's port can be recycled
+ *    - ESP_OK: Device's port can be recycled
  *    - ESP_ERR_INVALID_STATE: Hub driver is not installed
  *    - ESP_ERR_NOT_SUPPORTED: Recycling External Port is not available (External Hub support disabled),
  *      or ext hub port error
+ *    - ESP_ERR_NOT_FOUND: Device's node is not found
  */
-esp_err_t hub_port_recycle(usb_device_handle_t parent_dev_hdl, uint8_t parent_port_num, unsigned int dev_uid);
+esp_err_t hub_node_recycle(unsigned int node_uid);
 
 /**
- * @brief Reset the port
+ * @brief Reset the device in the port, related to the specific Device Tree node
  *
  * @note This function should only be called from the Host Library task
  *
- * @param[in] parent_dev_hdl    Parent device handle (is used to get the External Hub handle)
- * @param[in] parent_port_num   Parent number (is used to specify the External Port)
+ * @param[in] node_uid  Device's node unique ID
+ *
  * @return
- *    - ESP_OK: Port reset successful
+ *    - ESP_OK: If port reset was successful
  *    - ESP_ERR_INVALID_STATE: Hub driver is not installed
  *    - ESP_ERR_NOT_SUPPORTED: Resetting External Port is not available (External Hub support disabled),
  *      or ext hub port error
+ *    - ESP_ERR_NOT_FOUND: Device's node is not found
  */
-esp_err_t hub_port_reset(usb_device_handle_t parent_dev_hdl, uint8_t parent_port_num);
+esp_err_t hub_node_reset(unsigned int node_uid);
 
 /**
- * @brief Activate the port
+ * @brief Port, related to the specific Device Tree node, has an active device
  *
  * @note This function should only be called from the Host Library task
  *
- * @param[in] parent_dev_hdl    Parent device handle (is used to get the External Hub handle)
- * @param[in] parent_port_num   Parent number (is used to specify the External Port)
+ * @param[in] node_uid  Device's node unique ID
  *
  * @return
- *    - ESP_OK: Port activated successfully
- *    - ESP_ERR_NOT_SUPPORTED: Activating External Port is not available (External Hub support disabled),
- *      or ext hub port error
+ *    - ESP_OK: If Port, related to the Device Tree node was activated successfully
+ *    - ESP_ERR_NOT_SUPPORTED: If activating Port is not available (External Hub support disabled),
+*      or ext hub port error
+ *    - ESP_ERR_NOT_FOUND: If Device's node is not found
  */
-esp_err_t hub_port_active(usb_device_handle_t parent_dev_hdl, uint8_t parent_port_num);
+esp_err_t hub_node_active(unsigned int node_uid);
 
 /**
- * @brief Disable the port
+ * @brief Disable the port, related to the specific Device Tree node
  *
  * @note This function should only be called from the Host Library task
  *
- * @param[in] parent_dev_hdl    Parent device handle (is used to get the External Hub handle)
- * @param[in] parent_port_num   Parent number (is used to specify the External Port)
+ * @param[in] node_uid  Device's node unique ID
  *
  * @return
  *    - ESP_OK:                  Port has been disabled without error
  *    - ESP_ERR_INVALID_STATE:   Port can't be disabled in current state
- *    - ESP_ERR_NOT_SUPPORTED:   This function is not support by the selected port
+ *    - ESP_ERR_NOT_SUPPORTED:   This function is not supported by the selected port
+ *    - ESP_ERR_NOT_FOUND:       Device's node is not found
  */
-esp_err_t hub_port_disable(usb_device_handle_t parent_dev_hdl, uint8_t parent_port_num);
+esp_err_t hub_node_disable(unsigned int node_uid);
 
 /**
  * @brief Notify Hub driver that new device has been attached

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -148,6 +148,20 @@ static bool root_port_callback(hcd_port_handle_t port_hdl, hcd_port_event_t port
 
 // ---------------------- Internal Logic ------------------------
 
+dev_tree_node_t *dev_tree_node_get_by_uid(unsigned int node_uid)
+{
+    dev_tree_node_t *dev_tree_node = NULL;
+    dev_tree_node_t *dev_tree_iter;
+    // Search the device tree nodes list for a device node with the specified parent
+    TAILQ_FOREACH(dev_tree_iter, &p_hub_driver_obj->single_thread.dev_nodes_tailq, tailq_entry) {
+        if (dev_tree_iter->uid == node_uid) {
+            dev_tree_node = dev_tree_iter;
+            break;
+        }
+    }
+    return dev_tree_node;
+}
+
 /**
  * @brief Creates new device tree node and propagate HUB_EVENT_CONNECTED event
  *
@@ -805,20 +819,23 @@ esp_err_t hub_root_mark_resume(void)
     return ESP_OK;
 }
 
-esp_err_t hub_port_recycle(usb_device_handle_t parent_dev_hdl, uint8_t parent_port_num, unsigned int dev_uid)
+esp_err_t hub_node_recycle(unsigned int node_uid)
 {
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
     HUB_DRIVER_EXIT_CRITICAL();
     esp_err_t ret;
 
-    if (parent_port_num == 0) {
+    dev_tree_node_t *dev_tree_node = dev_tree_node_get_by_uid(node_uid);
+    HUB_DRIVER_CHECK(dev_tree_node != NULL, ESP_ERR_NOT_FOUND);
+
+    if (dev_tree_node->parent_dev_hdl == NULL) {
         ret = root_port_recycle();
     } else {
 #if ENABLE_USB_HUBS
         ext_hub_handle_t ext_hub_hdl = NULL;
-        ext_hub_get_handle(parent_dev_hdl, &ext_hub_hdl);
-        ret = ext_hub_port_recycle(ext_hub_hdl, parent_port_num);
+        ext_hub_get_handle(dev_tree_node->parent_dev_hdl, &ext_hub_hdl);
+        ret = ext_hub_port_recycle(ext_hub_hdl, dev_tree_node->parent_port_num);
         if (ret != ESP_OK) {
             ESP_LOGE(HUB_DRIVER_TAG, "Ext hub port recycle error: %s", esp_err_to_name(ret));
         }
@@ -829,20 +846,23 @@ esp_err_t hub_port_recycle(usb_device_handle_t parent_dev_hdl, uint8_t parent_po
     }
 
     if (ret == ESP_OK) {
-        ESP_ERROR_CHECK(dev_tree_node_remove_by_parent(parent_dev_hdl, parent_port_num));
+        ESP_ERROR_CHECK(dev_tree_node_remove_by_parent(dev_tree_node->parent_dev_hdl, dev_tree_node->parent_port_num));
     }
 
     return ret;
 }
 
-esp_err_t hub_port_reset(usb_device_handle_t parent_dev_hdl, uint8_t parent_port_num)
+esp_err_t hub_node_reset(unsigned int node_uid)
 {
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
     HUB_DRIVER_EXIT_CRITICAL();
     esp_err_t ret;
 
-    if (parent_port_num == 0) {
+    dev_tree_node_t *dev_tree_node = dev_tree_node_get_by_uid(node_uid);
+    HUB_DRIVER_CHECK(dev_tree_node != NULL, ESP_ERR_NOT_FOUND);
+
+    if (dev_tree_node->parent_dev_hdl == NULL) {
         ret = hcd_port_command(p_hub_driver_obj->constant.root_port_hdl, HCD_PORT_CMD_RESET);
         if (ret != ESP_OK) {
             ESP_LOGE(HUB_DRIVER_TAG, "Failed to issue root port reset");
@@ -852,8 +872,8 @@ esp_err_t hub_port_reset(usb_device_handle_t parent_dev_hdl, uint8_t parent_port
     } else {
 #if ENABLE_USB_HUBS
         ext_hub_handle_t ext_hub_hdl = NULL;
-        ext_hub_get_handle(parent_dev_hdl, &ext_hub_hdl);
-        ret = ext_hub_port_reset(ext_hub_hdl, parent_port_num);
+        ext_hub_get_handle(dev_tree_node->parent_dev_hdl, &ext_hub_hdl);
+        ret = ext_hub_port_reset(ext_hub_hdl, dev_tree_node->parent_port_num);
         if (ret != ESP_OK) {
             ESP_LOGE(HUB_DRIVER_TAG, "Ext hub port reset error: %s", esp_err_to_name(ret));
         }
@@ -865,19 +885,22 @@ esp_err_t hub_port_reset(usb_device_handle_t parent_dev_hdl, uint8_t parent_port
     return ret;
 }
 
-esp_err_t hub_port_active(usb_device_handle_t parent_dev_hdl, uint8_t parent_port_num)
+esp_err_t hub_node_active(unsigned int node_uid)
 {
     esp_err_t ret;
 
-    if (parent_port_num == 0) {
+    dev_tree_node_t *dev_tree_node = dev_tree_node_get_by_uid(node_uid);
+    HUB_DRIVER_CHECK(dev_tree_node != NULL, ESP_ERR_NOT_FOUND);
+
+    if (dev_tree_node->parent_dev_hdl == NULL) {
         // Root port no need to be activated
         ret = ESP_OK;
     } else {
 #if ENABLE_USB_HUBS
         // External Hub port
         ext_hub_handle_t ext_hub_hdl = NULL;
-        ext_hub_get_handle(parent_dev_hdl, &ext_hub_hdl);
-        ret = ext_hub_port_active(ext_hub_hdl, parent_port_num);
+        ext_hub_get_handle(dev_tree_node->parent_dev_hdl, &ext_hub_hdl);
+        ret = ext_hub_port_active(ext_hub_hdl, dev_tree_node->parent_port_num);
         if (ret != ESP_OK) {
             ESP_LOGE(HUB_DRIVER_TAG, "Ext hub port activation error: %s", esp_err_to_name(ret));
         }
@@ -889,20 +912,23 @@ esp_err_t hub_port_active(usb_device_handle_t parent_dev_hdl, uint8_t parent_por
     return ret;
 }
 
-esp_err_t hub_port_disable(usb_device_handle_t parent_dev_hdl, uint8_t parent_port_num)
+esp_err_t hub_node_disable(unsigned int node_uid)
 {
     esp_err_t ret;
 
-    if (parent_port_num == 0) {
+    dev_tree_node_t *dev_tree_node = dev_tree_node_get_by_uid(node_uid);
+    HUB_DRIVER_CHECK(dev_tree_node != NULL, ESP_ERR_NOT_FOUND);
+
+    if (dev_tree_node->parent_dev_hdl == NULL) {
         ret = root_port_disable();
     } else {
 #if ENABLE_USB_HUBS
         // External Hub port
         ext_hub_handle_t ext_hub_hdl = NULL;
-        ext_hub_get_handle(parent_dev_hdl, &ext_hub_hdl);
-        ret = ext_hub_port_disable(ext_hub_hdl, parent_port_num);
+        ext_hub_get_handle(dev_tree_node->parent_dev_hdl, &ext_hub_hdl);
+        ret = ext_hub_port_disable(ext_hub_hdl, dev_tree_node->parent_port_num);
 #else
-        ESP_LOGW(HUB_DRIVER_TAG, "Activating External Port is not available (External Hub support disabled)");
+        ESP_LOGW(HUB_DRIVER_TAG, "Disabling External Port is not available (External Hub support disabled)");
         ret = ESP_ERR_NOT_SUPPORTED;
 #endif // ENABLE_USB_HUBS
     }

--- a/host/usb/src/usb_host.c
+++ b/host/usb/src/usb_host.c
@@ -368,11 +368,9 @@ static void usbh_event_callback(usbh_event_data_t *event_data, void *arg)
         break;
     }
     case USBH_EVENT_DEV_FREE: {
-        // Let the Hub driver know that the device is free and its port can be recycled
-        // Port could be absent, no need to verify
-        hub_port_recycle(event_data->dev_free_data.parent_dev_hdl,
-                         event_data->dev_free_data.port_num,
-                         event_data->dev_free_data.dev_uid);
+        // Let the Hub driver know that the device is free and its node can be free and port re-enabled
+        // Node could be already freed on device disconnect (when clients still holding the device opened), no need to verify result
+        hub_node_recycle(event_data->dev_free_data.dev_uid);
         break;
     }
     case USBH_EVENT_ALL_FREE: {
@@ -447,16 +445,16 @@ static void enum_event_callback(enum_event_data_t *event_data, void *arg)
         break;
     case ENUM_EVENT_RESET_REQUIRED:
         // Device may be gone, don't need to verify result
-        hub_port_reset(event_data->reset_req.parent_dev_hdl, event_data->reset_req.parent_port_num);
+        hub_node_reset(event_data->node_uid);
         break;
     case ENUM_EVENT_COMPLETED:
         // Notify port that device completed enumeration
-        hub_port_active(event_data->complete.parent_dev_hdl, event_data->complete.parent_port_num);
+        hub_node_active(event_data->node_uid);
         // Propagate a new device event
-        ESP_ERROR_CHECK(usbh_devs_new_dev_event(event_data->complete.dev_hdl));
+        ESP_ERROR_CHECK(usbh_devs_new_dev_event(event_data->dev_hdl));
         break;
     case ENUM_EVENT_CANCELED:
-        hub_port_disable(event_data->canceled.parent_dev_hdl, event_data->canceled.parent_port_num);
+        hub_node_disable(event_data->node_uid);
         break;
     default:
         abort();    // Should never occur


### PR DESCRIPTION
## Description

Removed parent device information from the Enumeration Driver. The Driver operates only with device tree node and its uid.

## Related

- Cherry-picked from https://github.com/espressif/esp-usb/pull/267
- Follow-up in https://github.com/espressif/esp-usb/pull/289
- Relates to [IDF-10023 - Move parent-child tree management responsibility to Hub Driver](https://jira.espressif.com:8443/browse/IDF-10023)

## Testing

USB Host target tests with and without external hub.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Enum and Hub to operate by device-tree node UID, renaming hub_port_* -> hub_node_* and simplifying enum events to carry node_uid/dev_hdl.
> 
> - **API**:
>   - **Enum events**: `enum_event_data_t` simplified to `event`, `node_uid`, `dev_hdl`; per-event unions and parent port fields removed.
>   - **Hub API rename**: `hub_port_{recycle,reset,active,disable}` -> `hub_node_{recycle,reset,active,disable}`; params now `node_uid`; add `ESP_ERR_NOT_FOUND` when node missing.
> - **Hub Driver**:
>   - Add `dev_tree_node_get_by_uid()` and use node-based operations for root/external hubs in recycle/reset/active/disable paths.
>   - Node removal now keyed by parent info retrieved from node; improved messages.
> - **Enum Driver**:
>   - Track `node_uid` instead of parent handle/port; update event emissions (started/reset-required/completed/canceled) and logging; cleanup state accordingly.
>   - No functional enum sequence change; internal logs/error handling slightly adjusted.
> - **Host Library**:
>   - Update callbacks to use `hub_node_*` and new enum event data; on `DEV_FREE` call `hub_node_recycle(uid)`.
> - **Meta**: SPDX year ranges updated in touched files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 257d193b8cb838f68507a088c0e22f0cd3053316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->