### PR TITLE
feat(ci): Run esp-idf examples on targets

### DIFF
--- a/.github/ci/.idf-build-examples-rules.yml
+++ b/.github/ci/.idf-build-examples-rules.yml
@@ -1,16 +1,10 @@
 # Manifest file for build_idf_examples.yml CI workflow
 
 examples/peripherals/usb/device:
-  enable:
-    - if: (IDF_VERSION >= "6.0.0")
-      reason: Device examples have been updated to use esp_tinyusb 2.x only on esp-idf latest for now, TODO IDF-14282
   disable:
     - if: SOC_USB_OTG_SUPPORTED != 1
 
 examples/peripherals/usb/device/tusb_ncm:
-  enable:
-    - if: (IDF_VERSION >= "6.0.0")
-      reason: Device examples have been updated to use esp_tinyusb 2.x only on esp-idf latest for now, TODO IDF-14282
   disable:
     - if: SOC_USB_OTG_SUPPORTED != 1 or SOC_WIFI_SUPPORTED != 1
 

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -1,7 +1,7 @@
-# This workflow builds esp-idf examples:
+# This workflow builds and runs usb host and usb device esp-idf examples with overridden local components:
 #
+# Build:
 #   - usb device examples: with overridden esp_tinyusb from esp-usb/device/esp_tinyusb
-#     - Override esp_tinyusb component only for IDF >= 6.0 temporarily
 #
 #   - usb host examples:
 #     - Overridden usb component from esp-usb/host/usb and overridden class drivers from esp-usb/host/class
@@ -11,8 +11,22 @@
 #
 #   - cherryusb examples are ignored
 #   - usb_host_lib example -> manifest file must be created for IDF < 6.0 to override usb component
+#
+# Run:
+#   - usb device examples:
+#     - usb_device target runners, with matrix of all listed releases
+#     - IDF Releases: Latest, IDF 6.0, IDF 5.5
+#   - usb host examples:
+#     - usb_host_examples target runners, with matrix of all listed releases
+#     - IDF Releases: Latest, IDF 6.0, IDF 5.5
+#
+# Temporarily disabled tests and TODOs of this workflow:
+# - USB Host examples run: IDF latest and IDF 6.0 disabled for esp32p4 (ECO4-ECO5 build-runner mismatch)
+# - USB Device examples run: IDF latest and IDF 6.0 disabled for esp32p4 (ECO4-ECO5 build-runner mismatch)
+# - USB Device NCM example run: Ignored due to GH Runner configuration (docker needs --net=host to access host network namespace)
+# - Examples runs on targets enabled only for IDF >= 5.5
 
-name: Build ESP-IDF USB examples
+name: Build and Run ESP-IDF USB examples
 
 on:
   pull_request:
@@ -20,6 +34,8 @@ on:
 
 jobs:
   build:
+    # Run the workflow, only with BUILD_AND_TEST_IDF_EXAMPLES PR Label
+    if: contains(github.event.pull_request.labels.*.name, 'BUILD_AND_TEST_IDF_EXAMPLES')
     strategy:
       fail-fast: true
       matrix:
@@ -50,8 +66,6 @@ jobs:
       - name: Setup IDF Examples path
         run: echo "EXAMPLES_PATH=${IDF_PATH}/examples/peripherals/usb" >> $GITHUB_ENV
       - name: Override device component
-        # Override esp_tinyusb component only for IDF >= 6.0 temporarily
-        if: contains('release-v6.0 latest', matrix.idf_ver)
         run: |
           . ${IDF_PATH}/export.sh
           python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${{ env.EXAMPLES_PATH }}/device/*
@@ -85,7 +99,7 @@ jobs:
           python .github/ci/override_managed_component.py usb_host_uvc host/class/uvc/usb_host_uvc ${{ env.EXAMPLES_PATH }}/host/uvc
 
       - name: Create component manifest file for usb_host_lib
-        # Create manifest file for usb_host_lib example, because the examples does not have it for IDF < 6.0
+        # Create manifest file for usb_host_lib example, because the examples do not have it for IDF < 6.0
         # and we need to override the usb component
         if: contains('release-v5.4 release-v5.5', matrix.idf_ver)
         working-directory: ${{ env.EXAMPLES_PATH }}/host/usb_host_lib/main
@@ -125,3 +139,84 @@ jobs:
 
           idf-build-apps find --config-file ${CONFIG_PATH} --manifest-file ${MANIFEST_PATH}
           idf-build-apps build --config-file ${CONFIG_PATH} --manifest-file ${MANIFEST_PATH}
+
+      - uses: actions/upload-artifact@v4
+        # Upload build files, pytest files and sdkconfig files
+        with:
+          name: usb_examples_bin_${{ matrix.idf_ver }}
+          path: |
+            ${{ env.EXAMPLES_PATH }}/**/build_esp*/bootloader/bootloader.bin
+            ${{ env.EXAMPLES_PATH }}/**/build_esp*/partition_table/partition-table.bin
+            ${{ env.EXAMPLES_PATH }}/**/build_esp*/*.bin
+            ${{ env.EXAMPLES_PATH }}/**/build_esp*/*.elf
+            ${{ env.EXAMPLES_PATH }}/**/build_esp*/flasher_args.json
+            ${{ env.EXAMPLES_PATH }}/**/build_esp*/config/sdkconfig.json
+            ${{ env.EXAMPLES_PATH }}/**/pytest_*.py
+            ${{ env.EXAMPLES_PATH }}/**/sdkconfig.*
+          if-no-files-found: error
+
+  run:
+    # Run on target runners
+    if: ${{ github.repository_owner == 'espressif' }}
+    needs: build
+    strategy:
+      fail-fast: true
+      matrix:
+        idf_ver:
+          [
+            # Only run for IDF >= 5.5,
+            # For lower IDF versions, running pytest files from esp-idf outside of esp-idf container is too complicated
+            "release-v5.5",
+            "release-v6.0",
+            "latest",
+          ]
+        idf_target: ["esp32s2", "esp32p4"]
+        runner_tag: ["usb_host_flash_disk", "usb_device"]
+        include:
+          # Assign a folder structure to a target runner
+          - runner_tag: usb_host_flash_disk
+            example: host
+          - runner_tag: usb_device
+            example: device
+        exclude:
+          # Temp exclude esp32p4 usb_host_flash_disk and usb_device run
+          # for IDF Latest and 6.0 (ECO4-ECO5 build-runner mismatch)
+          - runner_tag: usb_host_flash_disk
+            idf_ver: "latest"
+            idf_target: "esp32p4"
+          - runner_tag: usb_host_flash_disk
+            idf_ver: "release-v6.0"
+            idf_target: "esp32p4"
+          - runner_tag: usb_device
+            idf_ver: "latest"
+            idf_target: "esp32p4"
+          - runner_tag: usb_device
+            idf_ver: "release-v6.0"
+            idf_target: "esp32p4"
+    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
+    container:
+      image: python:3.11-bookworm
+      options: --privileged --device-cgroup-rule="c 188:* rmw" --device-cgroup-rule="c 166:* rmw"
+    env:
+      EXAMPLES_PATH: ${{ github.workspace }}
+    steps:
+      - name: ⚙️ Install System tools
+        run: |
+          apt-get update -y
+          apt-get install -y --no-install-recommends net-tools
+      - name: Setup IDF Examples path
+      # Create matrix-specific directory name and save it's path to the EXAMPLES_PATH variable
+        run: |
+          EXAMPLES_DIR="idf_examples_${{ matrix.idf_ver }}_${{ matrix.idf_target }}_${{ matrix.runner_tag }}"
+          mkdir -p "$EXAMPLES_DIR" && cd "$EXAMPLES_DIR" && pwd
+          echo "EXAMPLES_PATH=$(pwd)" >> "$GITHUB_ENV"
+      - name: ⚙️ Install Python packages
+        env:
+          PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
+        run: pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb netifaces idf-ci pytest-ignore-test-results
+      - uses: actions/download-artifact@v4
+        with:
+          name: usb_examples_bin_${{ matrix.idf_ver }}
+          path: ${{ env.EXAMPLES_PATH }}
+      - name: Run USB Test App on target
+        run: pytest ${{ env.EXAMPLES_PATH }}/${{ matrix.example }} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases="*ncm_example*"

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -145,15 +145,15 @@ jobs:
       - name: ⚙️ Install System tools
         if: success() && steps.download_artifact.outcome == 'success'
         run: |
-          apt update
-          apt install -y usbutils
+          apt-get update -y
+          apt-get install -y usbutils
       - name: Install Python packages
         if: success() && steps.download_artifact.outcome == 'success'
         env:
           PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
         # We need idf-ci pytest plugin to handle 'no test_app binary found for test' error
         # We need pytest-ignore-test-results to ignore the error
-        run: pip install --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf idf-ci pytest-ignore-test-results pyserial pyusb
+        run: pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf idf-ci pytest-ignore-test-results pyserial pyusb
       - name: Run USB Test App on target
         if: success() && steps.download_artifact.outcome == 'success'
         run: |


### PR DESCRIPTION
## Description

Running esp-idf usb host and usb device examples with overridden local components on target runners.

## Related

- Follow-up for #265 

## Limitations

- NCM Device examples can't be currently run on GH Runners
  - docker container must be executed with `--net=host` option (same as it is done on GL runners where the NCM device tests are passing) to access host network interface, not possible due to default GH runners config
  - the solution is tested locally and working
- idf examples for IDF 5.4 and older releases are not run, due to complicated CI setup
  - in GL CI, there is a dedicated container `target-test-env` for this purpose

## Changes

### Target runners

- `usb_device` target runners in `esp-usb` run `esp-idf` device examples
- `usb_host_flash_disk` target runners in `esp-usb` run `esp-idf` host examples

### Conditional workflow run
- the `build_and_run_idf_examples.yml` workflow run conditionally specified by the PR author
- to save some CI build time, as this test don't have to be build for every PR
- the workflow runs if a PR label `BUILD_AND_TEST_IDF_EXAMPLES` is present - user can add this label to trigger the run

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Runs esp-idf USB host/device examples on hardware with artifact-based handoff between build and run jobs, and introduces centralized example-selection rules.
> 
> - Adds `.github/ci/.idf-build-examples-rules.yml` to enable/disable `usb` examples (notably enables `host/uvc` for `IDF_VERSION >= 5.5`; disables when `SOC_USB_OTG_SUPPORTED != 1`, and for NCM also when `SOC_WIFI_SUPPORTED != 1`).
> - Reworks `build_and_run_idf_examples.yml` to:
>   - Gate execution via `BUILD_AND_TEST_IDF_EXAMPLES` label; build matrix for IDF 5.2–latest; upload build artifacts.
>   - Always override `esp_tinyusb` for device and override host class/usb components as appropriate; create `idf_component.yml` for `usb_host_lib` on <6.0.
>   - New "run" job on self-hosted runners (`esp32s2`, `esp32p4`) for IDF ≥5.5; excludes esp32p4 on some versions; installs deps and executes pytest with markers.
> - Minor CI hygiene in `build_and_run_test_app_usb.yml`: switch to `apt-get` and add `--no-cache-dir` to pip installs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96b07e8827a7b13a6e83d7430bf129e6d8154d12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->