### PR TITLE
feature(tinyusb): Software VBUS monitoring feature on ESP32P4 (part2/2) [WIP] (IEC-436)

### DIFF
--- a/device/esp_tinyusb/include_private/tinyusb_vbus_monitor.h
+++ b/device/esp_tinyusb/include_private/tinyusb_vbus_monitor.h
@@ -30,14 +30,20 @@ typedef struct {
  *
  * @return
  *    - ESP_ERR_INVALID_ARG if config is NULL
+ *    - ESP_ERR_INVALID_STATE if VBUS monitoring is already initialized
+ *    - ESP_ERR_NO_MEM if debounce timer creation failed
  *    - ESP_OK if VBUS monitoring was initialized successfully
  */
 esp_err_t tinyusb_vbus_monitor_init(tinyusb_vbus_monitor_config_t *config);
 
 /**
  * @brief Deinitialize VBUS monitoring
+ *
+ * @return
+ *    - ESP_ERR_INVALID_STATE if VBUS monitoring is not initialized
+ *    - ESP_OK on success
  */
-void tinyusb_vbus_monitor_deinit(void);
+esp_err_t tinyusb_vbus_monitor_deinit(void);
 
 #ifdef __cplusplus
 }

--- a/device/esp_tinyusb/tinyusb_vbus_monitor.c
+++ b/device/esp_tinyusb/tinyusb_vbus_monitor.c
@@ -8,9 +8,19 @@
 #include "esp_log.h"
 #include "esp_err.h"
 #include "esp_check.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/timers.h"
+#include "driver/gpio.h"
 #include "tinyusb_vbus_monitor.h"
 
 const static char *TAG = "VBUS mon";
+
+#if (CONFIG_IDF_TARGET_ESP32P4)
+#include "soc/usb_dwc_struct.h"
+// On ESP32-P4 USB OTG 2.0 signals are not wired to GPIO matrix
+// So we need to override the Bvalid signal from PHY
+#define USB_DWC_REG                     USB_DWC_HS
+#endif // CONFIG_IDF_TARGET_ESP32P4
 
 /**
  * @brief VBUS monitoring context
@@ -23,16 +33,219 @@ typedef struct {
     TimerHandle_t debounce_timer;   /*!< Debounce timer handle */
 } vbus_monitor_context_t;
 
+static vbus_monitor_context_t _vbus_ctx = {
+    .gpio_num = GPIO_NUM_NC,
+    .prev_state = false,
+    .debounce_timer = NULL,
+};
+
+//
+// Additional low-level USB DWC functions, which are not present in the IDF USB DWC HAL
+//
+
+// --------------- GOTGCTL register ------------------
+
+static void usb_dwc_ll_gotgctl_set_bvalid_override_value(usb_dwc_dev_t *hw, uint8_t value)
+{
+    hw->gotgctl_reg.bvalidovval = value;
+}
+
+static void usb_dwc_ll_gotgctl_enable_bvalid_override(usb_dwc_dev_t *hw, bool enable)
+{
+    hw->gotgctl_reg.bvalidoven = enable ? 1 : 0;
+}
+
+// ------------------ DCTL register --------------------
+
+static void usb_dwc_ll_dctl_set_soft_disconnect(usb_dwc_dev_t *hw, bool enable)
+{
+    hw->dctl_reg.sftdiscon = enable ? 1 : 0;
+}
+
+// -------------- VBUS Internal Logic ------------------
+
+/**
+ * @brief Handle VBUS appeared event
+ */
+static void vbus_appeared(void)
+{
+    ESP_LOGD(TAG, "Appeared");
+    usb_dwc_ll_gotgctl_set_bvalid_override_value(&USB_DWC_REG, 1);
+    usb_dwc_ll_dctl_set_soft_disconnect(&USB_DWC_REG, false);
+}
+
+/**
+ * @brief Handle VBUS disappeared event
+ */
+static void vbus_disappeared(void)
+{
+    ESP_LOGD(TAG, "Disappeared");
+    usb_dwc_ll_gotgctl_set_bvalid_override_value(&USB_DWC_REG, 0);
+    usb_dwc_ll_dctl_set_soft_disconnect(&USB_DWC_REG, true);
+}
+
+/**
+ * @brief GPIO interrupt handler for VBUS monitoring io
+ *
+ * @param arg GPIO number
+ */
+static void vbus_io_cb(void *arg)
+{
+    (void) arg;
+    // disable interrupts for a while to debounce
+    gpio_intr_disable(_vbus_ctx.gpio_num);
+
+    bool vbus_curr_state = gpio_get_level(_vbus_ctx.gpio_num);
+
+    if (_vbus_ctx.prev_state != vbus_curr_state) {
+        _vbus_ctx.prev_state = vbus_curr_state;
+        // VBUS pin state has changed, start the debounce timer
+        BaseType_t yield = pdFALSE;
+        if (xTimerStartFromISR(_vbus_ctx.debounce_timer, &yield) != pdPASS) {
+            ESP_EARLY_LOGE(TAG, "Failed to start VBUS debounce timer");
+        }
+        if (yield == pdTRUE) {
+            portYIELD_FROM_ISR();
+        }
+    } else {
+        // VBUS gpio glitch, ignore and re-enable interrupt
+        ESP_ERROR_CHECK(gpio_intr_enable(_vbus_ctx.gpio_num));
+    }
+}
+
+/**
+ * @brief VBUS debounce timer callback
+ *
+ * @param xTimer Timer handle
+ */
+static void vbus_debounce_timer_cb(TimerHandle_t xTimer)
+{
+    bool vbus_prev_state = _vbus_ctx.prev_state;
+    bool vbus_curr_state = gpio_get_level(_vbus_ctx.gpio_num);
+
+    if (vbus_curr_state && vbus_prev_state) {
+        vbus_appeared();
+    } else if (!vbus_curr_state && !vbus_prev_state) {
+        vbus_disappeared();
+    } else {
+        // State changed again during debounce period, ignore
+    }
+    // Update the state
+    _vbus_ctx.prev_state = vbus_curr_state;
+    // Re-enable GPIO interrupt
+    ESP_ERROR_CHECK(gpio_intr_enable(_vbus_ctx.gpio_num));
+}
+
 // -------------- Public API ------------------
 
 esp_err_t tinyusb_vbus_monitor_init(tinyusb_vbus_monitor_config_t *config)
 {
     ESP_RETURN_ON_FALSE(config != NULL, ESP_ERR_INVALID_ARG, TAG, "Invalid argument: config is NULL");
+
+    esp_err_t ret;
+    // There could be only one instance of VBUS monitoring
+    if (_vbus_ctx.debounce_timer != NULL) {
+        ESP_LOGE(TAG, "Already initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    _vbus_ctx.gpio_num = config->gpio_num;
+    _vbus_ctx.prev_state = false;
+
+    // VBUS Debounce timer
+    _vbus_ctx.debounce_timer = xTimerCreate("vbus_debounce_timer",
+                                            pdMS_TO_TICKS(config->debounce_delay_ms),
+                                            pdFALSE,
+                                            NULL,
+                                            vbus_debounce_timer_cb);
+
+    if (_vbus_ctx.debounce_timer == NULL) {
+        ESP_LOGE(TAG, "Create VBUS debounce timer failed");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Init gpio IRQ for VBUS monitoring
+    const gpio_config_t vbus_io_cfg = {
+        .pin_bit_mask = BIT64(_vbus_ctx.gpio_num),
+        .mode = GPIO_MODE_INPUT,
+        .pull_down_en = GPIO_PULLDOWN_ENABLE,
+        .intr_type = GPIO_INTR_ANYEDGE,
+    };
+
+    ret = gpio_config(&vbus_io_cfg);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to configure VBUS GPIO%d: %s", _vbus_ctx.gpio_num, esp_err_to_name(ret));
+        goto gpio_fail;
+    }
+
+    ret = gpio_isr_handler_add(_vbus_ctx.gpio_num, vbus_io_cb, (void *) NULL);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to add ISR handler for GPIO%d: %s", _vbus_ctx.gpio_num, esp_err_to_name(ret));
+        goto isr_err;
+    }
+    // Disable GPIO interrupt
+    gpio_intr_disable(_vbus_ctx.gpio_num);
+    // Set initial Bvalid override value and enable override
+    usb_dwc_ll_gotgctl_set_bvalid_override_value(&USB_DWC_REG, 0);
+    // Wait 1 microsecond (sufficient for >5 PHY clocks)
+    esp_rom_delay_us(1);
+    // Enable to override the signal from PHY
+    usb_dwc_ll_gotgctl_enable_bvalid_override(&USB_DWC_REG, true);
+
+    // Device could be already connected, check the status and start the timer if needed
+    if (gpio_get_level(_vbus_ctx.gpio_num)) {
+        _vbus_ctx.prev_state = true;
+        // Start debounce timer
+        if (xTimerStart(_vbus_ctx.debounce_timer, 0) != pdPASS) {
+            ESP_LOGE(TAG, "Failed to start VBUS debounce timer");
+            goto timer_err;
+        }
+    } else {
+        // Enable GPIO interrupt
+        ESP_ERROR_CHECK(gpio_intr_enable(_vbus_ctx.gpio_num));
+    }
+
     ESP_LOGD(TAG, "Init GPIO%d, debounce delay: %"PRIu32" ms", config->gpio_num, config->debounce_delay_ms);
-    return ESP_OK; // Return success to unblock the usb_host_msc test, where the vbus monitor is used
+    return ESP_OK;
+
+timer_err:
+    gpio_isr_handler_remove(_vbus_ctx.gpio_num);
+    usb_dwc_ll_gotgctl_enable_bvalid_override(&USB_DWC_REG, false);
+isr_err:
+    gpio_reset_pin(_vbus_ctx.gpio_num);
+    _vbus_ctx.gpio_num = GPIO_NUM_NC;
+gpio_fail:
+    if (_vbus_ctx.debounce_timer) {
+        xTimerDelete(_vbus_ctx.debounce_timer, 0);
+        _vbus_ctx.debounce_timer = NULL;
+    }
+    return ret;
 }
 
-void tinyusb_vbus_monitor_deinit(void)
+esp_err_t tinyusb_vbus_monitor_deinit(void)
 {
+    if (_vbus_ctx.debounce_timer == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    // Reset GPIO to the default state
+    ESP_ERROR_CHECK(gpio_reset_pin(_vbus_ctx.gpio_num));
+    // Remove gpio IRQ for VBUS monitoring
+    esp_err_t ret = gpio_isr_handler_remove(_vbus_ctx.gpio_num);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to remove ISR handler for GPIO%d: %s", _vbus_ctx.gpio_num, esp_err_to_name(ret));
+        return ret;
+    }
+    _vbus_ctx.gpio_num = GPIO_NUM_NC;
+
+    // Disable Debounce timer
+    if (xTimerIsTimerActive(_vbus_ctx.debounce_timer) == pdTRUE) {
+        xTimerStop(_vbus_ctx.debounce_timer, 0);
+    }
+    xTimerDelete(_vbus_ctx.debounce_timer, 0);
+    _vbus_ctx.debounce_timer = NULL;
+
+    // Disable to override the signal from PHY
+    usb_dwc_ll_gotgctl_enable_bvalid_override(&USB_DWC_REG, false);
     ESP_LOGD(TAG, "Deinit");
+    return ESP_OK;
 }

--- a/host/class/msc/usb_host_msc/test_app/main/msc_device.c
+++ b/host/class/msc/usb_host_msc/test_app/main/msc_device.c
@@ -133,7 +133,9 @@ static void storage_init(void)
     tusb_cfg.descriptor.string_count = sizeof(string_desc_arr) / sizeof(string_desc_arr[0]);
     tusb_cfg.phy.self_powered = true;
     tusb_cfg.phy.vbus_monitor_io = VBUS_MONITORING_GPIO_NUM;
-
+#if (CONFIG_IDF_TARGET_ESP32P4)
+    gpio_install_isr_service(ESP_INTR_FLAG_LOWMED);
+#endif // CONFIG_IDF_TARGET_ESP32P4
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
     ESP_LOGI(TAG, "USB initialization DONE");
 }


### PR DESCRIPTION
## Description

### VBUS monitoring on ESP32-P4 - Part 2/2

- added GPIO ISR + debounce timer + debounce logic; drive GOTGCTL.BVALID on VBUS appear/disappear.

## Related
- Prerequisites in https://github.com/espressif/esp-usb/pull/305
- Closes [IDF-10720](https://jira.espressif.com:8443/browse/IDF-10720)

## Testing

- Enabling CI test for vbus_monitor on esp32p4

### Verification

Verification is made by launching the vbus_monitor test application test cases. 
To verify all scenarios, additional hardware features should be done with a dev board: 
1. Connect GPIO4 and GPIO5 together (for controlled vbus test)
2. Add the resistor divider, connected to the +5V of the usb port (the +5V point was taken from the drain of Q3 and Q4) 

- [x] ESP32-P4 ECO4
- Does not support ESP32-P4 ECO5  (Support in https://github.com/espressif/esp-usb/pull/313)

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements GPIO ISR + debounce-driven VBUS monitoring (with DWC BVALID override/soft-disconnect) on ESP32-P4, updates API to return esp_err, and enables corresponding tests and example setup.
> 
> - **Device (VBUS monitor)**:
>   - Implement ISR-based GPIO VBUS monitoring with FreeRTOS debounce timer in `device/esp_tinyusb/tinyusb_vbus_monitor.c`.
>   - Add low-level DWC helpers and drive `GOTGCTL.BVALID` and `DCTL.SFTDISCON` on VBUS appear/disappear (ESP32-P4).
>   - Robust init: single-instance guard, GPIO config/ISR hookup, debounce timer creation, BVALID override enable; start timer if VBUS already high.
>   - Deinit now returns `esp_err_t`; cleans up ISR, GPIO, timer, and disables BVALID override.
>   - Header `tinyusb_vbus_monitor.h`: document new error returns; change `tinyusb_vbus_monitor_deinit` signature to return `esp_err_t`.
> - **Tests (`test_vbus_monitor.c`)**:
>   - Enable GOTGCTL-based attach/detach test and replace placeholders with real routines.
>   - For controlled/real VBUS tests on OTG 2.0, install/uninstall GPIO ISR service.
> - **Example (MSC test app)**:
>   - On ESP32-P4, install GPIO ISR service before `tinyusb_driver_install` in `msc_device.c`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b9d6ea0fc0ac6a64c9bb273528fd0edbab2da77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->