### PR TITLE
release(usb_host_lib): v1.0.1

### DIFF
--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.1] - 2025-10-16
 
 ### Fixed
 

--- a/host/usb/idf_component.yml
+++ b/host/usb/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 description: USB Host library
-version: "1.0.1-rc0"
+version: "1.0.1"
 url: https://github.com/espressif/esp-usb/tree/master/host/usb
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html"
 issues: "https://github.com/espressif/esp-usb/issues"


### PR DESCRIPTION
# usb component, [1.0.1](https://components.espressif.com/components/espressif/usb/versions/1.0.1) 

## Changes

- Compatibility with esp-idf 5.5 and 5.4 releases
- Printing of High Speed periodic endpoint descriptor now also shows additional transactions in microframe

## Related
- https://github.com/espressif/esp-usb/pull/273
- https://github.com/espressif/esp-usb/pull/271
- https://github.com/espressif/esp-usb/pull/286
- https://github.com/espressif/esp-usb/pull/282
- https://github.com/espressif/esp-usb/pull/287
- https://github.com/espressif/esp-usb/pull/251

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary
