### PR TITLE
ci(docs): Deploy docs only from espressif repository

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,6 +54,7 @@ jobs:
   deploy-docs:
     needs: build-docs
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'espressif' }}
     # Set Deploy environment for master branch, otherwise set Preview environment
     environment: ${{ github.ref_name == 'master' && 'esp-docs deploy' || 'esp-docs preview' }}
     steps:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts documentation deployment to the official organization repository.
> 
> - Add `if: ${{ github.repository_owner == 'espressif' }}` to the `deploy-docs` job in `.github/workflows/docs.yml` to block deploys from forks/other owners
> - Build pipeline and artifact handling remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db9093cde3eb1d1242cb3a2c881a232dab52452c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->