### PR TITLE
fix(ci): Unlocks CI by temp disabling the usb host_managed tests on latest branch

### DIFF
--- a/.github/workflows/build_and_run_host_test.yml
+++ b/.github/workflows/build_and_run_host_test.yml
@@ -7,8 +7,10 @@
 name: Build and Run USB Host test
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+  # Disabled host_test on latest till the IEC-418 issue is resolved
+  # pull_request:
+    # types: [opened, reopened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -69,8 +69,9 @@ jobs:
           export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
           export ENV_VAR_USB_COMP_MANAGED=${{ matrix.usb_comp_managed }}
 
-          idf-build-apps find --paths ${{ matrix.path }}
-          idf-build-apps build --paths ${{ matrix.path }}
+          # We should have the --disable-targets linux by default anyway for this workflow, since there is a separate workflow for linux tests.
+          idf-build-apps find --paths ${{ matrix.path }} --disable-targets linux
+          idf-build-apps build --paths ${{ matrix.path }} --disable-targets linux
       - uses: actions/upload-artifact@v4
         with:
           name: usb_${{ matrix.test_app }}_test_app_bin_${{ matrix.idf_ver }}


### PR DESCRIPTION
## Description

Temporarily disabled usb host testing on Linux target.

## Related

- Relates to [IEC-418](https://jira.espressif.com:8443/browse/IEC-418)

## Testing

- N/A

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
