### PR TITLE
refactor(host/hcd): Make HCD driver stateless

### DIFF
--- a/host/usb/README.md
+++ b/host/usb/README.md
@@ -2,7 +2,7 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb/badge.svg)](https://components.espressif.com/components/espressif/usb) ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg) ![changelog](https://img.shields.io/badge/Keep_a_Changelog-blue?logo=keepachangelog&logoColor=E05735)
 
-This component contains an implementation of a [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
+This component contains an implementation of a [USB Host Library](https://docs.espressif.com/projects/esp-usb/en/latest/esp32p4/usb_host.html).
 
 In a typical USB application, the USB Host Library works underneath the USB Host Class drivers:
 

--- a/host/usb/maintainers.md
+++ b/host/usb/maintainers.md
@@ -79,7 +79,7 @@ The HCD (Host Controller Driver) abstracts the DWC_OTG as N number of ports and 
 The HCD currently has the following limitations:
 
 - HCD **does not "present the root hub and its behavior according to the hub class definition"**. We currently don't have a hub driver yet, so the port commands in the driver do not fully represent an interface of a USB hub as described in 10.4 of the USB2.0 spec.
-- No more than 8 pipes can be allocated at any one time due to underlying Host Controllers 8 channel limit. In the future, we could make particular pipes share a single Host Controller channel.
+- No more than 8 (or 16 on ESP32-P4) pipes can be allocated at any one time due to underlying Host Controllers 8 channel limit. In the future, we could make particular pipes share a single Host Controller channel.
 
 ## HCD Port
 
@@ -137,8 +137,7 @@ The client of the HCD can also forego callbacks entirely and simply poll for por
 
 The HCD API is thread safe however the following limitations should be noted:
 
-- It is the client's responsibility to ensure that `hcd_install()` is called before any other HCD function is called
-- Likewise, it is the client's responsibility to ensure that events and pipes are cleared before calling `hcd_port_deinit()`.
+- It is the client's responsibility to ensure that events and pipes are cleared before calling `hcd_port_deinit()`.
 - `hcd_port_command()` is thread safe, but only one port command can be executed at any one time. Therefore HCD internally used a mutex to protect against concurrent commands.
 - If multiple threads attempt to execute a command on the sample one, all but one of those threads will return with an invalid state error.
 - Blocking HCD functions should not be called from critical sections and interrupts (e.g., `hcd_port_command()` and `hcd_pipe_command()`).

--- a/host/usb/private_include/hcd.h
+++ b/host/usb/private_include/hcd.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -168,15 +168,6 @@ typedef struct {
     uint32_t ptx_fifo_lines;  /**< Number of periodic TX FIFO lines */
     uint32_t rx_fifo_lines;   /**< Number of RX FIFO lines */
 } hcd_fifo_settings_t;
-/**
- * @brief HCD configuration structure
- */
-typedef struct {
-    int intr_flags;                         /**< Interrupt flags for HCD interrupt */
-    const hcd_fifo_settings_t *fifo_config; /**< Optional pointer to custom FIFO config.
-                                                 If NULL, default configuration is used. */
-    unsigned peripheral_map;                /**< Bit map of USB-OTG peripherals that belong to HCD. Set to zero to use default */
-} hcd_config_t;
 
 /**
  * @brief Port configuration structure
@@ -185,7 +176,8 @@ typedef struct {
     hcd_port_callback_t callback;           /**< HCD port event callback */
     void *callback_arg;                     /**< User argument for HCD port callback */
     void *context;                          /**< Context variable used to associate the port with upper layer object */
-    unsigned peripheral_idx;                /**< Index of USB peripheral this port belongs to. Index numbers are defined in USB_DWC_LL_GET_HW */
+    const hcd_fifo_settings_t *fifo_config; /**< Optional pointer to custom FIFO config. If NULL, default configuration is used. */
+    int intr_flags;                         /**< Interrupt flags for HCD interrupt */
 } hcd_port_config_t;
 
 /**
@@ -201,42 +193,6 @@ typedef struct {
     usb_speed_t dev_speed;                  /**< Speed of the device */
     uint8_t dev_addr;                       /**< Device address of the pipe */
 } hcd_pipe_config_t;
-
-// --------------------------------------------- Host Controller Driver ------------------------------------------------
-
-/**
- * @brief Installs the Host Controller Driver
- *
- * - Allocates memory and interrupt resources for the HCD and underlying ports
- *
- * @note This function must be called before any other HCD function is called
- * @note Before calling this function, the Host Controller must already be un-clock gated and reset. The USB PHY
- *       (internal or external, and associated GPIOs) must already be configured.
- *
- * @param[in] config HCD configuration
- *
- * @return
- *    - ESP_OK: HCD successfully installed
- *    - ESP_ERR_NO_MEM: Insufficient memory
- *    - ESP_ERR_INVALID_STATE: HCD is already installed
- *    - ESP_ERR_INVALID_ARG: Arguments are invalid
- */
-esp_err_t hcd_install(const hcd_config_t *config);
-
-/**
- * @brief Uninstalls the HCD
- *
- * Before uninstalling the HCD, the following conditions should be met:
- * - All ports must be uninitialized, all pipes freed
- *
- * @note This function will simply free the resources used by the HCD. The underlying Host Controller and USB PHY will
- *       not be disabled.
- *
- * @return
- *    - ESP_OK: HCD successfully uninstalled
- *    - ESP_ERR_INVALID_STATE: HCD is not in the right condition to be uninstalled
- */
-esp_err_t hcd_uninstall(void);
 
 // ---------------------------------------------------- HCD Port -------------------------------------------------------
 

--- a/host/usb/private_include/hub.h
+++ b/host/usb/private_include/hub.h
@@ -1,17 +1,16 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
-#include <stdlib.h>
 #include <stdint.h>
 #include "sdkconfig.h"
 #include "esp_err.h"
 #include "usb_private.h"
-#include "usbh.h"
+#include "hcd.h"
 
 #if CONFIG_USB_HOST_HUBS_SUPPORTED
 #define ENABLE_USB_HUBS                     1
@@ -65,6 +64,8 @@ typedef struct {
     void *proc_req_cb_arg;                          /**< Processing request callback argument */
     hub_event_cb_t event_cb;                        /**< Hub event callback */
     void *event_cb_arg;                             /**< Hub event callback argument */
+    int intr_flags;                                 /**< Interrupt flags for HCD interrupt */
+    const hcd_fifo_settings_t *fifo_config;         /**< Optional pointer to custom FIFO config. If NULL, default configuration is used. */
 } hub_config_t;
 
 // ---------------------------------------------- Hub Driver Functions -------------------------------------------------

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -16,6 +16,7 @@
 #include "usb_private.h"
 #include "hcd.h"
 #include "hub.h"
+#include "usbh.h"
 
 #if ENABLE_USB_HUBS
 #include "ext_hub.h"
@@ -658,10 +659,12 @@ esp_err_t hub_install(hub_config_t *hub_config, void **client_ret)
 #endif // ENABLE_USB_HUBS
 
     // Install HCD port
-    hcd_port_config_t port_config = {
+    const hcd_port_config_t port_config = {
         .callback = root_port_callback,
         .callback_arg = NULL,
         .context = NULL,
+        .intr_flags = hub_config->intr_flags,
+        .fifo_config = hub_config->fifo_config,
     };
     hcd_port_handle_t root_port_hdl;
 

--- a/host/usb/test/host_test/usb_host_layer_test/main/usb_host_install_unit_test.cpp
+++ b/host/usb/test/host_test/usb_host_layer_test/main/usb_host_install_unit_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -69,37 +69,6 @@ SCENARIO("USB Host install")
             REQUIRE(ESP_ERR_INVALID_STATE == usb_host_install(&usb_host_config));
         }
 
-        // Try to install the USB Host driver, with HCD Install error, use internal PHY
-        SECTION("Fail to install USB Host - HCD Install error (internal PHY)") {
-
-            // Make the PHY install to pass
-            usb_phy_handle_t phy_handle;
-            usb_new_phy_ExpectAnyArgsAndReturn(ESP_OK);
-            usb_new_phy_ReturnThruPtr_handle_ret(&phy_handle);
-
-            // make the HCD port install to fail
-            hcd_install_ExpectAnyArgsAndReturn(ESP_ERR_INVALID_STATE);
-
-            // goto hcd_err: We must uninstall the PHY
-            usb_del_phy_ExpectAndReturn(phy_handle, ESP_OK);
-
-            // Call the DUT function, expect ESP_ERR_INVALID_STATE
-            REQUIRE(ESP_ERR_INVALID_STATE == usb_host_install(&usb_host_config));
-        }
-
-        // Try to install the USB Host driver, with HCD Install error, use external PHY
-        SECTION("Fail to install USB Host - HCD Install error (external PHY)") {
-
-            // Skip the PHY Setup (external phy)
-            usb_host_config.skip_phy_setup = true;
-
-            // make the HCD port install to fail
-            hcd_install_ExpectAnyArgsAndReturn(ESP_ERR_INVALID_STATE);
-
-            // Call the DUT function, expect ESP_ERR_INVALID_STATE
-            REQUIRE(ESP_ERR_INVALID_STATE == usb_host_install(&usb_host_config));
-        }
-
         // Try to install the USB Host driver, with USBH Install error, use internal PHY
         SECTION("Fail to install USB Host - USBH install error") {
 
@@ -108,14 +77,10 @@ SCENARIO("USB Host install")
             usb_new_phy_ExpectAnyArgsAndReturn(ESP_OK);
             usb_new_phy_ReturnThruPtr_handle_ret(&phy_handle);
 
-            // make the HCD port install to pass
-            hcd_install_ExpectAnyArgsAndReturn(ESP_OK);
-
             // Make the USBH install to fail
             usbh_install_ExpectAnyArgsAndReturn(ESP_ERR_INVALID_STATE);
 
-            // goto usbh_err: We must uninstall HCD port and PHY
-            hcd_uninstall_ExpectAndReturn(ESP_OK);
+            // goto usbh_err: We must uninstall PHY
             usb_del_phy_ExpectAndReturn(phy_handle, ESP_OK);
 
             // Call the DUT function, expect ESP_ERR_INVALID_STATE
@@ -130,18 +95,14 @@ SCENARIO("USB Host install")
             usb_new_phy_ExpectAnyArgsAndReturn(ESP_OK);
             usb_new_phy_ReturnThruPtr_handle_ret(&phy_handle);
 
-            // make the HCD port install to pass
-            hcd_install_ExpectAnyArgsAndReturn(ESP_OK);
-
             // Make the USBH install to pass
             usbh_install_ExpectAnyArgsAndReturn(ESP_OK);
 
             // Make the ENUM Driver to fail
             enum_install_ExpectAnyArgsAndReturn(ESP_ERR_INVALID_STATE);
 
-            // goto enum_err: We must uninstall USBH, HCD port and PHY
+            // goto enum_err: We must uninstall USBHand PHY
             usbh_uninstall_ExpectAndReturn(ESP_OK);
-            hcd_uninstall_ExpectAndReturn(ESP_OK);
             usb_del_phy_ExpectAndReturn(phy_handle, ESP_OK);
 
             // Call the DUT function, expect ESP_ERR_INVALID_STATE
@@ -156,9 +117,6 @@ SCENARIO("USB Host install")
             usb_new_phy_ExpectAnyArgsAndReturn(ESP_OK);
             usb_new_phy_ReturnThruPtr_handle_ret(&phy_handle);
 
-            // make the HCD port install to pass
-            hcd_install_ExpectAnyArgsAndReturn(ESP_OK);
-
             // Make the USBH install to pass
             usbh_install_ExpectAnyArgsAndReturn(ESP_OK);
 
@@ -168,10 +126,9 @@ SCENARIO("USB Host install")
             // Make the HUB Driver to fail
             hub_install_ExpectAnyArgsAndReturn(ESP_ERR_INVALID_STATE);
 
-            // goto hub_err: We must uninstall Enum driver, USBH, HCD port and PHY
+            // goto hub_err: We must uninstall Enum driver, USBH and PHY
             enum_uninstall_ExpectAndReturn(ESP_OK);
             usbh_uninstall_ExpectAndReturn(ESP_OK);
-            hcd_uninstall_ExpectAndReturn(ESP_OK);
             usb_del_phy_ExpectAndReturn(phy_handle, ESP_OK);
 
             // Call the DUT function, expect ESP_ERR_INVALID_STATE
@@ -185,9 +142,6 @@ SCENARIO("USB Host install")
             usb_phy_handle_t phy_handle;
             usb_new_phy_ExpectAnyArgsAndReturn(ESP_OK);
             usb_new_phy_ReturnThruPtr_handle_ret(&phy_handle);
-
-            // make the HCD port install to pass
-            hcd_install_ExpectAnyArgsAndReturn(ESP_OK);
 
             // Make the USBH install to pass
             usbh_install_ExpectAnyArgsAndReturn(ESP_OK);
@@ -234,7 +188,6 @@ SCENARIO("USB Host post-uninstall")
             hub_uninstall_ExpectAndReturn(ESP_OK);
             enum_uninstall_ExpectAndReturn(ESP_OK);
             usbh_uninstall_ExpectAndReturn(ESP_OK);
-            hcd_uninstall_ExpectAndReturn(ESP_OK);
 
             // Make the usb_del_phy() to pass
             usb_del_phy_ExpectAnyArgsAndReturn(ESP_OK);


### PR DESCRIPTION
Removed `hcd_install` and `hcd_uninstall` functions. Now ports are directly initialized without the need of installing HCD driver.

Now each HCD port represents one USB-DWC peripheral. This allows to have multiple USB-DWC peripherals in the system without any confusion. This is a preparation step for HUB redesign that must process multiple root ports.


## Testing

All tests and examples run locally

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes HCD stateless and initialized per root port; configuration is now provided at port/hub granularity and Hub owns port lifecycle.
> 
> - Remove `hcd_install()`/`hcd_uninstall()` and `hcd_config_t`; add `intr_flags` and optional `fifo_config` to `hcd_port_config_t` and `hub_config_t`
> - Rework `hcd_dwc.c`: allocate/free resources in `hcd_port_init()`/`hcd_port_deinit()`, track per-port init with `s_port_inited[]`, move checks from `initialized` flag, and convert/apply FIFO config on reset
> - Update `usb_host.c`: no longer installs/uninstalls HCD; Hub installs and initializes the root port; passes custom FIFO settings via Hub
> - Adjust Hub driver to create the HCD port using new config; include `usbh.h` in `hub.c`
> - Update tests to drop HCD install/uninstall expectations and to init/deinit ports directly; simplify target tests accordingly
> - Docs: update README link; maintainer notes reflect per-port model, ESP32-P4 pipe limit note, and thread-safety cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcf4fe99e0abed0fc967c7c9a9b6d224edf27419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->