### PR TITLE
fix(uvc): Fixed potential buffer overflow in desc printing

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -1,55 +1,103 @@
-## 2.3.1
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Fixed potential buffer overflow in descriptor printing functions by removing unnecessary memcpy operations
+- Removed unaligned access workaround; ESP targets support unaligned memory access natively
+
+## [2.3.1] - 2025-09-24
+
+### Added
 
 - Added support for ESP32-H4
 
-## 2.3.0
+## [2.3.0] - 2025-05-27
+
+### Added
 
 - Added `uvc_host_stream_format_get()` function that returns current stream's format
 - Added `uvc_host_buf_info_get()` function for esp_video binding
 - Added option to request default FPS by setting FPS = 0
+
+### Fixed
+
 - Fixed UVC driver re-installation
 - Fixed abort on unexpected EoF flag in bulk transfers
 
-## 2.2.0
+## [2.2.0] - 2025-04-06
+
+### Added
 
 - Added `uvc_host_stream_format_select()` function that allows change of format of an opened stream
+
+### Fixed
+
 - Fixed MPS limitation on FS targets from 600 to 596 bytes
 - Fixed device opening procedure. Now the frame format is committed when the stream is started
 
-## 2.1.0
+## [2.1.0] - 2025-02-14
+
+### Added
 
 - Added support for get frame list when device is inserted
 - Added support for multiple cameras with USB hub
 
-## 2.0.1
+## [2.0.1] - 2025-02-04
+
+### Fixed
 
 - Fixed negotiation for some non-conforming UVC devices (https://github.com/espressif/esp-idf/issues/9868)
 
-## 2.0.0
+## [2.0.0] - 2025-12-19
+
+### Changed
 
 - New version of the driver, native to Espressif's USB Host Library
 - Removed libuvc dependency
 
-## 1.0.4
+## [1.0.4] - 2024-05-09
+
+### Added
 
 - Support printf frame based descriptor
 
-## 1.0.3
+## [1.0.3] - 2024-03-11
+
+### Added
 
 - Added support for ESP32-P4
-- Bumped libuvc version to relax frame format negotiation
-- Fixed crash on opening non-UVC devices
 - Added `libuvc_get_usb_device_info` function
 
-## 1.0.2
+### Changed
+
+- Bumped libuvc version to relax frame format negotiation
+
+### Fixed
+
+- Fixed crash on opening non-UVC devices
+
+## [1.0.2] - 2023-09-27
+
+### Changed
 
 - Updated libuvc library to 0.0.7 https://github.com/libuvc/libuvc/tree/v0.0.7
 - Added Software BoM information
 
-## 1.0.1
+## [1.0.1] - 2023-04-19
+
+### Fixed
 
 - Fixed compatibility with IDF v4.4
 
-## 1.0.0
+## [1.0.0] - 2022-08-22
+
+### Added
 
 - Initial version

--- a/host/class/uvc/usb_host_uvc/README.md
+++ b/host/class/uvc/usb_host_uvc/README.md
@@ -2,6 +2,7 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_uvc/badge.svg)](https://components.espressif.com/components/espressif/usb_host_uvc)
 ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
+![changelog](https://img.shields.io/badge/Keep_a_Changelog-blue?logo=keepachangelog&logoColor=E05735)
 
 This component contains an implementation of a USB Host UVC Class Driver that is implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
 

--- a/host/class/uvc/usb_host_uvc/uvc_descriptor_printing.c
+++ b/host/class/uvc/usb_host_uvc/uvc_descriptor_printing.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -183,12 +183,8 @@ static void print_vs_format_mjpeg_desc(const usb_standard_desc_t *_desc)
 
 static void print_vs_frame_mjpeg_desc(const usb_standard_desc_t *_desc)
 {
-    // Copy to local buffer due to potential misalignment issues.
-    uint32_t raw_desc[25];
-    uint32_t desc_size = ((const uvc_frame_desc_t *)_desc)->bLength;
-    memcpy(raw_desc, _desc, desc_size);
-
-    const uvc_frame_desc_t *desc = (const uvc_frame_desc_t *) raw_desc;
+    // ESP32 supports unaligned memory access without penalty, so we can access directly
+    const uvc_frame_desc_t *desc = (const uvc_frame_desc_t *)_desc;
     printf("\t*** VS Frame Descriptor ***\n");
     printf("\tbLength %u\n", desc->bLength);
     printf("\tbDescriptorType 0x%02X\n", desc->bDescriptorType);
@@ -196,7 +192,7 @@ static void print_vs_frame_mjpeg_desc(const usb_standard_desc_t *_desc)
     printf("\tbFrameIndex %u\n", desc->bFrameIndex);
     printf("\tbmCapabilities 0x%X\n", desc->bmCapabilities);
     printf("\twWidth %u\n", desc->wWidth);
-    printf("\twHeigh %u\n", desc->wHeight);
+    printf("\twHeight %u\n", desc->wHeight);
     printf("\tdwMinBitRate %"PRIu32"\n", desc->dwMinBitRate);
     printf("\tdwMaxBitRate %"PRIu32"\n", desc->dwMaxBitRate);
     printf("\tdwMaxVideoFrameBufSize %"PRIu32"\n", desc->mjpeg_uncompressed.dwMaxVideoFrameBufferSize);
@@ -235,12 +231,8 @@ static void print_vs_format_frame_based_desc(const usb_standard_desc_t *_desc)
 
 static void print_vs_frame_frame_based_desc(const usb_standard_desc_t *_desc)
 {
-    // Copy to local buffer due to potential misalignment issues.
-    uint32_t raw_desc[25];
-    uint32_t desc_size = ((const uvc_frame_desc_t *)_desc)->bLength;
-    memcpy(raw_desc, _desc, desc_size);
-
-    const uvc_frame_desc_t *desc = (const uvc_frame_desc_t *) raw_desc;
+    // ESP32 supports unaligned memory access without penalty, so we can access directly
+    const uvc_frame_desc_t *desc = (const uvc_frame_desc_t *)_desc;
     printf("\t*** VS Frame Frame-Based Descriptor ***\n");
     printf("\tbLength %u\n", desc->bLength);
     printf("\tbDescriptorType 0x%02X\n", desc->bDescriptorType);


### PR DESCRIPTION
Removed memcpy from this originally 3rd party code.
ESP targets support unaligned access.