### PR TITLE
fix(ci): add ignore no tests collected error to examples run

### DIFF
--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -219,4 +219,4 @@ jobs:
           name: usb_examples_bin_${{ matrix.idf_ver }}
           path: ${{ env.EXAMPLES_PATH }}
       - name: Run USB Test App on target
-        run: pytest ${{ env.EXAMPLES_PATH }}/${{ matrix.example }} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases="*ncm_example*"
+        run: pytest ${{ env.EXAMPLES_PATH }}/${{ matrix.example }} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases="*ncm_example*" --ignore-no-tests-collected-error


### PR DESCRIPTION
## Description

Adding pytest flag `--ignore-no-tests-collected-error` to idf examples run. Without the flag, the pytest would fail to run.
There was a regression in running pytest after adding conditional CI run.

## Related

- Fixes #368

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
