### PR TITLE
release(usb_dte): Release v1.3.0

### DIFF
--- a/host/class/cdc/esp_modem_usb_dte/CHANGELOG.md
+++ b/host/class/cdc/esp_modem_usb_dte/CHANGELOG.md
@@ -4,11 +4,19 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2025-12-19
 
 ### Added
 
 - Added support for esp_modem v2
+
+### Deprecated
+
+- Deprecated esp_modem_usb_term_config->cdc_compliant field. CDC compliance is now auto detected by CDC-ACM USB driver.
+
+### Known issues
+
+- ESP32-P4 cannot receive fragmented AT responses from a modem. Thus, some SimCom modems do not work with this version
 
 ## [1.2.1] - 2024-06-24
 

--- a/host/class/cdc/esp_modem_usb_dte/idf_component.yml
+++ b/host/class/cdc/esp_modem_usb_dte/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.2.1"
+version: "1.3.0"
 description: USB DTE plugin for esp_modem component
 tags:
   - usb
@@ -14,6 +14,6 @@ repository_info:
 
 dependencies:
   usb_host_cdc_acm:
-    version: "2.*"
+    version: "^2.2"
     override_path: "../usb_host_cdc_acm"
   esp_modem: ">=1,<3"

--- a/host/class/cdc/esp_modem_usb_dte/include/esp_modem_usb_config.h
+++ b/host/class/cdc/esp_modem_usb_dte/include/esp_modem_usb_config.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,7 +19,7 @@ struct esp_modem_usb_term_config {
     int secondary_interface_idx; /*!< USB Interface index that will be used for secondary terminal: data. Set to -1 for modems with 1 AT port. */
     uint32_t timeout_ms;         /*!< Time for a USB modem to connect to USB host. 0 means wait forever. */
     int xCoreID;                 /*!< Core affinity of created tasks: CDC-ACM driver task and optional USB Host task */
-    bool cdc_compliant;          /*!< Treat the USB device as CDC-compliant. Read CDC-ACM driver documentation for more details */
+    bool cdc_compliant __attribute__((deprecated("Deprecated: CDC compliance is auto-detected")));
     bool install_usb_host;       /*!< Flag whether USB Host driver should be installed */
 };
 


### PR DESCRIPTION
In this release:
- Add forward compatibility with esp_modem v2 https://github.com/espressif/esp-usb/pull/336
- Start using large TX feature from CDC-ACM driver https://github.com/espressif/esp-usb/pull/341
- Depracating `cdc_compliant` config option, as CDC compliance is now auto detected by the underlying CDC-ACM driver c9c6f597ccbea5e77b75bf616809ca1d090127a6