### PR TITLE
fix(usb_host_ftdi_vcp): avoid bitfield truncation in ftdi_rx

### DIFF
--- a/host/class/cdc/usb_host_ftdi_vcp/CHANGELOG.md
+++ b/host/class/cdc/usb_host_ftdi_vcp/CHANGELOG.md
@@ -6,3 +6,6 @@
 
 ## 2.0.0
 - Update to [CDC-ACM driver](https://components.espressif.com/components/espressif/usb_host_cdc_acm) to v2
+
+## Unreleased
+- Fix FTDI VCP SerialState parsing (correct 1-bit flags, avoid short-packet reads)

--- a/host/class/cdc/usb_host_ftdi_vcp/usb_host_ftdi_vcp.cpp
+++ b/host/class/cdc/usb_host_ftdi_vcp/usb_host_ftdi_vcp.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -91,16 +91,16 @@ bool FT23x::ftdi_rx(const uint8_t *data, size_t data_len, void *user_arg)
     FT23x *this_ftdi = (FT23x *)user_arg;
 
     // Dispatch serial state if it has changed
-    if (this_ftdi->user_event_cb) {
+    if (this_ftdi->user_event_cb && data_len >= 2) {
         cdc_acm_uart_state_t new_state;
         new_state.val = 0;
-        new_state.bRxCarrier =  data[0] & 0x80; // DCD
-        new_state.bTxCarrier =  data[0] & 0x20; // DSR
-        new_state.bBreak =      data[1] & 0x10;
-        new_state.bRingSignal = data[0] & 0x40;
-        new_state.bFraming =    data[1] & 0x08;
-        new_state.bParity =     data[1] & 0x04;
-        new_state.bOverRun =    data[1] & 0x02;
+        new_state.bRxCarrier =  (data[0] & 0x80u) != 0; // DCD
+        new_state.bTxCarrier =  (data[0] & 0x20u) != 0; // DSR
+        new_state.bBreak =      (data[1] & 0x10u) != 0;
+        new_state.bRingSignal = (data[0] & 0x40u) != 0;
+        new_state.bFraming =    (data[1] & 0x08u) != 0;
+        new_state.bParity =     (data[1] & 0x04u) != 0;
+        new_state.bOverRun =    (data[1] & 0x02u) != 0;
 
         if (this_ftdi->uart_state != new_state.val) {
             cdc_acm_host_dev_event_data_t serial_event;


### PR DESCRIPTION
## Summary

Fix FTDI VCP SerialState flag parsing in `FT23x::ftdi_rx()` so 1-bit fields are set correctly and serial-state change events are dispatched reliably.

## Motivation / Context

`cdc_acm_uart_state_t` uses 1-bit bitfields. The existing code assigned masked values directly (e.g. `data[0] & 0x80`), which yields `0x80`/`0x00`. When written into a 1-bit field, the compiler truncates the value to the LSB, causing set bits like `0x80` to become `0`. This breaks carrier/error/break/ring detection and can prevent `CDC_ACM_HOST_SERIAL_STATE` events from firing.

Also, the previous code read `data[0]`/`data[1]` without checking that at least two status bytes are present.

## What changed

- Parse SerialState bits as booleans using `((data[i] & MASK) != 0)` before assigning to 1-bit fields.
- Guard SerialState parsing with `data_len >= 2` to avoid out-of-bounds reads.

## Expected impact

- Serial state changes are reported correctly (no lost bits due to truncation).
- No functional changes to RX payload handling; only the 2-byte FTDI status header decoding and safety guard.

## Related

Closes https://github.com/espressif/esp-usb/issues/361


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures reliable FTDI serial-state reporting and safer RX handling.
> 
> - Parse 1-bit `cdc_acm_uart_state_t` flags in `FT23x::ftdi_rx()` using boolean checks (`(data[i] & MASK) != 0`) to prevent bitfield truncation
> - Guard SerialState parsing with `data_len >= 2` to avoid short-packet reads; dispatches event only on state change
> - Update `CHANGELOG.md` with an Unreleased note documenting the fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56080cb421eb7497e2e9e30e1bd245bd4bbebba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->