### PR TITLE
fix(usb_host_hid): Fixed a vulnerability with overwrite freed heap memory

### DIFF
--- a/host/class/hid/usb_host_hid/CHANGELOG.md
+++ b/host/class/hid/usb_host_hid/CHANGELOG.md
@@ -1,21 +1,51 @@
-## 1.0.4
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Fixed a vulnerability with overwrite freed heap memory during `hid_host_get_report_descriptor()`
+
+### Added
+
+- Added a limitation for the HID report descriptor size to a maximum of 2048 bytes
+
+## [1.0.4] - 2025-09-24
+
+### Added
+
 - Added support for ESP32-H4
 
-## 1.0.3
-- Fixed a bug with interface mismatch on EP IN transfer complete while several HID devices are present.
-- Fixed a bug during device freeing, while detaching one of several attached HID devices.
+## [1.0.3] - 2024-08-20
 
-## 1.0.2
+### Fixed
+
+- Fixed a bug with interface mismatch on EP IN transfer complete while several HID devices are present
+- Fixed a bug during device freeing, while detaching one of several attached HID devices
+
+## [1.0.2] - 2024-01-25
+
+### Added
 
 - Added support for ESP32-P4
-- Fixed device open procedure for HID devices with multiple non-sequential interfaces.
+- Fixed device open procedure for HID devices with multiple non-sequential interfaces
 
-## 1.0.1
+## [1.0.1] - 2023-10-04
 
-- Fixed a bug where configuring the driver with `create_background_task = false` did not properly initialize the driver. This lead to `the hid_host_uninstall()` hang-up.
-- Fixed a bug where `hid_host_uninstall()` would cause a crash during the call while USB device has not been removed.
-- Added `hid_host_get_device_info()` to get the basic information of a connected USB HID device.
+### Added
 
-## 1.0.0
+- Added `hid_host_get_device_info()` to get the basic information of a connected USB HID device
+
+### Fixed
+
+- Fixed a bug where configuring the driver with `create_background_task = false` did not properly initialize the driver. This lead to `the hid_host_uninstall()` hang-up
+- Fixed a bug where `hid_host_uninstall()` would cause a crash during the call while USB device has not been removed
+
+## [1.0.0] - 2023-06-22
+
+### Added
 
 - Initial version

--- a/host/class/hid/usb_host_hid/test_app/main/test_hid_basic.c
+++ b/host/class/hid/usb_host_hid/test_app/main/test_hid_basic.c
@@ -707,8 +707,7 @@ TEST_CASE("sudden_disconnect", "[hid_host]")
     vSemaphoreDelete(s_global_hdl_sem);
 }
 
-// TODO: Enable during the fix https://github.com/espressif/esp-usb/pull/320
-TEST_CASE("request Report Descriptor 32K", "[hid_host][ignore]")
+TEST_CASE("request Report Descriptor 32K", "[hid_host_extra_large_report]")
 {
     // Create semaphore for s_global_hdl, because it will be used in multiple tasks access
     s_global_hdl_sem = xSemaphoreCreateBinary();
@@ -756,7 +755,7 @@ TEST_CASE("mock_hid_device_with_large_report", "[hid_device_large_report][ignore
     }
 }
 
-TEST_CASE("mock_hid_device_with_32K_report", "[hid_device_large_report][ignore]")
+TEST_CASE("mock_hid_device_with_32K_report", "[hid_device_extra_large_report][ignore]")
 {
     hid_mock_device_set_mode(TEST_HID_MOCK_DEVICE_WITH_REPORT_DESC_32KB);
     hid_mock_device_run();

--- a/host/class/hid/usb_host_hid/test_app/pytest_usb_host_hid.py
+++ b/host/class/hid/usb_host_hid/test_app/pytest_usb_host_hid.py
@@ -33,13 +33,18 @@ def test_usb_host_hid(dut: Tuple[IdfDut, IdfDut]) -> None:
 
     host.run_all_single_board_cases(group='hid_host')
 
-    # TODO: Enable during the fix https://github.com/espressif/esp-usb/pull/320
-    # Expected to fail due to the overriding the freed memory during realloc in the HID Host driver
-
     # Tests with mocked HID device with large report descriptor (1905 bytes) for HID tests
-    # device.serial.hard_reset()
-    # device.expect_exact('Press ENTER to see the list of tests.')
-    # device.write('[hid_device_large_report]')
-    # device.expect_exact('HID mock device with large report descriptor has been started')
+    device.serial.hard_reset()
+    device.expect_exact('Press ENTER to see the list of tests.')
+    device.write('[hid_device_large_report]')
+    device.expect_exact('HID mock device with large report descriptor has been started')
 
-    # host.run_all_single_board_cases(group='hid_host')
+    host.run_all_single_board_cases(group='hid_host')
+
+    # Tests with mocked HID device with extra large report descriptor (32KB) for HID tests
+    device.serial.hard_reset()
+    device.expect_exact('Press ENTER to see the list of tests.')
+    device.write('[hid_device_extra_large_report]')
+    device.expect_exact('HID mock device with extra large report descriptor has been started')
+
+    host.run_all_single_board_cases(group='hid_host_extra_large_report')


### PR DESCRIPTION
## Description

### Main change

- Fixed the `ctrl_xfer` local pointer usage

### Additional clean-up

- Made all the null checks before any dereference
- Fixed the unlock path on `usb_host_transfer_alloc()` error
- Limited `req->wLength` to some sane maximum: 2048 bytes
- [x] Added intermediate variable `hid_report_len` for clarity
- [x] Removed unused `dev_info` 
- [x] Added the note about HID Report Descriptor maximum length in the CHANGELOG.md 

## Related

- [x] Blocked by https://github.com/espressif/esp-usb/pull/323

## Testing

- Test case in https://github.com/espressif/esp-usb/pull/323

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden HID host EP0 control buffer management, cap report descriptor size to 2048 bytes, and add/update tests and changelog accordingly.
> 
> - **Driver (usb_host_hid)**:
>   - Harden `ctrl_xfer` buffer handling in `hid_host.c`:
>     - Validate descriptor length (`HID_MAX_REPORT_DESC_LEN` = 2048) and early-return on oversize.
>     - Reallocate EP0 control buffer safely with proper error/unlock paths; avoid using freed pointers.
>     - Use computed `required_size`, improved length checks, and robust copy of response data.
>     - Introduce `HID_MIN_REPORT_DESC_LEN` (512) for initial EP0 allocation.
>   - Update initial EP0 allocation in `hid_host_install_device()` to `HID_MIN_REPORT_DESC_LEN`.
> - **Tests**:
>   - Enable large report descriptor tests and add an extra-large (32KB) descriptor test that asserts failure (`[hid_host_extra_large_report]`).
>   - Update pytest flow to run new test groups and mocked device modes.
> - **Docs**:
>   - Revamp `CHANGELOG.md` to Keep a Changelog format; document fix and 2048-byte descriptor limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81b37c96593c0bec92ef14c6ee6bf8cab8d8f660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->