### PR TITLE
ci: Enable preview target builds

### DIFF
--- a/.github/ci/.idf_build_examples_config.toml
+++ b/.github/ci/.idf_build_examples_config.toml
@@ -14,6 +14,7 @@ exclude = [
 recursive = true
 check_warnings = true
 target = "all"
+enable_preview_targets = true
 
 # build related options
 build_dir = "build_@t_@w"

--- a/.github/workflows/build_and_run_host_test.yml
+++ b/.github/workflows/build_and_run_host_test.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install pytest pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyusb idf-build-apps==2.12.2 --upgrade
+          pip install pytest pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyusb idf-build-apps==2.13.3 --upgrade
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           . ${IDF_PATH}/export.sh
           git config --global safe.directory $(pwd)
-          pip install idf-build-apps==2.12.2 --upgrade
+          pip install idf-build-apps==2.13.3 --upgrade
           export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
           export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
           export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"

--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install idf-component-manager>=2.1.2 idf-build-apps==2.12.2 pyyaml --upgrade
+          pip install idf-component-manager>=2.1.2 idf-build-apps==2.13.3 pyyaml --upgrade
       - name: Setup IDF Examples path
         run: echo "EXAMPLES_PATH=${IDF_PATH}/examples/peripherals/usb" >> $GITHUB_ENV
       - name: Override device component

--- a/.idf_build_apps.toml
+++ b/.idf_build_apps.toml
@@ -5,6 +5,8 @@ exclude = [
 recursive = true
 manifest_file = ".build-test-rules.yml"
 check_warnings = true
+target = "all"
+enable_preview_targets = true
 
 # build related options
 build_dir = "build_@t_@w"


### PR DESCRIPTION
This will enable ESP32-H4 builds on esp-idf/master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables preview target builds and updates CI to use idf-build-apps 2.13.3 across workflows.
> 
> - **CI configuration**:
>   - Enable preview targets by setting `enable_preview_targets = true` in `.github/ci/.idf_build_examples_config.toml` and `.idf_build_apps.toml`.
>   - Set `target = "all"` in `.idf_build_apps.toml`.
> - **Workflows**:
>   - Upgrade `idf-build-apps` from `2.12.2` to `2.13.3` in:
>     - `.github/workflows/build_and_run_host_test.yml`
>     - `.github/workflows/build_and_run_test_app_usb.yml`
>     - `.github/workflows/build_idf_examples.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1800fe148b6aa1e073d754793903c3a4747d38c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->