### PR TITLE
refactor(uac_host): Suspend/Resume public API terminology

### DIFF
--- a/host/class/uac/usb_host_uac/CHANGELOG.md
+++ b/host/class/uac/usb_host_uac/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+
+- Changed API terminology from suspend/resume to pause/unpause as pre-requisite for root port suspend/resume feature
+
 ## [1.3.3] - 2025-11-27
 
 ### Changed

--- a/host/class/uac/usb_host_uac/README.md
+++ b/host/class/uac/usb_host_uac/README.md
@@ -24,9 +24,9 @@ The following steps outline the typical API call pattern of the UAC Class Driver
 06. To enable/disable data streaming with specific audio format use:
     - `uac_host_device_start()`
     - `uac_host_device_stop()`
-07. To suspend/resume data streaming use:
-    - `uac_host_device_suspend()`
-    - `uac_host_device_resume()`
+07. To pause/unpause data streaming use:
+    - `uac_host_device_pause()`
+    - `uac_host_device_unpause()`
 08. To control the volume/mute use:
     - `uac_host_device_set_mute()`
 09. To control the volume use:

--- a/host/class/uac/usb_host_uac/examples/audio_player/main/main.c
+++ b/host/class/uac/usb_host_uac/examples/audio_player/main/main.c
@@ -199,11 +199,11 @@ static void mic_palyback_done_cb(void)
 {
     vTaskDelay(pdMS_TO_TICKS(1000)); // wait for a while before resuming recording
     if (s_mic_dev_handle != NULL) {
-        if (uac_host_device_resume(s_mic_dev_handle) == ESP_OK) {
+        if (uac_host_device_unpause(s_mic_dev_handle) == ESP_OK) {
             s_mic_recording = true;
             s_mic_record_wr = 0;
         } else {
-            ESP_LOGE(TAG, "Failed to resume MIC device");
+            ESP_LOGE(TAG, "Failed to unpause MIC device");
         }
     }
 }
@@ -396,8 +396,8 @@ static void uac_lib_task(void *arg)
                         if (s_mic_record_wr >= s_mic_record_buf_size) {
                             if (s_spk_dev_handle != NULL) {
                                 s_mic_recording = false;
-                                // Suspend microphone streaming before playback
-                                uac_host_device_suspend(s_mic_dev_handle);
+                                // Pause microphone streaming before playback
+                                uac_host_device_pause(s_mic_dev_handle);
                                 // Prepare playback of the recorded PCM
                                 player_config_t player_config = {
                                     .pcm_ptr = s_mic_record_buf,
@@ -405,7 +405,7 @@ static void uac_lib_task(void *arg)
                                     .complete_cb = mic_palyback_done_cb,
                                 };
                                 if (start_pcm_playback(&player_config) != ESP_OK) {
-                                    uac_host_device_resume(s_mic_dev_handle);
+                                    uac_host_device_unpause(s_mic_dev_handle);
                                     s_mic_recording = true;
                                     s_mic_record_wr = 0;
                                 }

--- a/host/class/uac/usb_host_uac/include/usb/uac_host.h
+++ b/host/class/uac/usb_host_uac/include/usb/uac_host.h
@@ -31,10 +31,10 @@ extern "C" {
 /**
  * @brief Flags to control stream work flow
  *
- * FLAG_STREAM_SUSPEND_AFTER_START: do not start stream transfer during start, only claim interface and prepare memory
- * @note User should call uac_host_device_resume to start stream transfer when needed
+ * FLAG_STREAM_PAUSE_AFTER_START: do not start stream transfer during start, only claim interface and prepare memory
+ * @note User should call uac_host_device_unpause to start stream transfer when needed
 */
-#define FLAG_STREAM_SUSPEND_AFTER_START      (1 << 0)
+#define FLAG_STREAM_PAUSE_AFTER_START      (1 << 0)
 
 typedef struct uac_interface *uac_host_device_handle_t;    /*!< Logic Device Handle. Handle to a particular UAC interface */
 
@@ -303,7 +303,7 @@ esp_err_t uac_host_handle_events(TickType_t timeout);
 /**
  * @brief Start a UAC stream with specific stream configuration (channels, bit resolution, sample frequency)
  *
- * @note set flags FLAG_STREAM_SUSPEND_AFTER_START to suspend stream after start
+ * @note set flags FLAG_STREAM_PAUSE_AFTER_START to pause stream after start
  *
  * @param[in] uac_dev_handle  UAC device handle
  * @param[in] stream_config   Pointer to UAC stream configuration structure
@@ -318,7 +318,7 @@ esp_err_t uac_host_handle_events(TickType_t timeout);
 esp_err_t uac_host_device_start(uac_host_device_handle_t uac_dev_handle, const uac_host_stream_config_t *stream_config);
 
 /**
- * @brief Suspend a UAC stream
+ * @brief Pause a UAC stream
  *
  * @param[in] uac_dev_handle  UAC device handle
  * @return esp_err_t
@@ -326,10 +326,10 @@ esp_err_t uac_host_device_start(uac_host_device_handle_t uac_dev_handle, const u
  * - ESP_ERR_INVALID_ARG if the device handle is invalid
  * - ESP_ERR_INVALID_STATE if the device is not in the right state
  */
-esp_err_t uac_host_device_suspend(uac_host_device_handle_t uac_dev_handle);
+esp_err_t uac_host_device_pause(uac_host_device_handle_t uac_dev_handle);
 
 /**
- * @brief Resume a UAC stream with same stream configuration
+ * @brief Unpause a UAC stream with same stream configuration
  *
  * @param[in] uac_dev_handle  UAC device handle
  * @return esp_err_t
@@ -337,7 +337,7 @@ esp_err_t uac_host_device_suspend(uac_host_device_handle_t uac_dev_handle);
  * - ESP_ERR_INVALID_ARG if the device handle is invalid
  * - ESP_ERR_INVALID_STATE if the device is not in the right state
  */
-esp_err_t uac_host_device_resume(uac_host_device_handle_t uac_dev_handle);
+esp_err_t uac_host_device_unpause(uac_host_device_handle_t uac_dev_handle);
 
 /**
  * @brief Stop a UAC stream, stream resources will be released

--- a/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c
+++ b/host/class/uac/usb_host_uac/test_app/main/test_host_uac.c
@@ -602,7 +602,7 @@ TEST_CASE("test uac tx writing", "[uac_host][tx]")
         .channels = spk_alt_params.channels,
         .bit_resolution = spk_alt_params.bit_resolution,
         .sample_freq = spk_alt_params.sample_freq[0],
-        .flags = FLAG_STREAM_SUSPEND_AFTER_START,
+        .flags = FLAG_STREAM_PAUSE_AFTER_START,
     };
     TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_start(uac_device_handle, &stream_config));
 
@@ -669,7 +669,7 @@ TEST_CASE("test uac tx writing", "[uac_host][tx]")
     TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_get_volume(uac_device_handle, &actual_volume));
     volume = actual_volume;
     printf("Volume: %d \n", volume);
-    TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_resume(uac_device_handle));
+    TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_unpause(uac_device_handle));
     TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_write(uac_device_handle, (uint8_t *)tx_buffer, tx_size, 0));
 
     uint8_t test_counter = 0;
@@ -779,7 +779,7 @@ TEST_CASE("test uac tx rx loopback", "[uac_host][tx][rx]")
         .channels = mic_alt_params.channels,
         .bit_resolution = mic_alt_params.bit_resolution,
         .sample_freq = mic_alt_params.sample_freq[0],
-        .flags = FLAG_STREAM_SUSPEND_AFTER_START,
+        .flags = FLAG_STREAM_PAUSE_AFTER_START,
     };
 
     uint8_t actual_volume = 0;
@@ -831,8 +831,8 @@ TEST_CASE("test uac tx rx loopback", "[uac_host][tx][rx]")
     uint32_t test_counter = 0;
     event_queue_t evt_queue = {0};
     while (1) {
-        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_resume(mic_device_handle));
-        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_resume(spk_device_handle));
+        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_unpause(mic_device_handle));
+        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_unpause(spk_device_handle));
         while (1) {
             if (xQueueReceive(s_event_queue, &evt_queue, portMAX_DELAY)) {
                 TEST_ASSERT_EQUAL(UAC_DEVICE_EVENT, evt_queue.event_group);
@@ -885,8 +885,8 @@ restart_rx:
         if (++test_counter >= test_times) {
             goto exit_rx;
         }
-        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_suspend(mic_device_handle));
-        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_suspend(spk_device_handle));
+        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_pause(mic_device_handle));
+        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_pause(spk_device_handle));
         time_counter = 0;
         vTaskDelay(100);
     }
@@ -938,7 +938,7 @@ TEST_CASE("test uac tx rx loopback with disconnect", "[uac_host][tx][rx][hot-plu
         .channels = mic_alt_params.channels,
         .bit_resolution = mic_alt_params.bit_resolution,
         .sample_freq = mic_alt_params.sample_freq[0],
-        .flags = FLAG_STREAM_SUSPEND_AFTER_START,
+        .flags = FLAG_STREAM_PAUSE_AFTER_START,
     };
     TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_start(mic_device_handle, &stream_config));
     TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_set_mute(mic_device_handle, 0));
@@ -979,8 +979,8 @@ TEST_CASE("test uac tx rx loopback with disconnect", "[uac_host][tx][rx][hot-plu
     uint32_t test_counter = 0;
     event_queue_t evt_queue = {0};
     while (1) {
-        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_resume(mic_device_handle));
-        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_resume(spk_device_handle));
+        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_unpause(mic_device_handle));
+        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_unpause(spk_device_handle));
         while (1) {
             if (xQueueReceive(s_event_queue, &evt_queue, portMAX_DELAY)) {
                 TEST_ASSERT_EQUAL(UAC_DEVICE_EVENT, evt_queue.event_group);
@@ -1033,8 +1033,8 @@ restart_rx:
         if (++test_counter >= test_times) {
             goto exit_rx;
         }
-        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_suspend(mic_device_handle));
-        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_suspend(spk_device_handle));
+        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_pause(mic_device_handle));
+        TEST_ASSERT_EQUAL(ESP_OK, uac_host_device_pause(spk_device_handle));
         time_counter = 0;
         vTaskDelay(100);
     }


### PR DESCRIPTION
## Changes

- update (no functional changes) suspend/resume terminology to pause/unpause 

## Why do we need this change

- As a prerequisite for root port suspend/resume support for this driver
- The current driver contains a set of following public API functions and defines/enums

```cpp
esp_err_t uac_host_device_suspend(uac_host_device_handle_t uac_dev_handle);
esp_err_t uac_host_device_resume(uac_host_device_handle_t uac_dev_handle);
#define FLAG_STREAM_SUSPEND_AFTER_START
```

And private API functions

```cpp
static esp_err_t uac_host_interface_suspend(uac_iface_t *iface);
static esp_err_t uac_host_interface_resume(uac_iface_t *iface);
```

- Those functions do not actually suspend or resume the device (or interface) to lower power consumption, but rather suspend and resume audio data stream

#### The API shall be changed in a following way, not to confuse the users with the public API terminology 

- Updated public API
```cpp
esp_err_t uac_host_device_pause(uac_host_device_handle_t uac_dev_handle);
esp_err_t uac_host_device_unpause(uac_host_device_handle_t uac_dev_handle);
#define FLAG_STREAM_PAUSE_AFTER_START
```

- Updated private API

```cpp
static esp_err_t uac_host_interface_pause(uac_iface_t *iface);
static esp_err_t uac_host_interface_unpause(uac_iface_t *iface);
```
---

## Related

- prerequisite for #211 

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes UAC stream control terminology from suspend/resume to pause/unpause.
> 
> - Public API renamed: `uac_host_device_suspend/resume` -> `uac_host_device_pause/unpause`; `FLAG_STREAM_SUSPEND_AFTER_START` -> `FLAG_STREAM_PAUSE_AFTER_START`
> - Internal functions and states renamed (e.g., `uac_host_interface_suspend/resume` -> `..._pause/unpause`, `SUSPENDING` -> `PAUSING`); comments/logs updated
> - Usage updated across examples and tests (e.g., audio_player, loopback tests) to new APIs and flag
> - README and CHANGELOG updated; header docs note `FLAG_STREAM_PAUSE_AFTER_START` behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d498375490d12b602415292800cc2da3eb7b261. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->