### PR TITLE
Add validation for hardware limitation (IEC-448)

### DIFF
--- a/host/usb/src/usb_private.c
+++ b/host/usb/src/usb_private.c
@@ -17,7 +17,6 @@
 #endif
 
 // ----------------------- Configs -------------------------
-
 #ifdef CONFIG_USB_HOST_DWC_DMA_CAP_MEMORY_IN_PSRAM      // In esp32p4, the USB-DWC internal DMA can access external RAM
 #define DATA_BUFFER_CAPS                     (MALLOC_CAP_DMA | MALLOC_CAP_CACHE_ALIGNED | MALLOC_CAP_SPIRAM)
 #else
@@ -26,6 +25,7 @@
 
 urb_t *urb_alloc(size_t data_buffer_size, int num_isoc_packets)
 {
+    HOST_CHECK(data_buffer_size < (127000 - 1), ESP_ERR_INVALID_ARG); // Hardware limitation prevents larger transfers
     urb_t *urb = heap_caps_calloc(1, sizeof(urb_t) + (sizeof(usb_isoc_packet_desc_t) * num_isoc_packets), MALLOC_CAP_DEFAULT);
 
 #if !CONFIG_IDF_TARGET_LINUX


### PR DESCRIPTION
# Checklist

- [ ] Version in idf_component.yml file bumped
- [ ] CHANGELOG.md entry added
- [ ] _Optional:_ README.md updated
- [ ] CI passing

# Change description
_Please describe your change here_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a size check in `urb_alloc` to reject data buffers exceeding the hardware limit (~127 KB).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e136ed145624ed593ce6c65d27dd564f2dd4a249. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->