### PR TITLE
fix(device): Fix forward compatibility with TinyUSB 0.19

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- Fixed forward compatibility with TinyUSB 0.19
+
 ## 2.0.1
 
 - esp_tinyusb: Added ESP32H4 support

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -11,5 +11,5 @@ targets:
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
-    version: '>=0.17.0'
+    version: '>=0.17.0~2' # 0.17.0~2 is the first version that supports deinit
     public: true

--- a/device/esp_tinyusb/tinyusb.c
+++ b/device/esp_tinyusb/tinyusb.c
@@ -32,11 +32,6 @@ typedef struct {
 
 static tinyusb_ctx_t s_ctx; // TinyUSB context
 
-// For the tinyusb component without tusb_teardown() implementation
-#ifndef tusb_teardown
-#   define tusb_teardown()   (true)
-#endif // tusb_teardown
-
 // ==================================================================================
 // ============================= TinyUSB Callbacks ==================================
 // ==================================================================================

--- a/device/esp_tinyusb/tinyusb_task.c
+++ b/device/esp_tinyusb/tinyusb_task.c
@@ -14,6 +14,10 @@
 #include "sdkconfig.h"
 #include "descriptors_control.h"
 
+#ifndef tusb_deinit
+#define tusb_deinit(x)  tusb_teardown(x)  // For compatibility with tinyusb component versions from 0.17.0~2 to 0.18.0~5
+#endif // tusb_deinit
+
 const static char *TAG = "tinyusb_task";
 
 static portMUX_TYPE tusb_task_lock = portMUX_INITIALIZER_UNLOCKED;
@@ -176,7 +180,7 @@ esp_err_t tinyusb_task_stop(void)
     // Free descriptors
     tinyusb_descriptors_free();
     // Stop TinyUSB stack
-    ESP_RETURN_ON_FALSE(tusb_rhport_teardown(task_ctx->rhport), ESP_ERR_NOT_FINISHED, TAG, "Unable to teardown TinyUSB stack");
+    ESP_RETURN_ON_FALSE(tusb_deinit(task_ctx->rhport), ESP_ERR_NOT_FINISHED, TAG, "Unable to teardown TinyUSB stack");
     // Cleanup
     heap_caps_free(task_ctx);
     return ESP_OK;

--- a/host/usb/test/target_test/enum/main/idf_component.yml
+++ b/host/usb/test/target_test/enum/main/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
 dependencies:
   espressif/tinyusb:
-    version: '>=0.17.0'
+    version: '>=0.18.0'
     public: true

--- a/host/usb/test/target_test/enum/main/mock_dev.c
+++ b/host/usb/test/target_test/enum/main/mock_dev.c
@@ -28,6 +28,10 @@
 #define USB_SRP_BVALID_IN_IDX       USB_SRP_BVALID_PAD_IN_IDX
 #endif // CONFIG_IDF_TARGET_ESP32P4
 
+#ifndef tusb_deinit
+#define tusb_deinit(x)  tusb_teardown(x)  // For compatibility with older tinyusb component versions
+#endif // tusb_deinit
+
 //
 // Test configuration
 //
@@ -56,13 +60,6 @@ static void mock_dev_remove(void)
         vTaskDelay(pdMS_TO_TICKS(mock_dev_cfg->conn_dconn.delay_ms));
     }
 }
-
-//
-// TinyUSB driver related logic
-//
-#ifndef tusb_teardown
-#warning "Teardown feature is not available, please use tinyUSB component with tusb_teardown() support"
-#endif // tusb_teardown
 
 static void mock_device_task(void *arg)
 {
@@ -121,7 +118,7 @@ void mock_dev_release(void)
     // Remove mock USB device
     mock_dev_remove();
     // Uninstall TinyUSB driver
-    tusb_teardown();
+    tusb_deinit(0);
 
     // Delete device handling task
     if (mock_device_task_hdl) {


### PR DESCRIPTION
tusb_teardown() has been renamed to tusb_deinit() in TinyUSB 0.19. https://github.com/hathach/tinyusb/commit/f14fcaa84d44855ac3718eb2a786114385b53657

Related to https://github.com/espressif/tinyusb/pull/60

@roma-jam are there any other places we must change?
