### PR TITLE
feat(cdc_acm_host): Remote wakeup (IEC-453)

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added remote wakeup feature
+
 ## [2.3.0] - 2026-01-23
 
 ### Added

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/common_test_fixtures.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/common_test_fixtures.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -227,7 +227,12 @@ esp_err_t test_cdc_acm_host_close(cdc_acm_dev_hdl_t *cdc_hdl, uint8_t interface_
     }
 
     // Release data interface
-    usb_host_interface_release_ExpectAndReturn(nullptr, nullptr, interface_index, ESP_OK);
+    if (p_cdc_dev_expects->notif.has_separate_interface) {
+        usb_host_interface_release_ExpectAnyArgsAndReturn(ESP_OK);
+        usb_host_interface_release_ExpectAnyArgsAndReturn(ESP_OK);
+    } else {
+        usb_host_interface_release_ExpectAndReturn(nullptr, nullptr, interface_index, ESP_OK);
+    }
     usb_host_interface_release_IgnoreArg_client_hdl();  // Ignore all function parameters, except interface_index
     usb_host_interface_release_IgnoreArg_dev_hdl();
 
@@ -309,6 +314,9 @@ esp_err_t test_cdc_acm_reset_transfer_endpoint(uint8_t ep_address)
 esp_err_t test_usb_host_interface_claim(uint8_t interface_index)
 {
     usb_host_interface_claim_ExpectAndReturn(nullptr, nullptr, interface_index, 0, ESP_OK);
+    if (p_cdc_dev_expects && p_cdc_dev_expects->notif.has_separate_interface) {
+        usb_host_interface_claim_IgnoreArg_bInterfaceNumber();
+    }
     usb_host_interface_claim_IgnoreArg_client_hdl();        // Ignore all function parameters, except interface_index
     usb_host_interface_claim_IgnoreArg_dev_hdl();
     usb_host_interface_claim_IgnoreArg_bAlternateSetting();

--- a/host/class/cdc/usb_host_cdc_acm/include/esp_private/cdc_host_common.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/esp_private/cdc_host_common.h
@@ -59,5 +59,8 @@ struct cdc_dev_s {
     cdc_data_protocol_t data_protocol;
     int cdc_func_desc_cnt;                // Number of CDC Functional descriptors in following array
     const usb_standard_desc_t *(*cdc_func_desc)[]; // Pointer to array of pointers to const usb_standard_desc_t
+#ifdef CDC_HOST_REMOTE_WAKE_SUPPORTED
+    bool remote_wakeup_enabled;           // Remote wakeup currently enabled/disabled on the device
+#endif // CDC_HOST_REMOTE_WAKE_SUPPORTED
     SLIST_ENTRY(cdc_dev_s) list_entry;
 };

--- a/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_acm_host.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_acm_host.h
@@ -191,6 +191,27 @@ esp_err_t cdc_acm_host_cdc_desc_get(cdc_acm_dev_hdl_t cdc_hdl, cdc_desc_subtype_
  */
 esp_err_t cdc_acm_host_send_custom_request(cdc_acm_dev_hdl_t cdc_hdl, uint8_t bmRequestType, uint8_t bRequest, uint16_t wValue, uint16_t wIndex, uint16_t wLength, uint8_t *data);
 
+#ifdef CDC_HOST_REMOTE_WAKE_SUPPORTED
+/**
+ * @brief Enable/Disable remote wakeup on device
+ * @note API availability depends on presence of remote wakeup support in esp-idf HAL
+ *       and is guarded by the CDC_HOST_REMOTE_WAKE_SUPPORTED
+ *
+ * @param[in] cdc_hdl       CDC device handle
+ * @param[in] enable        Enable/Disable remote wakeup
+ * @return
+ *     - ESP_OK:                   Remote wakeup successfully enabled/disabled, or already enabled/disabled on the device
+ *     - ESP_ERR_INVALID_ARG:      Invalid input argument
+ *     - ESP_ERR_INVALID_STATE     CDC driver is not installed
+ *     - ESP_ERR_NOT_FOUND:        Device not found in device list (probably already closed)
+ *     - ESP_ERR_NOT_SUPPORTED:    Device does not support remote wakeup
+ *     - ESP_ERR_TIMEOUT:          Transfer timed out, or failed to acquire ctr transfer mutex
+ *     - ESP_ERR_INVALID_RESPONSE: Invalid response of the control transfer
+ *     - Errors propagated from caller functions
+ */
+esp_err_t cdc_acm_host_enable_remote_wakeup(cdc_acm_dev_hdl_t cdc_hdl, bool enable);
+#endif // CDC_HOST_REMOTE_WAKE_SUPPORTED
+
 #ifdef __cplusplus
 }
 class CdcAcmDevice {

--- a/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_host_types.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_host_types.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,6 +14,11 @@
 // For backward compatibility with IDF versions which do not have suspend/resume api
 #ifdef USB_HOST_LIB_EVENT_FLAGS_AUTO_SUSPEND
 #define CDC_HOST_SUSPEND_RESUME_API_SUPPORTED
+#endif
+
+// For backward compatibility with IDF versions which do not have remote wakeup HAL changes
+#ifdef REMOTE_WAKE_HAL_SUPPORTED
+#define CDC_HOST_REMOTE_WAKE_SUPPORTED
 #endif
 
 typedef struct cdc_dev_s *cdc_acm_dev_hdl_t;

--- a/host/class/cdc/usb_host_cdc_acm/test_app/pytest_usb_host_cdc.py
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/pytest_usb_host_cdc.py
@@ -27,6 +27,8 @@ def test_usb_host_cdc(dut: Tuple[IdfDut, IdfDut]) -> None:
         ("dual_iface",        "cdc_acm"),
         ("suspend_dconn",     "host_suspend_dconn"),
         ("resume_dconn",      "host_resume_dconn"),
+        ("remote_wake",       "host_remote_wake"),
+        ("remote_wake_dconn", "host_remote_wake_dconn"),
     ]
 
     for dev_test_mode, host_test_case_group in tests:

--- a/host/usb/test/mocks/usb_host_full_mock/usb/CMakeLists.txt
+++ b/host/usb/test/mocks/usb_host_full_mock/usb/CMakeLists.txt
@@ -28,3 +28,8 @@ target_sources(${COMPONENT_LIB} PRIVATE "${original_usb_dir}/src/usb_private.c")
 
 # Add the extra src files for USB device mocking
 target_sources(${COMPONENT_LIB} PRIVATE "mock_add_usb_device.cpp")
+
+# Set public symbol REMOTE_WAKE_HAL_SUPPORTED, which is normally set in usb component cmake
+# and depends on remote wakeup feature presence in USB HAL/LL
+set(REMOTE_WAKE_HAL_SUPPORTED ON)
+target_compile_definitions(${COMPONENT_LIB} PUBLIC REMOTE_WAKE_HAL_SUPPORTED)


### PR DESCRIPTION
## Description

Adding remote wakeup support for `cdc-acm` host.

- Configurable by newly added public API:
```c
esp_err_t cdc_acm_host_enable_remote_wakeup(cdc_acm_dev_hdl_t cdc_hdl, bool enable);
```

- Feature guarded by a public symbol `CDC_HOST_REMOTE_WAKE_SUPPORTED` represented by a remote wakeup HAL/LL presence in esp-idf

## Related

- Follow-up for #298 

## Testing

- New target and Linux host tests
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
