### PR TITLE
fix(host_test): Wrap main for argc and argv

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/CMakeLists.txt
@@ -4,6 +4,6 @@ idf_component_register(SRC_DIRS .
                         PRIV_INCLUDE_DIRS "../../../private_include"
                         WHOLE_ARCHIVE)
 
-# The following line would be needed to provide the 'main' function if this test used mocked FreeRTOS.
-# As this test uses the real FreeRTOS implementation, we don't need Catch2 to provide 'main'.
-#target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)
+# We do not use main() from esp-idf as it discards argc and argv arguments
+# We wrap main so argc and argv are correctly passed to Catch2
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_main.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_main.cpp
@@ -1,28 +1,50 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
 #include <catch2/catch_session.hpp>
-#include <catch2/catch_test_macros.hpp>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
+struct MainTaskArgs {
+    int argc;
+    const char **argv;
+};
 
-extern "C" void app_main(void)
+static void main_task(void *args)
 {
-    int argc = 1;
-    const char *argv[2] = {
-        "target_test_main",
-        NULL
-    };
+    MainTaskArgs *task_args = (MainTaskArgs *)args;
+    auto result = Catch::Session().run(task_args->argc, task_args->argv);
 
-    auto result = Catch::Session().run(argc, argv);
-    if (result != 0) {
-        printf("Test failed with result %d\n", result);
-    } else {
-        printf("Test passed.\n");
-    }
     fflush(stdout);
+    delete task_args;
     exit(result);
+    vTaskDelete(NULL);
+}
+
+extern "C" int __wrap_main(int argc, const char **argv)
+{
+    // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
+    // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.
+    // Only difference from esp-idf implementation is passing of argc and argv to the main task.
+
+    // This makes sure that stdio is always synchronized so that idf.py monitor
+    // and other tools read text output on time.
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    usleep(1000);
+    MainTaskArgs *task_args = new MainTaskArgs{argc, argv};
+    BaseType_t res = xTaskCreatePinnedToCore(&main_task, "main",
+                                             ESP_TASK_MAIN_STACK, task_args,
+                                             ESP_TASK_MAIN_PRIO, NULL, ESP_TASK_MAIN_CORE);
+    assert(res == pdTRUE);
+    (void)res;
+
+    vTaskStartScheduler();
+
+    // This line should never be reached
+    assert(false);
 }

--- a/host/class/uac/usb_host_uac/host_test/main/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/host_test/main/CMakeLists.txt
@@ -3,6 +3,6 @@ idf_component_register(SRC_DIRS .
                         INCLUDE_DIRS .
                         WHOLE_ARCHIVE)
 
-# The following line would be needed to provide the 'main' function if this test used mocked FreeRTOS.
-# As this test uses the real FreeRTOS implementation, we don't need Catch2 to provide 'main'.
-#target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)
+# We do not use main() from esp-idf as it discards argc and argv arguments
+# We wrap main so argc and argv are correctly passed to Catch2
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/class/uac/usb_host_uac/host_test/main/test_main.cpp
+++ b/host/class/uac/usb_host_uac/host_test/main/test_main.cpp
@@ -1,28 +1,50 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
 #include <catch2/catch_session.hpp>
-#include <catch2/catch_test_macros.hpp>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
+struct MainTaskArgs {
+    int argc;
+    const char **argv;
+};
 
-extern "C" void app_main(void)
+static void main_task(void *args)
 {
-    int argc = 1;
-    const char *argv[2] = {
-        "target_test_main",
-        NULL
-    };
+    MainTaskArgs *task_args = (MainTaskArgs *)args;
+    auto result = Catch::Session().run(task_args->argc, task_args->argv);
 
-    auto result = Catch::Session().run(argc, argv);
-    if (result != 0) {
-        printf("Test failed with result %d\n", result);
-    } else {
-        printf("Test passed.\n");
-    }
     fflush(stdout);
+    delete task_args;
     exit(result);
+    vTaskDelete(NULL);
+}
+
+extern "C" int __wrap_main(int argc, const char **argv)
+{
+    // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
+    // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.
+    // Only difference from esp-idf implementation is passing of argc and argv to the main task.
+
+    // This makes sure that stdio is always synchronized so that idf.py monitor
+    // and other tools read text output on time.
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    usleep(1000);
+    MainTaskArgs *task_args = new MainTaskArgs{argc, argv};
+    BaseType_t res = xTaskCreatePinnedToCore(&main_task, "main",
+                                             ESP_TASK_MAIN_STACK, task_args,
+                                             ESP_TASK_MAIN_PRIO, NULL, ESP_TASK_MAIN_CORE);
+    assert(res == pdTRUE);
+    (void)res;
+
+    vTaskStartScheduler();
+
+    // This line should never be reached
+    assert(false);
 }

--- a/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
@@ -4,6 +4,6 @@ idf_component_register(SRC_DIRS . parsing streaming opening
                         PRIV_INCLUDE_DIRS "../../private_include"
                         WHOLE_ARCHIVE)
 
-# The following line would be needed to provide the 'main' function if this test used mocked FreeRTOS.
-# As this test uses the real FreeRTOS implementation, we don't need Catch2 to provide 'main'.
-# target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)
+# We do not use main() from esp-idf as it discards argc and argv arguments
+# We wrap main so argc and argv are correctly passed to Catch2
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/class/uvc/usb_host_uvc/host_test/main/test_main.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/test_main.cpp
@@ -1,28 +1,50 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
 #include <catch2/catch_session.hpp>
-#include <catch2/catch_test_macros.hpp>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
+struct MainTaskArgs {
+    int argc;
+    const char **argv;
+};
 
-extern "C" void app_main(void)
+static void main_task(void *args)
 {
-    int argc = 1;
-    const char *argv[2] = {
-        "target_test_main",
-        NULL
-    };
+    MainTaskArgs *task_args = (MainTaskArgs *)args;
+    auto result = Catch::Session().run(task_args->argc, task_args->argv);
 
-    auto result = Catch::Session().run(argc, argv);
-    if (result != 0) {
-        printf("Test failed with result %d\n", result);
-    } else {
-        printf("Test passed.\n");
-    }
     fflush(stdout);
+    delete task_args;
     exit(result);
+    vTaskDelete(NULL);
+}
+
+extern "C" int __wrap_main(int argc, const char **argv)
+{
+    // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
+    // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.
+    // Only difference from esp-idf implementation is passing of argc and argv to the main task.
+
+    // This makes sure that stdio is always synchronized so that idf.py monitor
+    // and other tools read text output on time.
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    usleep(1000);
+    MainTaskArgs *task_args = new MainTaskArgs{argc, argv};
+    BaseType_t res = xTaskCreatePinnedToCore(&main_task, "main",
+                                             ESP_TASK_MAIN_STACK, task_args,
+                                             ESP_TASK_MAIN_PRIO, NULL, ESP_TASK_MAIN_CORE);
+    assert(res == pdTRUE);
+    (void)res;
+
+    vTaskStartScheduler();
+
+    // This line should never be reached
+    assert(false);
 }

--- a/host/usb/test/host_test/usb_host_layer_test/main/CMakeLists.txt
+++ b/host/usb/test/host_test/usb_host_layer_test/main/CMakeLists.txt
@@ -7,6 +7,6 @@ idf_component_register(SRCS  ${srcs}
                         REQUIRES cmock usb
                         WHOLE_ARCHIVE)
 
-# The following line would be needed to provide the 'main' function if this test used mocked FreeRTOS.
-# As this test uses the real FreeRTOS implementation, we don't need Catch2 to provide 'main'.
-#target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)
+# We do not use main() from esp-idf as it discards argc and argv arguments
+# We wrap main so argc and argv are correctly passed to Catch2
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/usb/test/host_test/usb_host_layer_test/main/test_main.cpp
+++ b/host/usb/test/host_test/usb_host_layer_test/main/test_main.cpp
@@ -1,27 +1,50 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
 #include <catch2/catch_session.hpp>
-#include <catch2/catch_test_macros.hpp>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
-extern "C" void app_main(void)
+struct MainTaskArgs {
+    int argc;
+    const char **argv;
+};
+
+static void main_task(void *args)
 {
-    int argc = 1;
-    const char *argv[2] = {
-        "target_test_main",
-        NULL
-    };
+    MainTaskArgs *task_args = (MainTaskArgs *)args;
+    auto result = Catch::Session().run(task_args->argc, task_args->argv);
 
-    auto result = Catch::Session().run(argc, argv);
-    if (result != 0) {
-        printf("Test failed with result %d\n", result);
-    } else {
-        printf("Test passed.\n");
-    }
     fflush(stdout);
+    delete task_args;
     exit(result);
+    vTaskDelete(NULL);
+}
+
+extern "C" int __wrap_main(int argc, const char **argv)
+{
+    // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
+    // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.
+    // Only difference from esp-idf implementation is passing of argc and argv to the main task.
+
+    // This makes sure that stdio is always synchronized so that idf.py monitor
+    // and other tools read text output on time.
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    usleep(1000);
+    MainTaskArgs *task_args = new MainTaskArgs{argc, argv};
+    BaseType_t res = xTaskCreatePinnedToCore(&main_task, "main",
+                                             ESP_TASK_MAIN_STACK, task_args,
+                                             ESP_TASK_MAIN_PRIO, NULL, ESP_TASK_MAIN_CORE);
+    assert(res == pdTRUE);
+    (void)res;
+
+    vTaskStartScheduler();
+
+    // This line should never be reached
+    assert(false);
 }

--- a/host/usb/test/host_test/usbh_layer_test/main/CMakeLists.txt
+++ b/host/usb/test/host_test/usbh_layer_test/main/CMakeLists.txt
@@ -7,6 +7,6 @@ idf_component_register(SRCS  ${srcs}
                         REQUIRES cmock usb
                         WHOLE_ARCHIVE)
 
-# The following line would be needed to provide the 'main' function if this test used mocked FreeRTOS.
-# As this test uses the real FreeRTOS implementation, we don't need Catch2 to provide 'main'.
-#target_link_libraries(${COMPONENT_LIB} PRIVATE Catch2WithMain)
+# We do not use main() from esp-idf as it discards argc and argv arguments
+# We wrap main so argc and argv are correctly passed to Catch2
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/usb/test/host_test/usbh_layer_test/main/test_main.cpp
+++ b/host/usb/test/host_test/usbh_layer_test/main/test_main.cpp
@@ -1,27 +1,50 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
 #include <catch2/catch_session.hpp>
-#include <catch2/catch_test_macros.hpp>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
-extern "C" void app_main(void)
+struct MainTaskArgs {
+    int argc;
+    const char **argv;
+};
+
+static void main_task(void *args)
 {
-    int argc = 1;
-    const char *argv[2] = {
-        "target_test_main",
-        NULL
-    };
+    MainTaskArgs *task_args = (MainTaskArgs *)args;
+    auto result = Catch::Session().run(task_args->argc, task_args->argv);
 
-    auto result = Catch::Session().run(argc, argv);
-    if (result != 0) {
-        printf("Test failed with result %d\n", result);
-    } else {
-        printf("Test passed.\n");
-    }
     fflush(stdout);
+    delete task_args;
     exit(result);
+    vTaskDelete(NULL);
+}
+
+extern "C" int __wrap_main(int argc, const char **argv)
+{
+    // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
+    // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.
+    // Only difference from esp-idf implementation is passing of argc and argv to the main task.
+
+    // This makes sure that stdio is always synchronized so that idf.py monitor
+    // and other tools read text output on time.
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    usleep(1000);
+    MainTaskArgs *task_args = new MainTaskArgs{argc, argv};
+    BaseType_t res = xTaskCreatePinnedToCore(&main_task, "main",
+                                             ESP_TASK_MAIN_STACK, task_args,
+                                             ESP_TASK_MAIN_PRIO, NULL, ESP_TASK_MAIN_CORE);
+    assert(res == pdTRUE);
+    (void)res;
+
+    vTaskStartScheduler();
+
+    // This line should never be reached
+    assert(false);
 }


### PR DESCRIPTION
All host tests are updated so
1. `main()` is wrapped, so the esp-idf/linux implementation is not called
2. in `__wrap_main()` we do the same as in the original implementation, but we also pass argc and argv arguments to `main_task` and then to Catch 2

This has great advantages in debugging, because we can now pass CLI arguments to the Catch2 application. Eg.

``` sh
$ ./build/host_test_usb_uvc.elf --help

Catch2 v3.7.0
usage:
  host_test_usb_uvc.elf [<test name|pattern|tags> ... ] options

where options are:
  -?, -h, --help                            display usage information
  -s, --success                             include successful tests in
                                            output
  -b, --break                               break into debugger on failure
...
```
or
``` sh
$ ./build/host_test_usb_uvc.elf --list-tags
All available tags:
   1  [anker]
   1  [bulk]
   1  [c200]
   1  [c270]
   1  [c980]
   1  [canyon]
...
```
or
``` sh
$ ./build/host_test_usb_uvc.elf [logitech]
Filters: [logitech]
Randomness seeded to: 3864178348
===============================================================================
All tests passed (2928 assertions in 3 test cases)
```