### PR TITLE
fix(esp_tinyusb_test): FIx CPU load measurement limit for esp32s2

### DIFF
--- a/device/esp_tinyusb/test_apps/runtime_config/pytest_runtime_config.py
+++ b/device/esp_tinyusb/test_apps/runtime_config/pytest_runtime_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
@@ -23,7 +23,7 @@ def test_usb_device_runtime_config(dut: IdfDut) -> None:
 
 # The threshold values for TinyUSB Task Run time (in cycles) for different targets
 TASK_RUN_TIME_LIMITS = {
-    'esp32s2': 5000,
+    'esp32s2': 7000,
     'esp32s3': 3000,
     'esp32p4': 1800,
 }


### PR DESCRIPTION
## Description

The CPU Load measurement limit for `esp32s2` has risen on `IDF 6.0` from `3600` to `5300` ticks. 

- I could not finish `git bisect` to identity the root cause, but it's pointing to the recent mbedtls update.
- Other targets do not suffer with this issue

## Related

[Failing CI job](https://github.com/espressif/esp-usb/actions/runs/20718456942/job/59480191538?pr=363#step:7:2270) wit this issue.

## Testing

Locally tested on all targets + `git bisect`

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Bumps `esp32s2` TinyUSB task run-time threshold in `pytest_runtime_config.py` from `5000` to `7000` cycles to avoid false failures
> - Updates SPDX copyright year to `2025-2026`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a632cb04fb38171e1d60e862ecfd3622a6fd2b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->