### PR TITLE
feature(esp_tinyusb): Remote wakeup device test application [WIP]

### DIFF
--- a/device/esp_tinyusb/test_apps/remote_wakeup/CMakeLists.txt
+++ b/device/esp_tinyusb/test_apps/remote_wakeup/CMakeLists.txt
@@ -1,0 +1,9 @@
+# The following lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# "Trim" the build. Include the minimal set of components, main, and anything it depends on.
+idf_build_set_property(MINIMAL_BUILD ON)
+
+project(test_app_remote_wakeup)

--- a/device/esp_tinyusb/test_apps/remote_wakeup/main/CMakeLists.txt
+++ b/device/esp_tinyusb/test_apps/remote_wakeup/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(SRC_DIRS .
+                       INCLUDE_DIRS .
+                       REQUIRES unity
+                       PRIV_REQUIRES fatfs wear_levelling esp_partition esp_timer
+                       WHOLE_ARCHIVE)

--- a/device/esp_tinyusb/test_apps/remote_wakeup/main/device_common.c
+++ b/device/esp_tinyusb/test_apps/remote_wakeup/main/device_common.c
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+//
+#include <stdio.h>
+#include <string.h>
+//
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+//
+#include "esp_system.h"
+#include "esp_log.h"
+#include "esp_err.h"
+//
+#include "unity.h"
+#include "tinyusb.h"
+#include "device_common.h"
+
+typedef struct {
+    union {
+        tinyusb_event_id_t tinyusb_event_id;  /*!< Event ID, comes from tinyusb.h */
+        tinyusb_extra_event_id_t extra_event_id;  /*!< Extra Event ID, extra, that isn't handled inside the driver */
+        int id;                             /*!< Common field to get the data of event_id */
+    };
+} test_device_event_t;
+
+#define TEST_QUEUE_LEN                  6       // Length of the queue for storage events
+#define TEST_EVENT_TIMEOUT_MS           30000   // Timeout for waiting storage events
+
+static QueueHandle_t _test_device_event_queue = NULL;
+
+void test_device_setup(void)
+{
+    _test_device_event_queue = xQueueCreate(TEST_QUEUE_LEN, sizeof(test_device_event_t));
+    TEST_ASSERT_NOT_NULL(_test_device_event_queue);
+}
+
+void test_device_teardown(void)
+{
+    TEST_ASSERT_NOT_NULL(_test_device_event_queue);
+    vQueueDelete(_test_device_event_queue);
+    _test_device_event_queue = NULL;
+}
+
+void test_device_wait_event(int event_id)
+{
+    TEST_ASSERT_NOT_NULL(_test_device_event_queue);
+    // Wait for port callback to send an event message
+    test_device_event_t evt;
+    BaseType_t ret = xQueueReceive(_test_device_event_queue, &evt, pdMS_TO_TICKS(TEST_EVENT_TIMEOUT_MS));
+    TEST_ASSERT_EQUAL_MESSAGE(pdPASS, ret, "Device event not generated on time");
+    // Check the contents of that event message
+    TEST_ASSERT_EQUAL_MESSAGE(event_id, evt.id, "Unexpected device event type received");
+}
+
+/**
+ * @brief TinyUSB callback for device mount.
+ *
+ * @note
+ * For Linux-based Hosts: Reflects the SetConfiguration() request from the Host Driver.
+ * For Win-based Hosts: SetConfiguration() request is present only with available Class in device descriptor.
+ */
+void test_device_event_handler(tinyusb_event_t *event, void *arg)
+{
+    test_device_event_t evt = {
+        .tinyusb_event_id = event->id,
+    };
+    xQueueSend(_test_device_event_queue, &evt, portMAX_DELAY);
+}
+
+// Some events are still not handled inside the TinyUSB driver, so we need to forward them manually
+/**
+ * @brief TinyUSB callback for device suspend event.
+ *
+ * This function is called when the USB host suspends the device.
+ *
+ * @param remote_wakeup_en Indicates whether the host has enabled remote wakeup for the device.
+ *        If true, the device is permitted to signal the host to resume communication.
+ */
+void tud_suspend_cb(bool remote_wakeup_en)
+{
+    printf("USB Host suspended the device, remote wakeup enabled: %s\n", remote_wakeup_en ? "true" : "false");
+
+    test_device_event_t evt = {
+        .extra_event_id = TINYUSB_EVENT_SUSPENDED,
+    };
+    xQueueSend(_test_device_event_queue, &evt, portMAX_DELAY);
+}
+
+/**
+ * @brief TinyUSB callback for device resume event.
+ *
+ * This function is called by the TinyUSB stack when the USB host resumes the device
+ * from a suspended state. It forwards the resume event to the test event queue.
+ */
+void tud_resume_cb(void)
+{
+    test_device_event_t evt = {
+        .extra_event_id = TINYUSB_EVENT_RESUMED,
+    };
+    xQueueSend(_test_device_event_queue, &evt, portMAX_DELAY);
+}
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/remote_wakeup/main/device_common.h
+++ b/device/esp_tinyusb/test_apps/remote_wakeup/main/device_common.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "tinyusb.h"
+
+
+#define TINYUSB_EXTRA_EVENT_BASE 10    /*!< Base value to avoid overlap with tinyusb_event_id_t */
+
+typedef enum {
+    TINYUSB_EVENT_SUSPENDED = TINYUSB_EXTRA_EVENT_BASE,     /*!< USB device suspended event, base to not overlap with tinyusb_event_id_t */
+    TINYUSB_EVENT_RESUMED,            /*!< USB device resumed event */
+} tinyusb_extra_event_id_t;
+
+/**
+ * @brief Test device setup
+ */
+void test_device_setup(void);
+
+/**
+ * @brief Test device teardown
+ */
+void test_device_teardown(void);
+
+/**
+ * @brief Test device wait
+ *
+ * @param event_id Event ID to wait for
+ */
+void test_device_wait_event(int event_id);
+
+/**
+ * @brief TinyUSB callback for device mount.
+ *
+ * @note
+ * For Linux-based Hosts: Reflects the SetConfiguration() request from the Host Driver.
+ * For Win-based Hosts: SetConfiguration() request is present only with available Class in device descriptor.
+ */
+void test_device_event_handler(tinyusb_event_t *event, void *arg);

--- a/device/esp_tinyusb/test_apps/remote_wakeup/main/idf_component.yml
+++ b/device/esp_tinyusb/test_apps/remote_wakeup/main/idf_component.yml
@@ -1,0 +1,7 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/esp_tinyusb:
+    version: "*"
+    override_path: "../../../"
+  # espressif/tinyusb:
+    # version: "0.18.0~5"

--- a/device/esp_tinyusb/test_apps/remote_wakeup/main/test_app_main.c
+++ b/device/esp_tinyusb/test_apps/remote_wakeup/main/test_app_main.c
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "unity.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "unity_test_runner.h"
+#include "unity_test_utils_memory.h"
+#include "device_common.h"
+
+/* setUp runs before every test */
+void setUp(void)
+{
+    unity_utils_record_free_mem();
+    test_device_setup();
+}
+
+/* tearDown runs after every test */
+void tearDown(void)
+{
+    // Short delay to allow task to be cleaned up
+    vTaskDelay(10);
+    test_device_teardown();
+    unity_utils_evaluate_leaks();
+}
+
+
+void app_main(void)
+{
+    /*
+                     _   _                       _
+                    | | (_)                     | |
+      ___  ___ _ __ | |_ _ _ __  _   _ _   _ ___| |__
+     / _ \/ __| '_ \| __| | '_ \| | | | | | / __| '_ \
+    |  __/\__ \ |_) | |_| | | | | |_| | |_| \__ \ |_) |
+     \___||___/ .__/ \__|_|_| |_|\__, |\__,_|___/_.__/
+              | |______           __/ |
+              |_|______|         |___/
+      _____ _____ _____ _____
+     |_   _|  ___/  ___|_   _|
+      | | | |__ \ `--.  | |
+      | | |  __| `--. \ | |
+      | | | |___/\__/ / | |
+      \_/ \____/\____/  \_/
+    */
+
+    printf("                 _   _                       _     \n");
+    printf("                | | (_)                     | |    \n");
+    printf("  ___  ___ _ __ | |_ _ _ __  _   _ _   _ ___| |__  \n");
+    printf(" / _ \\/ __| '_ \\| __| | '_ \\| | | | | | / __| '_ \\ \n");
+    printf("|  __/\\__ \\ |_) | |_| | | | | |_| | |_| \\__ \\ |_) |\n");
+    printf(" \\___||___/ .__/ \\__|_|_| |_|\\__, |\\__,_|___/_.__/ \n");
+    printf("          | |______           __/ |               \n");
+    printf("          |_|______|         |___/                \n");
+    printf(" _____ _____ _____ _____                           \n");
+    printf("|_   _|  ___/  ___|_   _|                          \n");
+    printf("  | | | |__ \\ `--.  | |                            \n");
+    printf("  | | |  __| `--. \\ | |                            \n");
+    printf("  | | | |___/\\__/ / | |                            \n");
+    printf("  \\_/ \\____/\\____/  \\_/                            \n");
+
+    unity_utils_setup_heap_record(80);
+    unity_utils_set_leak_level(128); // 128 (default)
+    unity_run_menu();
+}

--- a/device/esp_tinyusb/test_apps/remote_wakeup/main/test_remote_wakeup.c
+++ b/device/esp_tinyusb/test_apps/remote_wakeup/main/test_remote_wakeup.c
@@ -1,0 +1,195 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+//
+#include <stdio.h>
+#include <string.h>
+//
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+//
+#include "class/hid/hid_device.h"
+//
+#include "unity.h"
+#include "device_common.h"
+#include "tinyusb.h"
+#include "tinyusb_default_config.h"
+
+//
+// ========================== TinyUSB HID Device Descriptors ===============================
+//
+
+#define TUSB_DESC_TOTAL_LEN      (TUD_CONFIG_DESC_LEN + CFG_TUD_HID * TUD_HID_DESC_LEN)
+
+/**
+ * @brief HID report descriptor
+ *
+ * In this example we implement Keyboard + Mouse HID device,
+ * so we must define both report descriptors
+ */
+const uint8_t hid_report_descriptor[] = {
+    TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(HID_ITF_PROTOCOL_KEYBOARD)),
+    TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(HID_ITF_PROTOCOL_MOUSE))
+};
+
+/**
+ * @brief Configuration descriptor
+ *
+ * This is a simple configuration descriptor that defines 1 configuration and 1 HID interface
+ */
+static const uint8_t hid_configuration_descriptor[] = {
+    // Configuration number, interface count, string index, total length, attribute, power in mA
+    TUD_CONFIG_DESCRIPTOR(1, 1, 0, TUSB_DESC_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+
+    // Interface number, string index, boot protocol, report descriptor len, EP In address, size & polling interval
+    TUD_HID_DESCRIPTOR(0, 4, false, sizeof(hid_report_descriptor), 0x81, 16, 10),
+};
+
+//
+// =================================== TinyUSB callbacks ===========================================
+//
+
+/**
+ * @brief Get Report Descriptor callback
+ *
+ * - Invoked when received GET HID REPORT DESCRIPTOR request
+ * - Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+ */
+uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance)
+{
+    // We use only one interface and one HID report descriptor, so we can ignore parameter 'instance'
+    return hid_report_descriptor;
+}
+
+/**
+ * @brief Get Report callback
+ *
+ * - Invoked when received GET_REPORT control request
+ * - Application must fill buffer report's content and return its length.
+ * - Return zero will cause the stack to STALL request
+ */
+uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t *buffer, uint16_t reqlen)
+{
+    (void) instance;
+    (void) report_id;
+    (void) report_type;
+    (void) buffer;
+    (void) reqlen;
+
+    return 0;
+}
+
+/**
+ * @brief Set Report callback
+ *
+ * - Invoked when received SET_REPORT control request or received data on OUT endpoint ( Report ID = 0, Type = 0 )
+ */
+void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer, uint16_t bufsize)
+{
+    (void) instance;
+    (void) report_id;
+    (void) report_type;
+    (void) buffer;
+    (void) bufsize;
+
+}
+
+/**
+ * @brief Test the remote wakeup functionality of the USB HID device.
+ *
+ * This test function performs the following sequence:
+ * 1. Waits for the device event TINYUSB_EVENT_SUSPENDED.
+ * 2. Initiates remote wakeup to resume the device from suspension.
+ * 3. Waits for the device event TINYUSB_EVENT_RESUMED.
+ * 4. Sends a HID keyboard input report to simulate an 'A' key press.
+ *
+ * Expected behavior:
+ * - The device should be suspended by the host.
+ * - Upon remote wakeup, the device should resume operation.
+ * - After resuming, the device sends a keyboard report to the host.
+ *
+ * This test validates that the device can correctly signal remote wakeup and resume communication with the host.
+ */
+void test_device_remote_wakeup(void)
+{
+    // Suspend logic is tested on the Host side, so here we just wait for some time to allow manual testing
+    printf("Device is configured, you can now suspend it from the Host side to test remote wakeup...\n");
+
+    // Wait device to be suspended
+    test_device_wait_event(TINYUSB_EVENT_SUSPENDED);
+
+    printf("Device suspended, initialize remote wakeup...\n");
+    tud_remote_wakeup();
+
+    // Wait device to be resumed
+    test_device_wait_event(TINYUSB_EVENT_RESUMED);
+
+    // Initiate input report to send 'A' key press
+    printf("Press A\r\n");
+    uint8_t keycode[6] = { HID_KEY_A };
+    tud_hid_keyboard_report(HID_ITF_PROTOCOL_KEYBOARD, 0, keycode);
+    vTaskDelay(pdMS_TO_TICKS(50));
+    tud_hid_keyboard_report(HID_ITF_PROTOCOL_KEYBOARD, 0, NULL);
+}
+
+/**
+ * @brief Test case for USB HID Remote Wakeup functionality
+ *
+ * Notes:
+ * - This is a manual test, requiring user interaction on the host side to suspend the device.
+ * - This test uses the default port (USB 1.1 when hardware FS-only, USB 2.0 HS when hardware supports HS).
+ */
+TEST_CASE("HID class, Remote Wakeup", "[hid]")
+{
+    // Install TinyUSB driver
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
+    tusb_cfg.descriptor.full_speed_config = hid_configuration_descriptor;
+#if (TUD_OPT_HIGH_SPEED)
+    tusb_cfg.descriptor.high_speed_config = hid_configuration_descriptor;
+#endif // TUD_OPT_HIGH_SPEED
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+    // Wait device to be attached
+    test_device_wait_event(TINYUSB_EVENT_ATTACHED);
+    //
+    test_device_remote_wakeup();
+    // Cleanup
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+}
+
+#if (SOC_USB_OTG_PERIPH_NUM > 1)
+/**
+ * @brief Test case for USB HID Remote Wakeup functionality
+ *
+ * Notes:
+ * - This is a manual test, requiring user interaction on the host side to suspend the device.
+ * - This test uses the USB 1.1 when hardware supports both FS and HS.
+ */
+TEST_CASE("HID class, Remote Wakeup, USB OTG 1.1", "[hid][full_speed]")
+{
+    // Install TinyUSB driver
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
+
+    // Select USB OTG 1.1 port
+    tusb_cfg.port = TINYUSB_PORT_FULL_SPEED_0;
+
+    tusb_cfg.descriptor.full_speed_config = hid_configuration_descriptor;
+#if (TUD_OPT_HIGH_SPEED)
+    tusb_cfg.descriptor.high_speed_config = hid_configuration_descriptor;
+#endif // TUD_OPT_HIGH_SPEED
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+    // Wait device to be attached
+    test_device_wait_event(TINYUSB_EVENT_ATTACHED);
+    //
+    test_device_remote_wakeup();
+    // Cleanup
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+}
+#endif // (SOC_USB_OTG_PERIPH_NUM > 1)
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/remote_wakeup/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/remote_wakeup/sdkconfig.defaults
@@ -1,0 +1,18 @@
+# Configure TinyUSB, it will be used to mock USB devices
+CONFIG_TINYUSB_HID_COUNT=1
+
+# On chips with USB Serial JTAG, disable secondary console which does not make sense when using console component
+CONFIG_ESP_CONSOLE_SECONDARY_NONE=y
+
+# Disable watchdogs, they'd get triggered during unity interactive menu
+CONFIG_ESP_INT_WDT=n
+CONFIG_ESP_TASK_WDT=n
+
+# Run-time checks of Heap and Stack
+CONFIG_HEAP_POISONING_COMPREHENSIVE=y
+CONFIG_COMPILER_STACK_CHECK_MODE_STRONG=y
+CONFIG_COMPILER_STACK_CHECK=y
+
+CONFIG_UNITY_ENABLE_BACKTRACE_ON_FAIL=y
+
+CONFIG_COMPILER_CXX_EXCEPTIONS=y


### PR DESCRIPTION
## Description

Test application for Remote Wakeup feature on ESP32-S2, ESP32-S3, ESP32-P4 (USB OTG 1.1 and USB OTG 2.0).

Test requires external USB Host, which might be send to sleep mode by an operator. 

Logic of the test is linear, all events (ATTACH, SUSPEND, RESUME) are verified and the test simplifies the verification of the feature: 
- connect the device to the host
- run the test
- initiate the sleep
- get the result

Possible to run on USB1.1 for S2/S3 and on USB2.0 and USB1.1 for P4. 

### ESP32-P4 USB OTG 2.0

<img width="1234" height="468" alt="image" src="https://github.com/user-attachments/assets/8fb57391-195b-4197-a8b6-b198078c574b" />


### ESP32-P4, USB OTG 1.1

<img width="1234" height="468" alt="image" src="https://github.com/user-attachments/assets/a7a47855-6020-41b4-bd7d-0750099ed7ce" />


## Related

N/A

## Testing

Added additional test: 
<img width="1484" height="236" alt="image" src="https://github.com/user-attachments/assets/a3a36035-71d2-49f0-b686-d058ce16b6dc" />


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
