### PR TITLE
feat(usb_host_uvc): add support for user-provided frame buffers

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.0] - 2025-11-21
+
+### Added
+
+- Added support for user-provided frame buffers via `user_frame_buffers` field in `uvc_host_stream_config_t.advanced`
 
 ### Fixed
 
 - Fixed potential buffer overflow in descriptor printing functions by removing unnecessary memcpy operations
 - Removed unaligned access workaround; ESP targets support unaligned memory access natively
+- Fixed assertion failure when receiving packets with unexpected `frame_id`
 
 ## [2.3.1] - 2025-09-24
 

--- a/host/class/uvc/usb_host_uvc/docs/FAQ.md
+++ b/host/class/uvc/usb_host_uvc/docs/FAQ.md
@@ -29,6 +29,13 @@ You can limit RAM usage during UVC stream opening by configuring the frame buffe
 
 </details>
 
+<details>
+<summary>Q2: How can I use my own pre-allocated frame buffers instead of driver-managed allocation?</summary>
+
+Since v2.4.0, you can provide your own frame buffers via `uvc_host_stream_config_t.advanced.user_frame_buffers`.
+
+</details>
+
 ## FAQ H265 encoding
 
 <details>

--- a/host/class/uvc/usb_host_uvc/docs/arch_notes.md
+++ b/host/class/uvc/usb_host_uvc/docs/arch_notes.md
@@ -33,6 +33,11 @@ This driver utilizes two distinct types of memory buffers, both of which can be 
   - UVC cameras report the maximum frame buffer size during stream format negotiation.
   - These sizes are often overly large, leading to inefficient RAM usage.
   - This driver allows the allocation of smaller FBs to optimize memory usage.
+- **User-Provided Frame Buffers (Optional, since v2.4.0):**
+  - By default, the driver allocates frame buffers using `heap_caps_malloc()`.
+  - Users can optionally provide pre-allocated buffers via `uvc_host_stream_config_t.advanced.user_frame_buffers[]`.
+  - **Usage:** Set `user_frame_buffers` to an array of `number_of_frame_buffers` pointers, each pointing to a buffer of at least `frame_size` bytes. The driver will use these buffers instead of allocating its own.
+  - **Lifecycle:** Users manage buffer allocation and deallocation; the driver only manages buffer ownership during streaming (via frame callback and `uvc_host_frame_return()`).
 
 ### Frame buffer state transitions
 ![Frame buffer state transitions](./uvc_frames_state_transitions.png)

--- a/host/class/uvc/usb_host_uvc/host_test/main/opening/test_opening.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/opening/test_opening.cpp
@@ -121,6 +121,7 @@ SCENARIO("Test mocked device opening and closing")
                 .frame_heap_caps = 0,
                 .number_of_urbs = 4,
                 .urb_size = 10 * 1024,
+                .user_frame_buffers = NULL,
             },
         };
 
@@ -241,6 +242,7 @@ SCENARIO("Test mocked device format negotiation")
                 .frame_heap_caps = 0,
                 .number_of_urbs = 4,
                 .urb_size = 10 * 1024,
+                .user_frame_buffers = NULL,
             },
         };
 

--- a/host/class/uvc/usb_host_uvc/host_test/main/streaming/test_streaming.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/streaming/test_streaming.cpp
@@ -69,7 +69,7 @@ void run_streaming_frame_reconstruction_scenario(void)
                 return true;
             };
 
-            REQUIRE(uvc_frame_allocate(&stream, 1, 100 * 1024, 0) == ESP_OK);
+            REQUIRE(uvc_frame_allocate(&stream, 1, 100 * 1024, 0, NULL) == ESP_OK);
             uvc_frame_format_update(&stream, &logo_jpg_format);
 
             // Test
@@ -147,7 +147,7 @@ void run_streaming_frame_reconstruction_scenario(void)
                 enum uvc_host_dev_event *event_type = static_cast<enum uvc_host_dev_event *>(user_ctx);
                 *event_type = event->type;
             };
-            REQUIRE(uvc_frame_allocate(&stream, 1, logo_jpg.size() - 100, 0) == ESP_OK);
+            REQUIRE(uvc_frame_allocate(&stream, 1, logo_jpg.size() - 100, 0, NULL) == ESP_OK);
 
             WHEN("The frame is too big") {
                 send_function_wrapper(1024, &stream, std::span(logo_jpg));
@@ -170,7 +170,7 @@ void run_streaming_frame_reconstruction_scenario(void)
             };
 
             uvc_host_frame_t *temp_frame = nullptr;
-            REQUIRE(uvc_frame_allocate(&stream, 1, 100 * 1024, 0) == ESP_OK);
+            REQUIRE(uvc_frame_allocate(&stream, 1, 100 * 1024, 0, NULL) == ESP_OK);
             temp_frame = uvc_frame_get_empty(&stream);
             REQUIRE(temp_frame != nullptr);
 
@@ -236,7 +236,7 @@ SCENARIO("Bulk stream frame reconstruction", "[streaming][bulk]")
 
     GIVEN("Streaming enabled and frame allocated") {
         REQUIRE(uvc_host_stream_unpause(&stream) == ESP_OK);
-        REQUIRE(uvc_frame_allocate(&stream, 1, 100 * 1024, 0) == ESP_OK);
+        REQUIRE(uvc_frame_allocate(&stream, 1, 100 * 1024, 0, NULL) == ESP_OK);
         uvc_frame_format_update(&stream, &logo_jpg_format);
 
         WHEN("Expected SoF but got EoF") {

--- a/host/class/uvc/usb_host_uvc/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.3.1"
+version: "2.4.0"
 description: USB Host UVC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uvc/usb_host_uvc
 dependencies:

--- a/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
+++ b/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
@@ -182,6 +182,7 @@ typedef struct {
         int number_of_urbs;          /**< Number of URBs for this stream. Triple buffering scheme is recommended */
         size_t urb_size;             /**< Size in bytes of 1 URB, 10kB should be enough for start.
                                           Larger value results in less frequent interrupts at the cost of memory consumption */
+        uint8_t **user_frame_buffers; /**< Optional: Array of pointers to user-provided frame buffers. NULL (default) = driver allocates buffers. */
     } advanced;
 } uvc_host_stream_config_t;
 

--- a/host/class/uvc/usb_host_uvc/private_include/uvc_frame_priv.h
+++ b/host/class/uvc/usb_host_uvc/private_include/uvc_frame_priv.h
@@ -20,12 +20,13 @@ extern "C" {
  * @param[in] nb_of_fb   Number of frame buffers to allocate
  * @param[in] fb_size    Size of 1 frame buffer in bytes
  * @param[in] fb_caps    Memory capabilities of memory for frame buffers
+ * @param[in] user_frame_buffers Optional user-provided frame buffers. If not NULL, use these instead of allocating
  * @return
  *     - ESP_OK: Success
  *     - ESP_ERR_NO_MEM: Not enough memory for frame buffers
  *     - ESP_ERR_INVALID_ARG: Invalid count or size of frame buffers
  */
-esp_err_t uvc_frame_allocate(uvc_stream_t *uvc_stream, int nb_of_fb, size_t fb_size, uint32_t fb_caps);
+esp_err_t uvc_frame_allocate(uvc_stream_t *uvc_stream, int nb_of_fb, size_t fb_size, uint32_t fb_caps, uint8_t **user_frame_buffers);
 
 /**
  * @brief Free allocated frame buffers

--- a/host/class/uvc/usb_host_uvc/private_include/uvc_types_priv.h
+++ b/host/class/uvc/usb_host_uvc/private_include/uvc_types_priv.h
@@ -36,6 +36,7 @@ struct uvc_host_stream_s {
         uvc_host_frame_callback_t frame_cb;   // User's frame callback
         void *cb_arg;                         // Common argument for user's callbacks
         QueueHandle_t empty_fb_queue;         // Queue of empty framebuffers
+        bool user_provided_fb;                // Flag indicating if frame buffers are user-provided
 
         // Constant USB descriptor values
         uint16_t bcdUVC;                      // Version of UVC specs this device implements

--- a/host/class/uvc/usb_host_uvc/uvc_bulk.c
+++ b/host/class/uvc/usb_host_uvc/uvc_bulk.c
@@ -86,8 +86,9 @@ void bulk_transfer_callback(usb_transfer_t *transfer)
         uvc_stream->single_thread.next_bulk_packet = UVC_STREAM_BULK_PACKET_SOF;
 
         if (payload_header->bmHeaderInfo.end_of_frame) {
-            assert(payload_header->bmHeaderInfo.frame_id == uvc_stream->single_thread.current_frame_id);
-            if (payload_header->bmHeaderInfo.error) {
+            // Just skip the current frame if the frame_id does not match, we plan to include a better fix in #308
+            // Due to the SOF of the next frame may not be handled， this may result in dropping two consecutive frames.
+            if (payload_header->bmHeaderInfo.error || payload_header->bmHeaderInfo.frame_id != uvc_stream->single_thread.current_frame_id) {
                 uvc_stream->single_thread.skip_current_frame = true;
             }
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

1. Support user-provided frame buffers for zero-copy operation. Right now, You can now pass your own buffers to the driver through the user_frame_buffers field. The driver will write frames directly to your buffers, skipping the copy entirely.
2. Fixed assertion failure when receiving packets with unexpected `frame_id`. In some cameras, we encountered this situation. Perhaps it was because the USB transfer speed was insufficient that some data packets were lost inside the camera.

## Backward Compatibility

The new `user_frame_buffers` field is optional and defaults to NULL. If you don't set it, everything works exactly as before - no code changes needed.

However, out of caution, I've bumped the minor version to 2.4.0. While this shouldn't technically break anything (it's an additive change), the buffer management behavior does change when the new field is used. Better safe than sorry - this gives users a clear signal that something noteworthy was added.


<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

- [x] Test ESP32-P4 with USB Camera with 720P resolution

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds zero-copy support via user-supplied frame buffers and skips frames with unexpected frame_id at EoF; updates API, tests, docs, and bumps version to 2.4.0.
> 
> - **API/Driver**:
>   - Add `advanced.user_frame_buffers` to `uvc_host_stream_config_t`; validate buffers in `uvc_host_stream_open()`.
>   - Extend `uvc_frame_allocate()` to accept user buffers and track `user_provided_fb`; free buffers conditionally in `uvc_frame_free()`.
> - **Streaming (Bulk)**:
>   - On EoF, skip frame if `bmHeaderInfo.error` or `frame_id` mismatch instead of asserting.
> - **Tests**:
>   - Update calls to `uvc_frame_allocate(..., NULL)` and set `.user_frame_buffers = NULL` in opening tests.
>   - Add runtime test using user-provided buffers in `test_app`.
> - **Docs**:
>   - Document user-provided buffers in `docs/FAQ.md` and `docs/arch_notes.md`.
> - **Versioning/Changelog**:
>   - Bump component to `2.4.0` and update `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70f9013fd6bc37f7cd8e289fddea8d5175103c42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->