### PR TITLE
fix(usb_host_cdc): Temporarily disabling tx_timeout test in CI

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.c
@@ -773,7 +773,8 @@ TEST_CASE("closing", "[cdc_acm]")
 }
 
 /* Basic test to check CDC driver reaction to TX timeout */
-TEST_CASE("tx_timeout", "[cdc_acm]")
+/* Temporary disabling the test, as it keeps failing in the CI IDF-14863 */
+TEST_CASE("tx_timeout", "[cdc_acm][ignore]")
 {
     cdc_acm_dev_hdl_t cdc_dev = NULL;
 


### PR DESCRIPTION
## Description

Disabling frequently failing `tx_timeout` test in CI. 

## Related
 - IDF-14863 Failing test case of USB Host CDC-ACM: tx_timeout in CI

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks `tx_timeout` test in `host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.c` as ignored to avoid CI failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 841c604bcddf52cce6aa7674736ab1022d13f96a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->