### PR TITLE
refactor(esp_tinyusb): TinyUSB task deletion notification driven (part 1/3)

### DIFF
--- a/device/esp_tinyusb/test_apps/runtime_config/README.md
+++ b/device/esp_tinyusb/test_apps/runtime_config/README.md
@@ -1,0 +1,42 @@
+| Supported Targets | ESP32-H4 | ESP32-P4 | ESP32-S2 | ESP32-S3 |
+| ----------------- | -------- | -------- | -------- | -------- |
+
+# Espressif's Additions to TinyUSB - Runtime Configuration Test Application
+
+This directory contains Unity tests that validate Espressif-specific integration of TinyUSB.
+
+The tests focus on:
+
+- TinyUSB configuration helpers (default macros, per-port config).
+- USB Device descriptors (FS/HS, string descriptors, edge cases).
+- USB peripheral / PHY configuration for full-speed and high-speed.
+- TinyUSB task configuration (CPU pinning, invalid parameters).
+- Multitask access to the TinyUSB driver (concurrent installs).
+
+The test prints a numbered menu, for example:
+
+```
+(1) "Config: Default macros arguments" [runtime_config][default]
+(2) "Config: Full-speed (High-speed)" [runtime_config][full_speed]
+...
+```
+
+You can run all tests by running `pytest` or select individual ones by name and number.
+
+## Tags
+
+Each test is tagged with categories and modes:
+
+### Categories
+
+- [runtime_config] – Tests focusing on `tinyusb_config_t` and runtime configuration.
+- [periph] – Tests that directly exercise the USB peripheral (USB OTG 1.1 or USB OTG 2.0).
+- [task] – Tests related to the dedicated TinyUSB task configuration.
+
+### Speed / Mode
+
+- [default] – Generic, target-agnostic.
+- [full_speed] – Tests specific to USB OTG 1.1 / Full-speed port.
+- [high_speed] – Tests specific to USB OTG 2.0 / High-speed port.
+
+These tags can be used by test runners / CI to select or filter tests.

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_multitask_access.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_multitask_access.c
@@ -29,26 +29,73 @@
 
 #define MULTIPLE_THREADS_TASKS_NUM 5
 
-static int nb_of_success = 0;
+static SemaphoreHandle_t sem_done = NULL;
+TaskHandle_t test_task_handles[MULTIPLE_THREADS_TASKS_NUM];
+
+// Unlocked spinlock, ready to use
+static portMUX_TYPE _spinlock = portMUX_INITIALIZER_UNLOCKED;
+static volatile int nb_of_success = 0;
 
 static void test_task_install(void *arg)
 {
-    TaskHandle_t parent_task_handle = (TaskHandle_t)arg;
-
+    (void) arg;
     // Install TinyUSB driver
     tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
     tusb_cfg.phy.skip_setup = true; // Skip phy setup to allow multiple tasks to install the driver
 
+    // Wait to be started by main thread
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+
     if (tinyusb_driver_install(&tusb_cfg) == ESP_OK) {
         test_device_wait();
-        TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+        TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, tinyusb_driver_uninstall(), "Unable to uninstall driver after install in worker");
+        taskENTER_CRITICAL(&_spinlock);
         nb_of_success++;
+        taskEXIT_CRITICAL(&_spinlock);
     }
 
     // Notify the parent task that the task completed the job
-    xTaskNotifyGive(parent_task_handle);
+    xSemaphoreGive(sem_done);
     // Delete task
     vTaskDelete(NULL);
+}
+
+
+static void test_task_uninstall(void *arg)
+{
+    (void) arg;
+    // Wait to be started by main thread
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+
+    if (tinyusb_driver_uninstall() == ESP_OK) {
+        taskENTER_CRITICAL(&_spinlock);
+        nb_of_success++;
+        taskEXIT_CRITICAL(&_spinlock);
+    }
+
+    // Notify the parent task that the task completed the job
+    xSemaphoreGive(sem_done);
+    // Delete task
+    vTaskDelete(NULL);
+}
+
+// USB PHY
+
+static usb_phy_handle_t test_init_phy(void)
+{
+    usb_phy_handle_t phy_hdl = NULL;
+    usb_phy_config_t phy_conf = {
+        .controller = USB_PHY_CTRL_OTG,
+        .target = USB_PHY_TARGET_INT,
+        .otg_mode = USB_OTG_MODE_DEVICE,
+    };
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, usb_new_phy(&phy_conf, &phy_hdl), "Unable to install USB PHY ");
+    return phy_hdl;
+}
+
+static void test_deinit_phy(usb_phy_handle_t phy_hdl)
+{
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, usb_del_phy(phy_hdl), "Unable to delete USB PHY ");
 }
 
 // ============================= Tests =========================================
@@ -57,38 +104,86 @@ static void test_task_install(void *arg)
  * @brief TinyUSB Task specific testcase
  *
  * Scenario: Trying to install driver from several tasks
- * Note: when skip_phy_setup = false, the task access will be determined by the first task install the phy
+ * Note: when phy.skip_setup = false, the task access will be determined by the first task install the phy
  */
-TEST_CASE("Multitask: Install", "[runtime_config][full_speed][high_speed]")
+TEST_CASE("Multitask: Install", "[runtime_config][default]")
 {
-    usb_phy_handle_t phy_hdl = NULL;
-    // Install the PHY externally
-    usb_phy_config_t phy_conf = {
-        .controller = USB_PHY_CTRL_OTG,
-        .target = USB_PHY_TARGET_INT,
-        .otg_mode = USB_OTG_MODE_DEVICE,
-    };
-    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, usb_new_phy(&phy_conf, &phy_hdl), "Unable to install USB PHY ");
+    usb_phy_handle_t phy_hdl = test_init_phy();
 
+    // Create counting semaphore to wait for all tasks to complete
+    sem_done = xSemaphoreCreateCounting(MULTIPLE_THREADS_TASKS_NUM, 0);
+    TEST_ASSERT_NOT_NULL(sem_done);
+
+    // No task are running yet
     nb_of_success = 0;
+
     // Create tasks that will start the driver
     for (int i = 0; i < MULTIPLE_THREADS_TASKS_NUM; i++) {
-        TEST_ASSERT_EQUAL(pdTRUE, xTaskCreate(test_task_install,
+        TEST_ASSERT_EQUAL(pdPASS, xTaskCreate(test_task_install,
                                               "InstallTask",
                                               4096,
-                                              (void *) xTaskGetCurrentTaskHandle(),
+                                              NULL,
                                               4 + i,
-                                              NULL));
+                                              &test_task_handles[i]));
     }
 
-    // Wait until all tasks are finished
-    vTaskDelay(pdMS_TO_TICKS(5000));
-    // Check if all tasks finished, we should get all notification from the tasks
-    TEST_ASSERT_EQUAL_MESSAGE(MULTIPLE_THREADS_TASKS_NUM, ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(5000)), "Not all tasks finished");
+    // Start all tasks
+    for (int i = 0; i < MULTIPLE_THREADS_TASKS_NUM; i++) {
+        xTaskNotifyGive(test_task_handles[i]);
+    }
+
+    // Wait for all tasks to complete
+    for (int i = 0; i < MULTIPLE_THREADS_TASKS_NUM; i++) {
+        TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(sem_done, pdMS_TO_TICKS(5000)), "Not all tasks completed in time");
+    }
+
     // There should be only one task that was able to install the driver
     TEST_ASSERT_EQUAL_MESSAGE(1, nb_of_success, "Only one task should be able to install the driver");
     // Clean-up
-    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, usb_del_phy(phy_hdl), "Unable to delete PHY");
+    test_deinit_phy(phy_hdl);
+    vSemaphoreDelete(sem_done);
 }
+
+TEST_CASE("Multitask: Uninstall", "[runtime_config][default]")
+{
+    usb_phy_handle_t phy_hdl = test_init_phy();
+    // Create counting semaphore to wait for all tasks to complete
+    sem_done = xSemaphoreCreateCounting(MULTIPLE_THREADS_TASKS_NUM, 0);
+    TEST_ASSERT_NOT_NULL(sem_done);
+
+    // No task are running yet
+    nb_of_success = 0;
+
+    // Install the driver once
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
+    tusb_cfg.phy.skip_setup = true; // Skip phy setup to allow multiple tasks
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, tinyusb_driver_install(&tusb_cfg), "Unable to install TinyUSB driver ");
+    // Create tasks that will uninstall the driver
+    for (int i = 0; i < MULTIPLE_THREADS_TASKS_NUM; i++) {
+        TEST_ASSERT_EQUAL(pdPASS, xTaskCreate(test_task_uninstall,
+                                              "UninstallTask",
+                                              4096,
+                                              NULL,
+                                              4 + i,
+                                              &test_task_handles[i]));
+    }
+
+    // Start all tasks
+    for (int i = 0; i < MULTIPLE_THREADS_TASKS_NUM; i++) {
+        xTaskNotifyGive(test_task_handles[i]);
+    }
+    // Wait for all tasks to complete
+    for (int i = 0; i < MULTIPLE_THREADS_TASKS_NUM; i++) {
+        TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(sem_done, pdMS_TO_TICKS(5000)), "Not all tasks completed in time");
+    }
+
+    // There should be only one task that was able to uninstall the driver
+    TEST_ASSERT_EQUAL_MESSAGE(1, nb_of_success, "Only one task should be able to uninstall the driver");
+
+    // Clean-up
+    test_deinit_phy(phy_hdl);
+    vSemaphoreDelete(sem_done);
+}
+
 
 #endif // SOC_USB_OTG_SUPPORTED


### PR DESCRIPTION
## Description

This is the first part of the plan: **Refactor the runtime_config test application** 

- Fixed concurrent access to the `nb_of_success` var from several tasks
- Changed the logic of getting notification from the worker thread to `sem_done` instead of direct notification
- Added the test case for uninstall the tinyusb driver via several tasks
- Added README.md to `runtime_config` test application 

## Related

- Follow-up in: https://github.com/espressif/esp-usb/pull/325
- Relates [IEC-351](https://jira.espressif.com:8443/browse/IEC-351)
- Blocked by https://github.com/espressif/esp-usb/pull/324

## Testing

- CI 
- Added test case: `"Multitask: Uninstall" [runtime_config][default]`

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors TinyUSB runtime_config multitask tests to use semaphore-based synchronization with thread-safe counters, adds a new uninstall test, and introduces a README.
> 
> - **Tests (`runtime_config/main/test_multitask_access.c`)**:
>   - Switch worker completion signaling to counting `sem_done`; tasks start via notifications and wait with `xSemaphoreTake`.
>   - Make success counter thread-safe (`volatile` + spinlock) and track task handles for coordinated start.
>   - Extract USB PHY helpers: `test_init_phy()` and `test_deinit_phy()`.
>   - Add new test: `"Multitask: Uninstall"` tagged `[runtime_config][default]`.
>   - Update existing multitask install test to `[default]`, improve assertions and task creation (`pdPASS`).
> - **Docs**:
>   - Add `README.md` describing the runtime_config test app, focus areas, and tag taxonomy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ac149ba5768b48deb24a9d2c5887ec8b0915736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->