### PR TITLE
feature(usb_host_hid): Added test case for the HID device with large Report Descriptor (1905 bytes)

### DIFF
--- a/host/class/hid/usb_host_hid/test_app/main/hid_mock_device.h
+++ b/host/class/hid/usb_host_hid/test_app/main/hid_mock_device.h
@@ -1,13 +1,34 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdint.h>
 
-typedef enum {
-    TUSB_IFACE_COUNT_ONE = 0x00,
-    TUSB_IFACE_COUNT_TWO = 0x01,
-    TUSB_IFACE_COUNT_MAX
-} tusb_iface_count_t;
+// Define test HID mock device types
+enum test_hid_mock_device {
+    TEST_HID_MOCK_DEVICE_WITH_ONE_IFACE = 0,
+    TEST_HID_MOCK_DEVICE_WITH_TWO_IFACES,
+    TEST_HID_MOCK_DEVICE_WITH_REPORT_DESC_1905B,
+    TEST_HID_MOCK_DEVICE_WITH_REPORT_DESC_32KB,
+    TEST_HID_MOCK_DEVICE_MAX,
+};
 
-void hid_mock_device(tusb_iface_count_t iface_count);
+/**
+ * @brief Set HID mock device test mode
+ *
+ * Note: Should be called before hid_mock_device_run()
+ *
+ * @param[in] mode   Test mode to set
+ */
+void hid_mock_device_set_mode(const enum test_hid_mock_device mode);
+
+/**
+ * @brief Run HID mock device
+ *
+ * Sets up and starts the TinyUSB device stack with the selected test mode
+ * Waits for the device to be connected
+ *
+ * Note: Should be called after hid_mock_device_set_mode()
+ */
+void hid_mock_device_run(void);

--- a/host/class/hid/usb_host_hid/test_app/pytest_usb_host_hid.py
+++ b/host/class/hid/usb_host_hid/test_app/pytest_usb_host_hid.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Tuple
@@ -18,19 +18,28 @@ def test_usb_host_hid(dut: Tuple[IdfDut, IdfDut]) -> None:
     device = dut[0]
     host = dut[1]
 
-    # 1 Prepare USB device with one Interface for HID tests
+    # Tests with mocked HID device with one Interface for HID tests
     device.expect_exact('Press ENTER to see the list of tests.')
     device.write('[hid_device]')
     device.expect_exact('HID mock device with 1xInterface (Protocol=None) has been started')
 
-    # 2 Run HID tests
     host.run_all_single_board_cases(group='hid_host')
 
-    # 3 Prepare USB device with two Interfaces for HID tests
+    # Tests with mocked HID device with two Interfaces for HID tests
     device.serial.hard_reset()
     device.expect_exact('Press ENTER to see the list of tests.')
     device.write('[hid_device2]')
     device.expect_exact('HID mock device with 2xInterfaces (Protocol=BootKeyboard, Protocol=BootMouse) has been started')
 
-    # 4 Run HID tests
     host.run_all_single_board_cases(group='hid_host')
+
+    # TODO: Enable during the fix https://github.com/espressif/esp-usb/pull/320
+    # Expected to fail due to the overriding the freed memory during realloc in the HID Host driver
+
+    # Tests with mocked HID device with large report descriptor (1905 bytes) for HID tests
+    # device.serial.hard_reset()
+    # device.expect_exact('Press ENTER to see the list of tests.')
+    # device.write('[hid_device_large_report]')
+    # device.expect_exact('HID mock device with large report descriptor has been started')
+
+    # host.run_all_single_board_cases(group='hid_host')


### PR DESCRIPTION
## Description

Adds a specific test case, when the Report Descriptor is larger then default CTRL EP buffer size (512 bytes).
In this case, upon request the Report Descriptor we re-allocate the CTRL XFER buffer size to the requested value. 

## Changes

### Test application

- [x] Refactored logic of HID mock device to enable different configuration. Now, it can be configured via `hid_mock_device_set_mode(mode)` before `hid_mock_device_run()`
- [x] Added the test case, when HID mocked device with large Report Descriptor is used as a HID-mocked device (disabled yet, will be enabled in https://github.com/espressif/esp-usb/pull/320)
- [x] Added the mocked device with Report Descriptor 32KB (disabled yet, will be enabled in https://github.com/espressif/esp-usb/pull/320)
- [x] Added the device event handle to monitor the attach event

### Additional improvements
- [x] Refactored the logic for concurrent access: Added semaphore protection of the s_global_hdl,  which is used in several tasks.  
- [x] Removed the delays (250 ms for device appearance), replaced by `s_global_hdl_sem`. 
- [x] Replaced `test_num_passed` with counting semaphore logic. 
- [ ] ~~Parameterize the `CFG_TUD_HID` for this test to avoid such misleading two interfaces in `hid_configuration_descriptor_one_iface`.~~ Moved out of the scope of this PR.

## Related

- Test case https://github.com/espressif/esp-usb/pull/320

## Testing

- Run in CI

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
