### PR TITLE
release(esp_tinyusb): v2.0.1~1

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,6 +1,7 @@
-## [Unreleased]
+## 2.0.1~1
 
-- Fixed forward compatibility with TinyUSB 0.19
+- esp_tinyusb: Claim forward compatibility with TinyUSB 0.19
+- CDC: Added support for new VFS API (for esp-idf v5.4 and higher)
 
 ## 2.0.1
 

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "2.0.1"
+version: "2.0.1~1"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 targets:
   - esp32s2


### PR DESCRIPTION
## Description

Release of v2.0.1, revision 1 with claiming compatibility with TinyUSB v0.19.0.

Unlocks the CI for espressif/tinyusb repository. 

## Related

- https://github.com/espressif/esp-usb/pull/292 
- https://github.com/espressif/esp-usb/pull/294
- https://github.com/espressif/esp-usb/pull/295

## Testing

N/A

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
