### PR TITLE
Refactor(usb_host): Rename auto suspend timer public API

### DIFF
--- a/host/usb/include/usb/usb_host.h
+++ b/host/usb/include/usb/usb_host.h
@@ -53,12 +53,12 @@ typedef enum {
 } usb_host_client_event_t;
 
 /**
- * @brief USB Host lib power management timer type
+ * @brief USB Host lib automatic suspend timer
  */
 typedef enum {
-    USB_HOST_LIB_PM_SUSPEND_ONE_SHOT,               /**< USB Host lib power management -> Auto suspend one-shot timer */
-    USB_HOST_LIB_PM_SUSPEND_PERIODIC,               /**< USB Host lib power management -> Auto suspend periodic timer */
-} usb_host_lib_pm_t;
+    USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT,             /**< Automatic suspend one-shot timer */
+    USB_HOST_LIB_AUTO_SUSPEND_PERIODIC,             /**< Automatic suspend periodic timer */
+} usb_host_lib_auto_suspend_tmr_t;
 
 /**
  * @brief Client event message
@@ -292,15 +292,15 @@ esp_err_t usb_host_lib_root_port_suspend(void);
 esp_err_t usb_host_lib_root_port_resume(void);
 
 /**
- * @brief Set auto power management timer
+ * @brief Set automatic suspend timer
  *
- * - The function sets the auto suspend timer, used for global suspend of the root port
+ * - The function sets the automatic suspend timer, used for global suspend of the root port
  * - The timer is either one-shot or periodic
- * - The timerexpires after the set period, only if there is no activity on the USB Bus
+ * - The timer expires after the set period, only if there is no activity on the USB Bus
  * - The timer resets (if enabled) every time, the usb_host_client_handle_events() handles any client events,
  *   or the usb_host_lib_handle_events() handles any host lib events, thus checking any activity on all the
  *   registered clients or inside the host lib
- * - Once the timer expires, an auto_pm_timer_cb() is called, which delivers USB Host lib event flags
+ * - Once the timer expires, an auto_suspend_timer_cb() is called, which delivers USB Host lib event flags
  *
  * @note set the timer interval to 0, to disable the timer (in case NO auto suspend functionality is required anymore)
  * @note this function is not ISR safe
@@ -311,7 +311,7 @@ esp_err_t usb_host_lib_root_port_resume(void);
  *    - ESP_ERR_INVALID_STATE: USB Host lib is not installed
  *    - ESP_FAIL: Timer was not configured correctly
  */
-esp_err_t usb_host_lib_set_auto_pm(usb_host_lib_pm_t timer_type, size_t timer_interval_ms);
+esp_err_t usb_host_lib_set_auto_suspend(usb_host_lib_auto_suspend_tmr_t timer_type, size_t timer_interval_ms);
 
 // ------------------------------------------------ Client Functions ---------------------------------------------------
 

--- a/host/usb/test/target_test/usb_host/main/msc_client_transfer_resume.c
+++ b/host/usb/test/target_test/usb_host/main/msc_client_transfer_resume.c
@@ -27,7 +27,7 @@ Implementation of an asynchronous MSC client used for USB Host's root port resum
     - Receive USB_HOST_CLIENT_EVENT_NEW_DEV event message, and open the device
     - Open the device by a client
     - Allocate IN and OUT transfer objects for MSC SCSI transfers
-    - Suspend the root port using the PM timer
+    - Suspend the root port using the automatic suspend timer
         - Receive USB_HOST_CLIENT_EVENT_DEV_SUSPENDED event message
     - Issue MSC reset (while the root port is still suspended) to test root port automatic resume by submitting a control transfer
     - Expect USB_TRANSFER_STATUS_COMPLETED
@@ -245,8 +245,8 @@ void msc_client_async_resume_by_transfer_task(void *arg)
             break;
         }
         case TEST_STAGE_SUSPEND_BY_TIMER: {
-            ESP_LOGD(MSC_CLIENT_TAG, "Suspend by PM timer");
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, 200));
+            ESP_LOGD(MSC_CLIENT_TAG, "Suspend by auto suspend timer");
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, 200));
             // Next stage is set from msc_client_event_cb
             break;
         }

--- a/host/usb/test/target_test/usb_host/main/test_usb_host_async.c
+++ b/host/usb/test/target_test/usb_host/main/test_usb_host_async.c
@@ -513,7 +513,7 @@ Purpose:
 
 Procedure:
     - Install USB Host Library, register MSC client, open a device and start handling client events
-    - Set PM periodic timer to 2000ms, start handling usb host lib events
+    - Set auto suspend periodic timer to 2000ms, start handling usb host lib events
     - Expect USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND usb host lib flag
     - Check if the root port is in resumed state, suspend the root port
     - Expect USB_HOST_CLIENT_EVENT_DEV_SUSPENDED client event
@@ -528,8 +528,8 @@ TEST_CASE("Test USB Host auto suspend", "[usb_host][low_speed][full_speed][high_
     // Create mcs client task
     TEST_ASSERT_EQUAL(pdTRUE, xTaskCreate(notif_msc_client, "notif_msc", 4096, NULL, 2, &client_task_hdl));
     TEST_ASSERT_NOT_NULL(client_task_hdl);
-    // Set PM timer to periodic
-    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, TEST_AUTO_SUSPEND_PERIOD_MS));
+    // Set auto suspend timer to periodic
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, TEST_AUTO_SUSPEND_PERIOD_MS));
 
     int suspend_iter = 0;
     while (1) {
@@ -544,8 +544,8 @@ TEST_CASE("Test USB Host auto suspend", "[usb_host][low_speed][full_speed][high_
             if (++suspend_iter >= TEST_AUTO_SUSPEND_ITERATIONS) {
                 // Stop handling the client events, deregister the client
                 xTaskNotifyGive(client_task_hdl);
-                // Stop the periodic PM timer
-                TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, 0));
+                // Stop the periodic auto suspend timer
+                TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, 0));
                 continue;
             }
 

--- a/host/usb/test/target_test/usb_host/main/test_usb_host_suspend_timer.c
+++ b/host/usb/test/target_test/usb_host/main/test_usb_host_suspend_timer.c
@@ -12,10 +12,10 @@
 #include "usb/usb_host.h"
 #include "unity.h"
 
-const char *USB_HOST_PM_TIMER_TAG = "USB Host PM timer";
+const char *USB_HOST_SUSPEND_TIMER_TAG = "USB Host suspend timer";
 
-#define TEST_PM_TIMER_INTERVAL_MS           500
-#define TEST_PM_TIMER_MARGIN_TICKS          5
+#define TEST_SUSPEND_TIMER_INTERVAL_MS           500
+#define TEST_SUSPEND_TIMER_MARGIN_TICKS          5
 
 /**
  * @brief Expect USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND flag to be delivered by the usb host lib
@@ -62,31 +62,31 @@ static inline void check_suspend_flag_not_delivered(TickType_t ticks_to_wait)
  * @param[in] ticks_expected: Expected tick count
  * @param[in] ticks_actual: Actual tick count
  */
-static inline void check_pm_timer_tick_count(uint32_t ticks_expected, uint32_t ticks_actual)
+static inline void check_suspend_timer_tick_count(uint32_t ticks_expected, uint32_t ticks_actual)
 {
-    ESP_LOGD(USB_HOST_PM_TIMER_TAG, "Expected ticks: %ld, Actual ticks %ld", pdMS_TO_TICKS(ticks_expected), ticks_actual);
+    ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "Expected ticks: %ld, Actual ticks %ld", pdMS_TO_TICKS(ticks_expected), ticks_actual);
     TEST_ASSERT_INT_WITHIN_MESSAGE(
-        TEST_PM_TIMER_MARGIN_TICKS, pdMS_TO_TICKS(ticks_expected), ticks_actual,
+        TEST_SUSPEND_TIMER_MARGIN_TICKS, pdMS_TO_TICKS(ticks_expected), ticks_actual,
         "Timer expired too early"
     );
 }
 
-static void pm_timer_measure_task(void *arg)
+static void auto_suspend_timer_measure_task(void *arg)
 {
     typedef enum {
-        TEST_STAGE_PM_ONE_SHOT_TIMER,
-        TEST_STAGE_PM_ONE_SHOT_TIMER_MUL_TIMES,
-        TEST_STAGE_PM_ONE_SHOT_NO_DEV,
-        TEST_STAGE_PM_PERIODIC_TIMER,
-        TEST_STAGE_PM_PERIODIC_TIMER_PORT_SUSPENDED,
-        TEST_STAGE_PM_TIMER_SWITCH,
-        TEST_STAGE_START_STOP_PM_TIMER,
-        TEST_STAGE_RESET_PM_TIMER_BY_HOST_LIB,
+        TEST_STAGE_SUSPEND_ONE_SHOT_TIMER,
+        TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_MUL_TIMES,
+        TEST_STAGE_SUSPEND_ONE_SHOT_NO_DEV,
+        TEST_STAGE_SUSPEND_PERIODIC_TIMER,
+        TEST_STAGE_SUSPEND_PERIODIC_TIMER_PORT_SUSPENDED,
+        TEST_STAGE_SUSPEND_TIMER_SWITCH,
+        TEST_STAGE_START_STOP_SUSPEND_TIMER,
+        TEST_STAGE_RESET_SUSPEND_TIMER_BY_HOST_LIB,
         TEST_STAGE_DEV_FREE,
     } test_stage_t;
 
     TaskHandle_t main_task_hdl = (TaskHandle_t)arg;
-    test_stage_t test_stage = TEST_STAGE_PM_ONE_SHOT_TIMER;
+    test_stage_t test_stage = TEST_STAGE_SUSPEND_ONE_SHOT_TIMER;
     TickType_t timer_start, timer_stop, ticks_to_wait;
     usb_host_lib_info_t lib_info;
     vTaskDelay(100);   // Some time for the device to enumerate
@@ -95,87 +95,87 @@ static void pm_timer_measure_task(void *arg)
     while (!exit_loop) {
         switch (test_stage) {
 
-        // Start the PM one-shot timer, expect an event flag to be delivered, measure ticks between starting the timer and event delivery
-        case TEST_STAGE_PM_ONE_SHOT_TIMER:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_ONE_SHOT_TIMER");
+        // Start the auto suspend one-shot timer, expect an event flag to be delivered, measure ticks between starting the timer and event delivery
+        case TEST_STAGE_SUSPEND_ONE_SHOT_TIMER:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_ONE_SHOT_TIMER");
 
-            // Set the PM timer to 500ms and measure tick count
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_PM_TIMER_INTERVAL_MS));
+            // Set the auto suspend timer to 500ms and measure tick count
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_SUSPEND_TIMER_INTERVAL_MS));
             timer_start = xTaskGetTickCount();
 
             // Expect auto suspend event flag
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS) + TEST_PM_TIMER_MARGIN_TICKS;
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS) + TEST_SUSPEND_TIMER_MARGIN_TICKS;
             check_suspend_flag_delivered(ticks_to_wait);
 
             // Measure tick count, to check if the timer did not expire too early
             timer_stop = xTaskGetTickCount();
-            check_pm_timer_tick_count(TEST_PM_TIMER_INTERVAL_MS, timer_stop - timer_start);
+            check_suspend_timer_tick_count(TEST_SUSPEND_TIMER_INTERVAL_MS, timer_stop - timer_start);
 
             // Make sure no more event flags are delivered during extended period of time
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 2);
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 2);
             check_suspend_flag_not_delivered(ticks_to_wait);
             break;
 
-        // Start the PM one-shot timer multiple times, expect one event flag to be delivered and the period of the timer to prolong
-        case TEST_STAGE_PM_ONE_SHOT_TIMER_MUL_TIMES:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_ONE_SHOT_TIMER_MUL_TIMES");
+        // Start the auto suspend one-shot timer multiple times, expect one event flag to be delivered and the period of the timer to prolong
+        case TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_MUL_TIMES:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_MUL_TIMES");
 
-            // Set the PM timer to 1000ms and measure tick count
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_PM_TIMER_INTERVAL_MS * 2));
+            // Set the auto suspend timer to 1000ms and measure tick count
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_SUSPEND_TIMER_INTERVAL_MS * 2));
             timer_start = xTaskGetTickCount();
 
             // Let the timer run for 500ms
-            vTaskDelay(pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS));
+            vTaskDelay(pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS));
 
-            // Set the PM timer again, to 1500ms
+            // Set the auto suspend timer again, to 1500ms
             // Since we are setting another timer without the first's timer expiration, the active timer is reset and the period is updated
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_PM_TIMER_INTERVAL_MS * 3));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_SUSPEND_TIMER_INTERVAL_MS * 3));
 
             // Expect auto suspend flag to be delivered after 2000ms (1500 + 500)
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 4) + TEST_PM_TIMER_MARGIN_TICKS;
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 4) + TEST_SUSPEND_TIMER_MARGIN_TICKS;
             check_suspend_flag_delivered(ticks_to_wait);
 
             // Measure tick count, to check if the timer did not expire too early
             timer_stop = xTaskGetTickCount();
-            check_pm_timer_tick_count(TEST_PM_TIMER_INTERVAL_MS * 4, timer_stop - timer_start);
+            check_suspend_timer_tick_count(TEST_SUSPEND_TIMER_INTERVAL_MS * 4, timer_stop - timer_start);
             break;
 
-        // Start the PM One-Shot timer with no device, but connect a device immediately, expect the event flag to be delivered
-        case TEST_STAGE_PM_ONE_SHOT_NO_DEV:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_ONE_SHOT_NO_DEV");
+        // Start the auto suspend One-Shot timer with no device, but connect a device immediately, expect the event flag to be delivered
+        case TEST_STAGE_SUSPEND_ONE_SHOT_NO_DEV:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_ONE_SHOT_NO_DEV");
 
             // Disconnect the device and check all devs free flag delivery
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(false));
             check_all_dev_gone_flag_delivered(50);
 
-            // Set the PM timer to 500ms and measure tick count
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_PM_TIMER_INTERVAL_MS));
+            // Set the auto suspend timer to 500ms and measure tick count
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_SUSPEND_TIMER_INTERVAL_MS));
             timer_start = xTaskGetTickCount();
 
             // Connect the device
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(true));
 
             // Expect auto suspend flag to be delivered after more than timer interval (500ms), because of the timer gets reset during the device connection
-            ticks_to_wait = TEST_PM_TIMER_INTERVAL_MS * 2;
+            ticks_to_wait = TEST_SUSPEND_TIMER_INTERVAL_MS * 2;
             check_suspend_flag_delivered(ticks_to_wait);
             timer_stop = xTaskGetTickCount();
 
             // Measure the tick count to check if the timer did not expire too early
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "Expected ticks: more than %ld, Actual ticks %ld", pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS), timer_stop - timer_start);
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "Expected ticks: more than %ld, Actual ticks %ld", pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS), timer_stop - timer_start);
             TEST_ASSERT_GREATER_THAN_INT_MESSAGE(
-                pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS) + TEST_PM_TIMER_MARGIN_TICKS,
+                pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS) + TEST_SUSPEND_TIMER_MARGIN_TICKS,
                 timer_stop - timer_start,
                 "Auto suspend timer did not reset"
             );
             break;
 
-        // Start the PM periodic timer, expect event flags to be delivered periodically
-        case TEST_STAGE_PM_PERIODIC_TIMER:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_PERIODIC_TIMER");
+        // Start the auto suspend periodic timer, expect event flags to be delivered periodically
+        case TEST_STAGE_SUSPEND_PERIODIC_TIMER:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_PERIODIC_TIMER");
 
-            // Set the PM timer to 500ms and measure tick count
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, TEST_PM_TIMER_INTERVAL_MS));
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS) + TEST_PM_TIMER_MARGIN_TICKS;
+            // Set the auto suspend timer to 500ms and measure tick count
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, TEST_SUSPEND_TIMER_INTERVAL_MS));
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS) + TEST_SUSPEND_TIMER_MARGIN_TICKS;
             timer_start = xTaskGetTickCount();
 
             for (int i = 0; i < 3; i++) {
@@ -184,24 +184,24 @@ static void pm_timer_measure_task(void *arg)
 
                 // Measure tick count, to check if the timer did not expire too early
                 timer_stop = xTaskGetTickCount();
-                check_pm_timer_tick_count(TEST_PM_TIMER_INTERVAL_MS, timer_stop - timer_start);
+                check_suspend_timer_tick_count(TEST_SUSPEND_TIMER_INTERVAL_MS, timer_stop - timer_start);
                 timer_start = timer_stop;
             }
 
             // Stop the periodic timer
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, 0));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, 0));
 
             // Make sure no more event flags are delivered during extended period of time
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 2) + TEST_PM_TIMER_MARGIN_TICKS;
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 2) + TEST_SUSPEND_TIMER_MARGIN_TICKS;
             check_suspend_flag_not_delivered(ticks_to_wait);
             break;
 
         // Start the periodic timer, suspend the root port, verify the event flag is not delivered, resume the root port, verify the event flag is delivered
-        case TEST_STAGE_PM_PERIODIC_TIMER_PORT_SUSPENDED:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_PERIODIC_TIMER_PORT_SUSPENDED");
+        case TEST_STAGE_SUSPEND_PERIODIC_TIMER_PORT_SUSPENDED:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_PERIODIC_TIMER_PORT_SUSPENDED");
 
-            // Set the PM to 500ms periodic mode and suspend the root port
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, TEST_PM_TIMER_INTERVAL_MS));
+            // Set the auto suspend timer to 500ms periodic mode and suspend the root port
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, TEST_SUSPEND_TIMER_INTERVAL_MS));
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_root_port_suspend());
             vTaskDelay(50);     // Yield the main task, to handle root port suspend + Wait for suspend entry delay
 
@@ -210,7 +210,7 @@ static void pm_timer_measure_task(void *arg)
             TEST_ASSERT_MESSAGE(lib_info.root_port_suspended, "Root port is not suspended, but it's expected to be");
 
             // Make sure no event is delivered during 3-times the timer period
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 3);
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 3);
             check_suspend_flag_not_delivered(ticks_to_wait);
 
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_root_port_resume());
@@ -221,72 +221,72 @@ static void pm_timer_measure_task(void *arg)
             TEST_ASSERT_FALSE_MESSAGE(lib_info.root_port_suspended, "Root port is suspended, but it's expected not to be");
 
             // Expect auto suspend flag to be delivered after 500ms after the root port has been resumed
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS) + TEST_PM_TIMER_MARGIN_TICKS;
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS) + TEST_SUSPEND_TIMER_MARGIN_TICKS;
             check_suspend_flag_delivered(ticks_to_wait);
 
             // Disable the periodic timer
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, 0));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, 0));
             break;
 
-        // Start the PM periodic timer and switch to the one shot timer, expect event flag to be delivered just once
-        case TEST_STAGE_PM_TIMER_SWITCH:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_TIMER_SWITCH");
+        // Start the auto suspend periodic timer and switch to the one shot timer, expect event flag to be delivered just once
+        case TEST_STAGE_SUSPEND_TIMER_SWITCH:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_TIMER_SWITCH");
 
-            // Set the PM timer to 1000ms and measure tick count
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, TEST_PM_TIMER_INTERVAL_MS * 2));
+            // Set the auto suspend timer to 1000ms and measure tick count
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, TEST_SUSPEND_TIMER_INTERVAL_MS * 2));
             timer_start = xTaskGetTickCount();
 
             // Let the timer run for 500ms
-            vTaskDelay(pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS));
+            vTaskDelay(pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS));
 
             // Switch from periodic to one-shot with different period: 1500ms
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_PM_TIMER_INTERVAL_MS * 3));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_SUSPEND_TIMER_INTERVAL_MS * 3));
 
             // Expect auto suspend flag to be delivered after 2000ms (1500 + 500)
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 4) + TEST_PM_TIMER_MARGIN_TICKS;
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 4) + TEST_SUSPEND_TIMER_MARGIN_TICKS;
             check_suspend_flag_delivered(ticks_to_wait);
 
             // Measure tick count, to check if the timer did not expire too early
             timer_stop = xTaskGetTickCount();
-            check_pm_timer_tick_count(TEST_PM_TIMER_INTERVAL_MS * 4, timer_stop - timer_start);
+            check_suspend_timer_tick_count(TEST_SUSPEND_TIMER_INTERVAL_MS * 4, timer_stop - timer_start);
 
             // Make sure no more event flags are delivered during extended period of time
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 4) + TEST_PM_TIMER_MARGIN_TICKS;
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 4) + TEST_SUSPEND_TIMER_MARGIN_TICKS;
             check_suspend_flag_not_delivered(ticks_to_wait);
             break;
 
         // Start and stop the active timer, expect no event flag to be delivered
-        case TEST_STAGE_START_STOP_PM_TIMER:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_START_STOP_PM_TIMER");
+        case TEST_STAGE_START_STOP_SUSPEND_TIMER:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_START_STOP_SUSPEND_TIMER");
 
-            // Set the PM timer to 500ms
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_PM_TIMER_INTERVAL_MS));
+            // Set the auto suspend timer to 500ms
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_SUSPEND_TIMER_INTERVAL_MS));
 
             // Let the timer run for 250ms and stop the timer
-            vTaskDelay(pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS / 2));
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, 0));
+            vTaskDelay(pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS / 2));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, 0));
 
             // Make sure no more event flags are delivered during extended period of time
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 2);
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 2);
             check_suspend_flag_not_delivered(ticks_to_wait);
             break;
 
-        // Start the PM timer and simulate some workload on the usb host lib, to induce reset of the running PM timer internally by the usb host lib
-        case TEST_STAGE_RESET_PM_TIMER_BY_HOST_LIB:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_RESET_PM_TIMER_BY_HOST_LIB");
+        // Start the auto suspend timer and simulate some workload on the usb host lib, to induce reset of the running auto suspend timer internally by the usb host lib
+        case TEST_STAGE_RESET_SUSPEND_TIMER_BY_HOST_LIB:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_RESET_SUSPEND_TIMER_BY_HOST_LIB");
 
-            // Set the PM timer to 500ms and measure tick count
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_PM_TIMER_INTERVAL_MS));
+            // Set the auto suspend timer to 500ms and measure tick count
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_SUSPEND_TIMER_INTERVAL_MS));
             timer_start = xTaskGetTickCount();
 
             // Let the timer run for 400ms
-            vTaskDelay(pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 0.8));
+            vTaskDelay(pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 0.8));
 
             // Induce a usb host lib workload by root port suspend
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_root_port_suspend());
 
             // Make sure no event is delivered during 1.6-times the timer period
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS * 0.8);
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS * 0.8);
             check_suspend_flag_not_delivered(ticks_to_wait);
 
             // Verify that the root port is suspended thorough USB Host lib info
@@ -302,14 +302,14 @@ static void pm_timer_measure_task(void *arg)
             TEST_ASSERT_FALSE_MESSAGE(lib_info.root_port_suspended, "Root port is suspended, but it's expected not to be");
 
             // Expect auto suspend flag to be delivered after 500ms after the root port has been resumed
-            ticks_to_wait = pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS) + TEST_PM_TIMER_MARGIN_TICKS;
+            ticks_to_wait = pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS) + TEST_SUSPEND_TIMER_MARGIN_TICKS;
             check_suspend_flag_delivered(ticks_to_wait);
             timer_stop = xTaskGetTickCount();
 
             // Measure the tick count to check if the timer did not expire too early
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "Expected ticks: more than %ld, Actual ticks %ld", pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS), timer_stop - timer_start);
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "Expected ticks: more than %ld, Actual ticks %ld", pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS), timer_stop - timer_start);
             TEST_ASSERT_GREATER_THAN_INT_MESSAGE(
-                pdMS_TO_TICKS(TEST_PM_TIMER_INTERVAL_MS) + TEST_PM_TIMER_MARGIN_TICKS,
+                pdMS_TO_TICKS(TEST_SUSPEND_TIMER_INTERVAL_MS) + TEST_SUSPEND_TIMER_MARGIN_TICKS,
                 timer_stop - timer_start,
                 "Auto suspend timer did not reset"
             );
@@ -317,7 +317,7 @@ static void pm_timer_measure_task(void *arg)
 
         // Free the device and finish the test
         case TEST_STAGE_DEV_FREE:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_DEV_FREE");
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_DEV_FREE");
 
             // Stop handling events in the main task after the device is gone
             xTaskNotifyGiveIndexed(main_task_hdl, USB_HOST_LIB_EVENT_FLAGS_ALL_FREE);
@@ -341,7 +341,7 @@ static void pm_timer_measure_task(void *arg)
 Test USB Host auto Suspend timer event flags delivery
 
 Purpose:
-- Test the PM Timer event flags delivery upon timer settings
+- Test the auto suspend timer event flags delivery upon timer settings
 - Measure time between setting of the timer and event flag delivery
 - Test USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND is correctly delivered
 
@@ -349,33 +349,33 @@ Procedure:
     - Install USB Host Library
     - Create timer cancellation measure task
     - Test the following cases:
-        - Set the One-Shot PM Timer, expect correct event flag delivery,  measure (in ticks) time between starting of the timer and event flag delivery
-        - Set the One-Shot PM Timer with no device connected, but connect a device immediately, expect correct event flag delivery
-        - Set the One-Shot PM Timer multiple times without timer expiration, make sure the total timer period prolongs (timer resets)
-        - Set the periodic PM TImer, expect correct event flag to be delivered repeatedly
-        - Set the periodic PM Timer, but switch to the One-Shot Timer, expect correct flag delivery just once
-        - Set and Stop the One-Shot PM Timer, expect no event flag delivery
-        - Set the One-Shot PM Timer, induce some workload for the usb host lib to reset the timer internally, expect and measure event flag delivery
+        - Set the One-Shot auto suspend timer, expect correct event flag delivery,  measure (in ticks) time between starting of the timer and event flag delivery
+        - Set the One-Shot auto suspend timer with no device connected, but connect a device immediately, expect correct event flag delivery
+        - Set the One-Shot auto suspend timer multiple times without timer expiration, make sure the total timer period prolongs (timer resets)
+        - Set the periodic auto suspend tImer, expect correct event flag to be delivered repeatedly
+        - Set the periodic auto suspend timer, but switch to the One-Shot timer, expect correct flag delivery just once
+        - Set and Stop the One-Shot auto suspend timer, expect no event flag delivery
+        - Set the One-Shot auto suspend timer, induce some workload for the usb host lib to reset the timer internally, expect and measure event flag delivery
     - Turn off the root port, teardown
 */
 TEST_CASE("Test USB Host auto suspend timer event flags delivery (no client)", "[usb_host][low_speed][full_speed][high_speed]")
 {
     // Create control task
-    TaskHandle_t pm_timer_measure_task_hdl = NULL;
-    TEST_ASSERT_EQUAL(pdTRUE, xTaskCreate(pm_timer_measure_task, "pm timer measure", 1024 * 2, xTaskGetCurrentTaskHandle(), 4, &pm_timer_measure_task_hdl));
-    TEST_ASSERT_NOT_NULL(pm_timer_measure_task_hdl);
+    TaskHandle_t auto_suspend_timer_measure_task_hdl = NULL;
+    TEST_ASSERT_EQUAL(pdTRUE, xTaskCreate(auto_suspend_timer_measure_task, "suspend timer measure", 1024 * 2, xTaskGetCurrentTaskHandle(), 4, &auto_suspend_timer_measure_task_hdl));
+    TEST_ASSERT_NOT_NULL(auto_suspend_timer_measure_task_hdl);
 
     while (1) {
         uint32_t event_flags;
         usb_host_lib_handle_events(portMAX_DELAY, &event_flags);
 
         if (event_flags & USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND) {
-            xTaskNotifyGiveIndexed(pm_timer_measure_task_hdl, USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND);
+            xTaskNotifyGiveIndexed(auto_suspend_timer_measure_task_hdl, USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND);
             printf("Auto suspend event\n");
         }
 
         if (event_flags & USB_HOST_LIB_EVENT_FLAGS_ALL_FREE) {
-            xTaskNotifyGiveIndexed(pm_timer_measure_task_hdl, USB_HOST_LIB_EVENT_FLAGS_ALL_FREE);
+            xTaskNotifyGiveIndexed(auto_suspend_timer_measure_task_hdl, USB_HOST_LIB_EVENT_FLAGS_ALL_FREE);
             printf("Device gone\n");
 
             if (ulTaskNotifyTakeIndexed(USB_HOST_LIB_EVENT_FLAGS_ALL_FREE, pdFALSE, 0)) {
@@ -386,7 +386,7 @@ TEST_CASE("Test USB Host auto suspend timer event flags delivery (no client)", "
     }
 }
 
-#define TEST_AUTO_PM_TIMER_MS           250
+#define TEST_AUTO_SUSPEND_TIMER_MS           250
 #define TEST_HOST_LIB_EVENT_WAIT_MS     1000
 #define TEST_DEV_GONE_WAIT_MS           50
 
@@ -401,15 +401,15 @@ static void check_device_gone(void)
     );
 }
 
-static void pm_timer_cancel_task(void *arg)
+static void auto_suspend_timer_cancel_task(void *arg)
 {
     typedef enum {
         TEST_STAGE_INIT_PORT_POWER_OFF,
-        TEST_STAGE_PM_ONE_SHOT_TIMER_NO_DEVICE,
-        TEST_STAGE_PM_PERIODIC_TIMER_NO_DEVICE,
-        TEST_STAGE_PM_ONE_SHOT_TIMER_DEVICE_DISCONNECT,
-        TEST_STAGE_PM_ONE_SHOT_TIMER_TOGGLE_DEV,
-        TEST_STAGE_PM_ONE_SHOT_TIMER_PORT_SUSPENDED,
+        TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_NO_DEVICE,
+        TEST_STAGE_SUSPEND_PERIODIC_TIMER_NO_DEVICE,
+        TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_DEVICE_DISCONNECT,
+        TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_TOGGLE_DEV,
+        TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_PORT_SUSPENDED,
         TEST_STAGE_DEV_FREE,
     } test_stage_t;
 
@@ -424,7 +424,7 @@ static void pm_timer_cancel_task(void *arg)
 
         // Initially power off the root port
         case TEST_STAGE_INIT_PORT_POWER_OFF:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_INIT_PORT_POWER_OFF");
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_INIT_PORT_POWER_OFF");
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(false));
 
             // Check that the device is gone and keep the device disconnected for a while
@@ -432,36 +432,36 @@ static void pm_timer_cancel_task(void *arg)
             vTaskDelay(50);
             break;
 
-        // Set the PM One-Shot Timer with no device connected
-        case TEST_STAGE_PM_ONE_SHOT_TIMER_NO_DEVICE:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_ONE_SHOT_TIMER_NO_DEVICE");
+        // Set the auto suspend One-Shot timer with no device connected
+        case TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_NO_DEVICE:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_NO_DEVICE");
 
             // Set auto suspend timer and wait for 1000ms, to make sure no usb host lib event is delivered
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_AUTO_PM_TIMER_MS));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_AUTO_SUSPEND_TIMER_MS));
             vTaskDelay(pdMS_TO_TICKS(TEST_HOST_LIB_EVENT_WAIT_MS));
             break;
 
-        // Set the PM Periodic Timer, with no device connected
-        case TEST_STAGE_PM_PERIODIC_TIMER_NO_DEVICE:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_PERIODIC_TIMER_NO_DEVICE");
+        // Set the auto suspend Periodic timer, with no device connected
+        case TEST_STAGE_SUSPEND_PERIODIC_TIMER_NO_DEVICE:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_PERIODIC_TIMER_NO_DEVICE");
 
             // Set auto suspend timer and wait for 1000ms, to make sure no usb host lib event is delivered
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, TEST_AUTO_PM_TIMER_MS));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, TEST_AUTO_SUSPEND_TIMER_MS));
             vTaskDelay(pdMS_TO_TICKS(TEST_HOST_LIB_EVENT_WAIT_MS));
 
             // Disable the periodic auto suspend timer
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_PERIODIC, 0));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, 0));
 
             // Connect the device back, yield to the main task to handle port connection
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(true));
             vTaskDelay(50);
             break;
 
-        // Set the PM One-Shot Timer with a device connected, but power off the root port immediately
-        case TEST_STAGE_PM_ONE_SHOT_TIMER_DEVICE_DISCONNECT:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_ONE_SHOT_TIMER_DEVICE_DISCONNECT");
+        // Set the auto suspend One-Shot timer with a device connected, but power off the root port immediately
+        case TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_DEVICE_DISCONNECT:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_DEVICE_DISCONNECT");
 
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_AUTO_PM_TIMER_MS));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_AUTO_SUSPEND_TIMER_MS));
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(false));
 
             // Check that the device is gone and wait for 1000ms to make sure no usb hot lib event is delivered
@@ -473,11 +473,11 @@ static void pm_timer_cancel_task(void *arg)
             vTaskDelay(50);
             break;
 
-        // Set the PM One-Shot Timer with a device connected, but toggle the root port power immediately
-        case TEST_STAGE_PM_ONE_SHOT_TIMER_TOGGLE_DEV:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_ONE_SHOT_TIMER_TOGGLE_DEV");
+        // Set the auto suspend One-Shot timer with a device connected, but toggle the root port power immediately
+        case TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_TOGGLE_DEV:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_TOGGLE_DEV");
 
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_AUTO_PM_TIMER_MS));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_AUTO_SUSPEND_TIMER_MS));
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(false));
 
             // Check that the device is gone and keep the device disconnected for a while
@@ -489,11 +489,11 @@ static void pm_timer_cancel_task(void *arg)
             vTaskDelay(pdMS_TO_TICKS(TEST_HOST_LIB_EVENT_WAIT_MS));
             break;
 
-        // Set the PM One-Shot timer and suspend the root port immediately
-        case TEST_STAGE_PM_ONE_SHOT_TIMER_PORT_SUSPENDED:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_PM_ONE_SHOT_TIMER_PORT_SUSPENDED");
+        // Set the auto suspend One-Shot timer and suspend the root port immediately
+        case TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_PORT_SUSPENDED:
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_SUSPEND_ONE_SHOT_TIMER_PORT_SUSPENDED");
 
-            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_pm(USB_HOST_LIB_PM_SUSPEND_ONE_SHOT, TEST_AUTO_PM_TIMER_MS));
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT, TEST_AUTO_SUSPEND_TIMER_MS));
             TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_root_port_suspend());
             vTaskDelay(50);     // Yield the main task, to handle root port suspend + Wait for suspend entry delay
 
@@ -507,7 +507,7 @@ static void pm_timer_cancel_task(void *arg)
 
         // Power the root port off, disconnect the device and finish the test
         case TEST_STAGE_DEV_FREE:
-            ESP_LOGD(USB_HOST_PM_TIMER_TAG, "TEST_STAGE_DEV_FREE");
+            ESP_LOGD(USB_HOST_SUSPEND_TIMER_TAG, "TEST_STAGE_DEV_FREE");
 
             // Stop handling events in the main task after the device is gone
             xTaskNotifyGive(main_task_hdl);
@@ -526,28 +526,28 @@ static void pm_timer_cancel_task(void *arg)
 }
 
 /*
-Test USB Host auto Suspend timer cancellation
+Test USB Host automatic suspend timer cancellation
 
 Purpose:
-- Test the PM Timer cancellation upon device disconnection or reconnection
+- Test the automatic suspend timer cancellation upon device disconnection or reconnection
 - Test USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND not incorrectly delivered
 
 Procedure:
     - Install USB Host Library
     - Create timer cancellation task
     - Test the following cases:
-        - Set the PM Timer with no device connected
-        - Set the PM Timer with a device connected, but disconnect the device immediately
-        - Set the PM Timer with a device connected, but reconnect the device immediately
+        - Set the auto suspend timer with no device connected
+        - Set the auto suspend timer with a device connected, but disconnect the device immediately
+        - Set the auto suspend timer with a device connected, but reconnect the device immediately
     - During the whole test run, expect that no USB_HOST_LIB event is generated
     - Turn off the root port, teardown
 */
 TEST_CASE("Test USB Host auto suspend timer cancellation (no client)", "[usb_host][low_speed][full_speed][high_speed]")
 {
     // Create control task
-    TaskHandle_t pm_timer_cancel_task_hdl = NULL;
-    TEST_ASSERT_EQUAL(pdTRUE, xTaskCreate(pm_timer_cancel_task, "pm timer cancel", 1024 * 2, xTaskGetCurrentTaskHandle(), 4, &pm_timer_cancel_task_hdl));
-    TEST_ASSERT_NOT_NULL(pm_timer_cancel_task_hdl);
+    TaskHandle_t suspend_timer_cancel_task_hdl = NULL;
+    TEST_ASSERT_EQUAL(pdTRUE, xTaskCreate(auto_suspend_timer_cancel_task, "suspend timer cancel", 1024 * 2, xTaskGetCurrentTaskHandle(), 4, &suspend_timer_cancel_task_hdl));
+    TEST_ASSERT_NOT_NULL(suspend_timer_cancel_task_hdl);
 
     while (1) {
         uint32_t event_flags;
@@ -558,7 +558,7 @@ TEST_CASE("Test USB Host auto suspend timer cancellation (no client)", "[usb_hos
         }
 
         if (event_flags & USB_HOST_LIB_EVENT_FLAGS_ALL_FREE) {
-            xTaskNotifyGive(pm_timer_cancel_task_hdl);
+            xTaskNotifyGive(suspend_timer_cancel_task_hdl);
             printf("Device gone\n");
 
             if (ulTaskNotifyTake(pdFALSE, 0)) {


### PR DESCRIPTION
## Description

Renaming `usb_host_lib_set_auto_pm` to `usb_host_lib_set_auto_suspend`.
Also renaming it's related enums and typedefs, to align with the new name.

No functional change, just renaming.

### Suspend timer type enum

Renamed from:
```
typedef enum {
    USB_HOST_LIB_PM_SUSPEND_ONE_SHOT,               /**< USB Host lib power management -> Auto suspend one-shot timer */
    USB_HOST_LIB_PM_SUSPEND_PERIODIC,               /**< USB Host lib power management -> Auto suspend periodic timer */
} usb_host_lib_pm_t;
```

to

```
typedef enum {
    USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT,             /**< Automatic suspend one-shot timer */
    USB_HOST_LIB_AUTO_SUSPEND_PERIODIC,             /**< Automatic suspend periodic timer */
} usb_host_lib_auto_suspend_tmr_t;
```

### Suspend timer public API functions

Renamed from

```
esp_err_t usb_host_lib_set_auto_pm(usb_host_lib_pm_t timer_type, size_t timer_interval_ms);
```

to 

```
esp_err_t usb_host_lib_set_auto_suspend(usb_host_lib_auto_suspend_tmr_t timer_type, size_t timer_interval_ms);
```

## Related

- #275 
- #181 
- #182 
- #206 
- #211 
- #328 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `usb_host_lib_set_auto_pm` and related PM types/constants to `usb_host_lib_set_auto_suspend` with new auto-suspend enum names, and updates core implementation and tests accordingly.
> 
> - **API (usb_host.h)**:
>   - Rename `usb_host_lib_set_auto_pm(...)` → `usb_host_lib_set_auto_suspend(...)`.
>   - Replace `usb_host_lib_pm_t` with `usb_host_lib_auto_suspend_tmr_t`.
>   - Replace `USB_HOST_LIB_PM_SUSPEND_ONE_SHOT/PERIODIC` with `USB_HOST_LIB_AUTO_SUSPEND_ONE_SHOT/PERIODIC`.
> - **Core (usb_host.c)**:
>   - Rename internal timer objects and helpers: `auto_pm_timer` → `auto_suspend_timer`, `reset_pm_timer/stop_pm_timer` → `reset_auto_suspend_timer/stop_auto_suspend_timer`, `auto_pm_timer_cb` → `auto_suspend_timer_cb`.
>   - Wire new API and naming through install/uninstall, event handling, and logging.
> - **Tests**:
>   - Update CDC/MSC tests and USB host target tests to new API and constants.
>   - Rename test macros, comments, and log tags from PM timer to suspend timer; adjust calls accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3670dbd1c3e5fa4ddb05402caa47261ed0434e05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->