### PR TITLE
temp: Use TinyUSB 0.19 in CI

### DIFF
--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -11,5 +11,5 @@ targets:
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
-    version: '>=0.17.0~2' # 0.17.0~2 is the first version that supports deinit
+    version: '==0.19.0~1-rc0'
     public: true

--- a/host/usb/test/target_test/enum/main/idf_component.yml
+++ b/host/usb/test/target_test/enum/main/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
 dependencies:
   espressif/tinyusb:
-    version: '>=0.18.0'
+    version: '==0.19.0~1-rc0'
     public: true


### PR DESCRIPTION
This PR only runs CI to verify TinyUSB 0.19.0~0-rc0 before we release it.

_**EDIT:**_ ESP32-H4 build was performed locally (due to buggy idf-build-apps). All PASS