### PR TITLE
feat(cdc): Added support for large TX transfers

### DIFF
--- a/host/class/cdc/esp_modem_usb_dte/esp_modem_usb.cpp
+++ b/host/class/cdc/esp_modem_usb_dte/esp_modem_usb.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -162,11 +162,6 @@ private:
         auto *this_terminal = static_cast<UsbTerminal *>(user_ctx);
 
         switch (event->type) {
-        // Notifications like Ring, Rx Carrier indication or Network connection indication are not relevant for USB terminal
-        case CDC_ACM_HOST_NETWORK_CONNECTION:
-        case CDC_ACM_HOST_SERIAL_STATE:
-            ESP_LOGD(TAG, "Ignored USB event %d", event->type);
-            break;
         case CDC_ACM_HOST_DEVICE_DISCONNECTED:
             ESP_LOGW(TAG, "USB terminal disconnected");
             if (this_terminal->on_error) {
@@ -180,8 +175,13 @@ private:
                 this_terminal->on_error(terminal_error::UNEXPECTED_CONTROL_FLOW);
             }
             break;
+        // Notifications like Ring, Rx Carrier indication or Network connection indication are not relevant for USB terminal
+        // Suspend/resume events also ignored
+        case CDC_ACM_HOST_NETWORK_CONNECTION:
+        case CDC_ACM_HOST_SERIAL_STATE:
         default:
-            abort();
+            ESP_LOGD(TAG, "Ignored USB event %d", event->type);
+            break;
         }
     }
     size_t buffer_size;

--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 - Added global suspend/resume support
+- Added support for transmitting data larger than the configured output buffer size
 
 ## [2.1.1] - 2025-09-24
 

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/CMakeLists.txt
@@ -5,3 +5,4 @@ idf_component_register(SRC_DIRS .
 
 # So we have access to private_include:
 target_include_directories(${COMPONENT_LIB} PRIVATE "../../")
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-missing-field-initializers)

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_app_main.c
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_app_main.c
@@ -1,11 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
 #include <string.h>
+#include "esp_newlib.h"
 #include "unity.h"
 #include "unity_test_runner.h"
 #include "unity_test_utils_memory.h"
@@ -17,6 +18,7 @@ void setUp(void)
 
 void tearDown(void)
 {
+    esp_reent_cleanup();    //clean up some of the newlib's lazy allocations
     unity_utils_evaluate_leaks();
 }
 
@@ -36,6 +38,6 @@ void app_main(void)
     printf("                 \\/         \\/             \\/     \\/        \r\n");
 
     unity_utils_setup_heap_record(80);
-    unity_utils_set_leak_level(530);
+    unity_utils_set_leak_level(30);
     unity_run_menu();
 }


### PR DESCRIPTION
List of changes:
* USB modem DTE updated not to abort on Suspend and Resume events
* USB-CDC driver now accepts transfers larger then OUT buffer. It sends them in chunks in a loop
* Test app refactored to C++ so we can easily use lambda functions for callbacks