### PR TITLE
fix(uvc_host): Use managed usb component in examples by default

### DIFF
--- a/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/idf_component.yml
@@ -7,6 +7,5 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../../usb"
-    rules:                                      # Both if clauses must be fulfilled to override the component
-      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+    rules:
       - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above

--- a/host/class/uvc/usb_host_uvc/examples/camera_display/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/examples/camera_display/main/idf_component.yml
@@ -9,6 +9,5 @@ dependencies:
   espressif/usb:
     version: "*"
     override_path: "../../../../../../usb"
-    rules:                                      # Both if clauses must be fulfilled to override the component
-      - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
+    rules:
       - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above


### PR DESCRIPTION
UVC Host examples use managed component by default from IDF 5.4 and newer

<details>
<summary> UVC Example build for IDF 5.3, using Native USB component </summary>

```
NOTICE: Processing 2 dependencies:
NOTICE: [1/2] espressif/usb_host_uvc (2.3.1) (/__w/esp-usb/esp-usb/host/class/uvc/usb_host_uvc)
NOTICE: [2/2] idf (5.3.4)
```

</details>


<details>
<summary> UVC Example build for IDF 5.4 using managed USB component </summary>

```
NOTICE: Processing 3 dependencies:
NOTICE: [1/3] espressif/usb (1.0.1) (/__w/esp-usb/esp-usb/host/usb)
NOTICE: [2/3] espressif/usb_host_uvc (2.3.1) (/__w/esp-usb/esp-usb/host/class/uvc/usb_host_uvc)
NOTICE: [3/3] idf (5.4.3)
```

</details>



## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use managed USB component in UVC examples for IDF >=5.4; keep native for earlier versions.
> 
> - **Examples**:
>   - Update `idf_component.yml` in `examples/basic_uvc_stream` and `examples/camera_display` to use managed `espressif/usb` when `idf_version >=5.4`, removing the env-var based override rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f9b4ba211f6777a9e8cc3e64a8a4ee3445a0fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->