### PR TITLE
fix(host/hid): Fixed race condition in hid_host_device_close()

### DIFF
--- a/host/class/hid/usb_host_hid/CHANGELOG.md
+++ b/host/class/hid/usb_host_hid/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a vulnerability with overwrite freed heap memory during `hid_host_get_report_descriptor()`
+- Fixed race condition in `hid_host_device_close()` that could lead to double-free and list corruption under concurrent close/disconnect
 
 ### Added
 

--- a/host/class/hid/usb_host_hid/host_test/main/test_unit_public_api.cpp
+++ b/host/class/hid/usb_host_hid/host_test/main/test_unit_public_api.cpp
@@ -63,6 +63,7 @@ SCENARIO("HID Host install")
     // HID Host driver config set to config from HID Host example
     GIVEN("Full HID Host config, driver not already installed") {
         int mtx;
+        int open_close_mtx;
 
         // Install error: failed to create semaphore
         SECTION("Install error: unable to create semaphore") {
@@ -81,6 +82,7 @@ SCENARIO("HID Host install")
             // Because of missing Freertos Mocks
             // Create a semaphore, return the semaphore handle (Queue Handle in this scenario), so the semaphore is created successfully
             xQueueGenericCreate_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&mtx));
+            xQueueCreateMutexStatic_ExpectAnyArgsAndReturn(reinterpret_cast<SemaphoreHandle_t>(&open_close_mtx)); // Static calls should always succeed, no need to mock failure
             // Register a client, return ESP_ERR_INVALID_STATE, so the client is not registered successfully
             usb_host_client_register_ExpectAnyArgsAndReturn(ESP_ERR_INVALID_STATE);
 
@@ -96,6 +98,7 @@ SCENARIO("HID Host install")
 
             // Create a semaphore, return the semaphore handle (Queue Handle in this scenario), so the semaphore is created successfully
             xQueueGenericCreate_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&mtx));
+            xQueueCreateMutexStatic_ExpectAnyArgsAndReturn(reinterpret_cast<SemaphoreHandle_t>(&open_close_mtx)); // Static calls should always succeed, no need to mock failure
             // Register a client, return ESP_OK, so the client is registered successfully
             usb_host_client_register_ExpectAnyArgsAndReturn(ESP_OK);
             // Fill the pointer to the client_handle, which is used in goto fail, to deregister the client
@@ -120,6 +123,7 @@ SCENARIO("HID Host install")
         SECTION("Client register successful: hid_host_install successful") {
             // Create semaphore, return semaphore handle (Queue Handle in this scenario), so the semaphore is created successfully
             xQueueGenericCreate_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&mtx));
+            xQueueCreateMutexStatic_ExpectAnyArgsAndReturn(reinterpret_cast<SemaphoreHandle_t>(&open_close_mtx));
             // return ESP_OK, so the client is registered successfully
             usb_host_client_register_ExpectAnyArgsAndReturn(ESP_OK);
 


### PR DESCRIPTION
Fixes security issue that could corrupt internal memory with concurrent closing of the same device


Supersedes #321

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens thread-safety around HID device lifecycle and fixes a race that could corrupt memory.
> 
> - Adds driver-wide `open_close_mutex` (static) and uses it in `hid_host_device_open()`, `hid_host_device_close()`, and `hid_host_uninstall()` with timeouts and proper release on all paths
> - Adjusts close flow to release the mutex before invoking user callbacks and on errors to avoid deadlocks; replaces RETURN macros with GOTO in critical paths for consistent cleanup
> - Updates `CHANGELOG.md` noting the race fix and security impact
> - Updates unit tests to expect static mutex creation (`xQueueCreateMutexStatic`) and successful install/teardown paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd28106e9f72ac2719682c06f94601f9f034390b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->