### PR TITLE
fix(usb): clarify hardware fifo size description in menuconfig

### DIFF
--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Global suspend/resume (https://github.com/espressif/esp-usb/pull/275)
 
+### Fixed
+
+- Hardware FIFO size biasing Kconfig now shows allocation formulas instead of chip-specific examples
+
 ## [1.0.1] - 2025-10-16
 
 ### Fixed

--- a/host/usb/Kconfig
+++ b/host/usb/Kconfig
@@ -21,22 +21,28 @@ menu "USB-OTG"
             FIFOS: RX (for all IN packets), Non-periodic TX (for Bulk and Control OUT packets), and Periodic TX
             (for Interrupt and Isochronous OUT packets). This configuration option allows biasing the FIFO sizes
             towards a particular use case, which may be necessary for devices that have endpoints with large MPS.
-            The MPS limits for each biasing are listed below:
+
+            The FIFO allocation formulas (where D = otg_dfifo_depth, Total = Total available FIFO size in lines):
 
             Balanced:
-            - IN (all transfer types), 408 bytes
-            - OUT non-periodic (Bulk/Control), 192 bytes (i.e., 3 x 64 byte packets)
-            - OUT periodic (Interrupt/Isochronous), 192 bytes
+            - IN (RX FIFO) = Total - D/4 - D/8
+            - OUT non-periodic (Non-periodic TX FIFO) = D/4
+            - OUT periodic (Periodic TX FIFO) = D/8
 
             Bias IN:
-            - IN (all transfer types), 600 bytes
-            - OUT non-periodic (Bulk/Control), 64 bytes (i.e., 1 x 64 byte packets)
-            - OUT periodic (Interrupt/Isochronous), 128 bytes
+            - IN (RX FIFO) = Total - D/16 - D/8
+            - OUT non-periodic (Non-periodic TX FIFO) = D/16
+            - OUT periodic (Periodic TX FIFO) = D/8
 
             Bias Periodic OUT:
-            - IN (all transfer types), 128 bytes
-            - OUT non-periodic (Bulk/Control), 64 bytes (i.e., 1 x 64 byte packets)
-            - OUT periodic (Interrupt/Isochronous), 600 bytes
+            - IN (RX FIFO) = D/8 + 2 (2 extra lines for status information)
+            - OUT non-periodic (Non-periodic TX FIFO) = D/16
+            - OUT periodic (Periodic TX FIFO) = Total - D/16 - (D/8 + 2)
+
+            Note:
+            - Each line = 4 bytes. To convert FIFO size: bytes = lines × 4
+            - D (otg_dfifo_depth) is typically 256 for FS PHY, 1024 for HS PHY (chip-dependent)
+            - Total is slightly less than D due to controller overhead
 
         config USB_HOST_HW_BUFFER_BIAS_BALANCED
             bool "Balanced"


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Replace chip-specific MPS examples with generic FIFO allocation formulas. Add notes on otg_dfifo_depth values, Total FIFO size relationship, and line-to-byte conversion.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies USB host FIFO biasing by replacing chip-specific examples with allocation formulas in Kconfig and updates the changelog accordingly.
> 
> - **Kconfig (USB Host)**:
>   - Replace chip-specific MPS examples with formula-based FIFO allocations for `Balanced`, `Bias IN`, and `Bias Periodic OUT`.
>   - Add notes on unit conversion (lines to bytes), typical `D (otg_dfifo_depth)` values, and that `Total` is slightly less than `D`.
> - **Changelog**:
>   - Note under `unreleased` that FIFO biasing Kconfig now shows allocation formulas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8498782ddc4ac55b151fdf8be7280f65964ff40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->