### PR TITLE
fix(msc_test): fopen Werror=use-after-free

### DIFF
--- a/host/class/msc/usb_host_msc/test_app/main/test_msc.c
+++ b/host/class/msc/usb_host_msc/test_app/main/test_msc.c
@@ -160,7 +160,8 @@ static void write_read_file(const char *file_path)
     fclose(f);
 
     ESP_LOGI(TAG, "Reading file");
-    TEST_ASSERT(fopen(file_path, "r"));
+    f = fopen(file_path, "r");
+    TEST_ASSERT(f);
     fgets(line, sizeof(line), f);
     fclose(f);
     // strip newline


### PR DESCRIPTION
## Description

Fixing build error of msc test app to unblock [CI](https://github.com/espressif/esp-usb/actions/runs/20092892102/job/57644230316?pr=351#step:4:10273)

<details>
<summary> Error error </summary>

```
/__w/esp-usb/esp-usb/host/class/msc/usb_host_msc/test_app/main/test_msc.c: In function 'write_read_file':
/__w/esp-usb/esp-usb/host/class/msc/usb_host_msc/test_app/main/test_msc.c:165:5: error: pointer 'f' may be used after 'fclose' [-Werror=use-after-free]
  165 |     fclose(f);
      |     ^~~~~~~~~
/__w/esp-usb/esp-usb/host/class/msc/usb_host_msc/test_app/main/test_msc.c:160:5: note: call to 'fclose' here
  160 |     fclose(f);
      |     ^~~~~~~~~
/__w/esp-usb/esp-usb/host/class/msc/usb_host_msc/test_app/main/test_msc.c:164:5: error: pointer 'f' may be used after 'fclose' [-Werror=use-after-free]
  164 |     fgets(line, sizeof(line), f);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/esp-usb/esp-usb/host/class/msc/usb_host_msc/test_app/main/test_msc.c:160:5: note: call to 'fclose' here
  160 |     fclose(f);
      |     ^~~~~~~~~
cc1: all warnings being treated as errors
[712/719] Building C object esp-idf/esp_tinyusb/CMakeFiles/__idf_esp_tinyusb.dir/tinyusb_msc.c.obj
ninja: build stopped: subcommand failed.
HINT: The warning(s) '-Werror=use-after-free' may appear after compiler update above [](https://jira.espressif.com:8443/browse/)
```

</details>



## Related

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
