### PR TITLE
fix(esp_tinyusb_test): USB component dependency in for IDF >= 6.0

### DIFF
--- a/device/esp_tinyusb/test_apps/runtime_config/main/CMakeLists.txt
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/CMakeLists.txt
@@ -1,6 +1,13 @@
+# 1. USB component dependency in IDF < 6.0 is used only to access USB PHY
+# 2. USB PHY was removed from the usb component in IDF 6.0 to esp_hw_support
+set(priv_requires "")
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND priv_requires usb)
+endif()
+
 idf_component_register(SRC_DIRS .
                        INCLUDE_DIRS .
                        PRIV_INCLUDE_DIRS "../../../include_private"
-                       PRIV_REQUIRES usb
+                       PRIV_REQUIRES ${priv_requires}
                        REQUIRES unity
                        WHOLE_ARCHIVE)


### PR DESCRIPTION
## Related

Fixing build of test application `esp_tinyusb/test_apps/runtime_config`, which is accessing USB PHY from the USB component. The USB PHY was removed from the USB component in IDF 6.0.

Fixing CI for #265 

<details>
<summary> CI build log error of runtime_config test app </summary>

```
-- Configuring incomplete, errors occurred!
HINT: The component 'usb' could not be found. This could be because: component name was misspelled, the component was not added to the build, the component has been moved to the IDF component manager, the component has been removed and refactored into some other component or the component may not be supported by the selected target.
Please look out for component in 'https://components.espressif.com/' and add using 'idf.py add-dependency' command.
Refer to the migration guide for more details about moved components.
Refer to the build-system guide for more details about how components are found and included in the build.
HINT: USB host layer ('usb' component) was removed from ESP-IDF. Please use 'usb' component from IDF component manager instead.
You can install 'usb' component using 'idf.py add-dependency espressif/usb' command.
Refer to the migration guide for more details.
```

</details>

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
