### PR TITLE
feat(ci): Add IDF release-v6.0 to CI workflows

### DIFF
--- a/.github/workflows/build_and_run_main_ci.yml
+++ b/.github/workflows/build_and_run_main_ci.yml
@@ -19,5 +19,11 @@ jobs:
   build_run:
     uses: ./.github/workflows/build_and_run_test_app_usb.yml
     with:
-      idf_releases: '["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]'
+      idf_releases: '["release-v5.1",
+                      "release-v5.2",
+                      "release-v5.3",
+                      "release-v5.4",
+                      "release-v5.5",
+                      "release-v6.0",
+                      "latest"]'
       idf_targets: '["esp32s2", "esp32p4"]'

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -46,7 +46,9 @@ jobs:
             idf_ver: "release-v5.2"
           - test_app: host_managed
             idf_ver: "release-v5.3"
-            #Exclude native usb component for IDF Latest (usb component has been removed from esp-idf)
+          # Exclude native usb component for IDF >= 6 (usb component has been removed from esp-idf)
+          - test_app: host_native
+            idf_ver: "release-v6.0"
           - test_app: host_native
             idf_ver: "latest"
 
@@ -116,7 +118,9 @@ jobs:
             idf_ver: "release-v5.2"
           - test_app: host_managed
             idf_ver: "release-v5.3"
-            #Exclude native usb component for IDF Latest (usb component has been removed from esp-idf)
+          # Exclude native usb component for IDF >= 6 (usb component has been removed from esp-idf)
+          - test_app: host_native
+            idf_ver: "release-v6.0"
           - test_app: host_native
             idf_ver: "latest"
 

--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -24,6 +24,7 @@ jobs:
             "release-v5.3",
             "release-v5.4",
             "release-v5.5",
+            "release-v6.0",
             "latest",
           ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Adding `release-v6.0` to the CI workflows

## Related

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add IDF release-v6.0 to CI matrices and exclude host_native USB tests/builds for IDF >= 6.
> 
> - **CI workflows**:
>   - **IDF versions**:
>     - Add `"release-v6.0"` to `idf_releases`/`idf_ver` matrices in `/.github/workflows/build_and_run_main_ci.yml` and `/.github/workflows/build_idf_examples.yml`.
>   - **USB host-native exclusions**:
>     - In `/.github/workflows/build_and_run_test_app_usb.yml`, exclude `host_native` for `idf_ver: "release-v6.0"` (in both build and run jobs) alongside `latest`; update comment to indicate exclusion for IDF >= 6.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaddc1b893eee7f020795fe2ea206e6f1e43a6c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->