### PR TITLE
fix(usb_host): Disable multi client usb host test in CI

### DIFF
--- a/host/usb/test/target_test/usb_host/main/test_usb_host_async.c
+++ b/host/usb/test/target_test/usb_host/main/test_usb_host_async.c
@@ -97,8 +97,10 @@ Procedure:
     - Wait for the host library event handler to report a USB_HOST_LIB_EVENT_FLAGS_NO_CLIENTS event
     - Free all devices
     - Uninstall USB Host Library
+
+    TODO: IDF-15119 Failing test in CI
 */
-TEST_CASE("Test USB Host async client (multi client)", "[usb_host][full_speed][high_speed]")
+TEST_CASE("Test USB Host async client (multi client)", "[usb_host][full_speed][high_speed][ignore]")
 {
     // Create task to run the MSC client
     msc_client_test_param_t msc_params = {


### PR DESCRIPTION
## Description

Disabling regularly failing test in CI. Did not manage to reproduce the test locally.

## Related

- Ticket for tracking IDF-15119

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables a flaky test to stabilize CI.
> 
> - Adds `[ignore]` tag to `TEST_CASE("Test USB Host async client (multi client)")` in `test_usb_host_async.c` so it is skipped in CI
> - Adds a TODO comment referencing `IDF-15119` for tracking
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bdf88b3d1420a99257baa3748e19ad022de7fc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->