### PR TITLE
feat(usb_host): Exit suspend state by port reset

### DIFF
--- a/host/usb/src/hcd_dwc.c
+++ b/host/usb/src/hcd_dwc.c
@@ -1254,8 +1254,11 @@ static esp_err_t _port_cmd_reset(port_t *port)
 {
     esp_err_t ret;
 
-    // Port can only a reset when it is in the enabled or disabled (in the case of a new connection)states.
-    if (port->state != HCD_PORT_STATE_ENABLED && port->state != HCD_PORT_STATE_DISABLED) {
+    // Port can only be reset when it is in the enabled or disabled (in the case of a new connection) states, or
+    // in suspended state, to exit suspended state through host initiated reset
+    if (port->state != HCD_PORT_STATE_ENABLED &&
+            port->state != HCD_PORT_STATE_DISABLED &&
+            port->state != HCD_PORT_STATE_SUSPENDED) {
         ret = ESP_ERR_INVALID_STATE;
         goto exit;
     }

--- a/host/usb/test/target_test/common/hcd_common.h
+++ b/host/usb/test/target_test/common/hcd_common.h
@@ -191,10 +191,14 @@ void test_hcd_free_urb(urb_t *urb);
 uint8_t test_hcd_enum_device(hcd_pipe_handle_t default_pipe);
 
 /**
- * @brief Set endpoint descriptor
+ * @brief Ping device to check whether the device is responsive or not
  *
- * Set endpoint descriptor of the mock device with different wMaxPacketSize according to the connected device's speed
+ * Use this function to check whether it is possible to communicate with a device.
+ * For example after resuming a device, to check whether the device has been resumed correctly.
+ * The function sends a get configuration descriptor request to a device, checking both, the IN and OUT transfers
  *
- * @param port_speed Port speed after the device is connected
+ * @note this function sends a control transfer to the device
+ * @param default_pipe The connected device's default pipe
+ * @param default_urb A default_pipe's URB used for get configuration descriptor request
  */
-void test_hcd_set_mock_msc_ep_descriptor(usb_speed_t port_speed);
+void test_hcd_ping_device(hcd_pipe_handle_t default_pipe, urb_t *default_urb);


### PR DESCRIPTION
## Description

According to the programming guide, there are several ways how to exit suspended state:
- Host initiated resume
    - calling `usb_host_lib_root_port_resume()`
- Device initiated remote wakeup
     - in progress in #298
- Device disconnect
    - already working
- **Host initiated reset**
    - this PR
- and others which are not relevant for us yet.

## Exiting Suspend Through Host Initiated Reset
When the port is in suspended state, it must react to `HCD_PORT_CMD_RESET` command, which will effectively resume the root port after the reset sequence.

This change does not bring any benefits right now, adding it just for the sake of the completeness of the global suspend/resume feature.

## Related

- Follow-up for #275 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable host-initiated reset while port is suspended to exit suspend; add ping helper and tests, including a new suspend+reset test.
> 
> - **Driver (HCD DWC)**
>   - Allow `HCD_PORT_CMD_RESET` when port is `HCD_PORT_STATE_SUSPENDED` in `_port_cmd_reset()` (`host/usb/src/hcd_dwc.c`).
> - **Tests**
>   - Add `TRANSFER_MAX_BYTES` and `test_hcd_ping_device()` helper to probe device responsiveness (`host/usb/test/target_test/common/hcd_common.{c,h}`).
>   - Update suspend/resume and sudden disconnect tests to use `test_hcd_ping_device()`, manage URB lifecycle, and validate states (`host/usb/test/target_test/hcd/main/test_hcd_port.c`).
>   - Add new test "Test HCD port suspend and resume port reset" verifying reset exits suspend and restores enabled state while pipe remains halted (`test_hcd_port.c`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e48b3d49c3336c14f346b1038c214b3d31f3c1ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->