### PR TITLE
fix(ci): Temp disable UVC example build in idf for idf 5.5

### DIFF
--- a/.github/ci/.idf-build-examples-rules.yml
+++ b/.github/ci/.idf-build-examples-rules.yml
@@ -21,9 +21,13 @@ examples/peripherals/usb/host:
   disable:
     - if: SOC_USB_OTG_SUPPORTED != 1
 
+#TODO: Change back to:
+#    - if: (IDF_VERSION >= "5.5.0")
+#      reason: Run UVC example starts using UVC driver 2.0 only on IDF version 5.5
+# After the release/v5.5 docker is updated
 examples/peripherals/usb/host/uvc:
   enable:
-    - if: (IDF_VERSION >= "5.5.0")
-      reason: Run UVC example starts using UVC driver 2.0 only on IDF version 5.5
+    - if: (IDF_VERSION >= "6.0.0")
+      reason: Temporarily build only for IDF 6.0
   disable:
     - if: SOC_USB_OTG_SUPPORTED != 1


### PR DESCRIPTION
Temporarily disable UVC Example build for IDF 5.5, as the docker image of the `release-v5.5` has not been updated in month.

## Related

Unlock CI for:
- #251 
- #265 
- #296

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
