### PR TITLE
fix(esp_tinyusb): Fix compatibility with tinyusb 0.19

### DIFF
--- a/device/esp_tinyusb/tinyusb_task.c
+++ b/device/esp_tinyusb/tinyusb_task.c
@@ -14,9 +14,9 @@
 #include "sdkconfig.h"
 #include "descriptors_control.h"
 
-#ifndef tusb_deinit
+#if TUSB_VERSION_NUMBER < 1900 // < 0.19.0
 #define tusb_deinit(x)  tusb_teardown(x)  // For compatibility with tinyusb component versions from 0.17.0~2 to 0.18.0~5
-#endif // tusb_deinit
+#endif
 
 const static char *TAG = "tinyusb_task";
 

--- a/host/usb/test/target_test/enum/main/mock_dev.c
+++ b/host/usb/test/target_test/enum/main/mock_dev.c
@@ -28,9 +28,9 @@
 #define USB_SRP_BVALID_IN_IDX       USB_SRP_BVALID_PAD_IN_IDX
 #endif // CONFIG_IDF_TARGET_ESP32P4
 
-#ifndef tusb_deinit
-#define tusb_deinit(x)  tusb_teardown(x)  // For compatibility with older tinyusb component versions
-#endif // tusb_deinit
+#if TUSB_VERSION_NUMBER < 1900 // < 0.19.0
+#define tusb_deinit(x)  tusb_teardown(x)  // For compatibility with tinyusb component versions from 0.17.0~2 to 0.18.0~5
+#endif
 
 //
 // Test configuration


### PR DESCRIPTION
Fix of https://github.com/espressif/esp-usb/pull/292