### PR TITLE
release(hid): Release usb_host_hid 1.1.0

### DIFF
--- a/host/class/hid/usb_host_hid/CHANGELOG.md
+++ b/host/class/hid/usb_host_hid/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-01-09
 
 ### Fixed
 

--- a/host/class/hid/usb_host_hid/idf_component.yml
+++ b/host/class/hid/usb_host_hid/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.4"
+version: "1.1.0"
 description: USB Host HID driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/hid/usb_host_hid
 issues: "https://github.com/espressif/esp-usb/issues"


### PR DESCRIPTION
## usb_host_hid release 1.1.0

- Releases milestone https://github.com/espressif/esp-usb/milestone/20
- Contains #367
-  #182
-  #323
-  #320


