### PR TITLE
feat(usb_host): Fix abort on failed suspend/resume

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/test_app/pytest_usb_host_cdc.py
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/pytest_usb_host_cdc.py
@@ -17,10 +17,19 @@ def test_usb_host_cdc(dut: Tuple[IdfDut, IdfDut]) -> None:
     device = dut[0]
     host = dut[1]
 
-    # 1 Prepare USB device for CDC test
-    device.expect_exact('Press ENTER to see the list of tests.')
-    device.write('[cdc_acm_device]')
-    device.expect_exact('USB initialization DONE')
+    tests = [
+        # Device test mode    Host test case group
+        ("dual_iface",        "cdc_acm"),
+        ("suspend_dconn",     "host_suspend_dconn"),
+        ("resume_dconn",      "host_resume_dconn"),
+    ]
 
-    ## 2 Run CDC test
-    host.run_all_single_board_cases(group='cdc_acm')
+    for dev_test_mode, host_test_case_group in tests:
+        # Prepare USB Device for test
+        device.expect_exact("Press ENTER to see the list of tests.")
+        device.write(f"[cdc_acm_mock_dev][{dev_test_mode}]")
+        device.expect_exact("USB initialization DONE")
+
+        # Run tests USB Host tests
+        host.run_all_single_board_cases(group=host_test_case_group)
+        device.serial.hard_reset()

--- a/host/usb/src/hcd_dwc.c
+++ b/host/usb/src/hcd_dwc.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1721,6 +1721,9 @@ esp_err_t hcd_port_recover(hcd_port_handle_t port_hdl)
                         && port->flags.val == 0 && port->task_waiting_port_notif == NULL,
                         ESP_ERR_INVALID_STATE);
 
+    // In case, we are recovering from a state which has gated internal clock, ungate it to be able to reconnect a device
+    // Soft reset does not clear the GateHclk bit
+    _internal_clk_gate(port, false);
     // We are about to do a soft reset on the peripheral. Disable the peripheral throughout
     esp_intr_disable(port->isr_hdl);
     usb_dwc_hal_core_soft_reset(port->hal);

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -458,6 +458,7 @@ reset_err:
 #ifdef REMOTE_WAKE_HAL_SUPPORTED
     case HCD_PORT_EVENT_REMOTE_WAKEUP:
         // Mark root port as ready to be resumed
+        // We allow this to fail in case a disconnect/port error happens while remote wakeup.
         hub_root_mark_resume();
         break;
 #endif // REMOTE_WAKE_HAL_SUPPORTED
@@ -511,8 +512,22 @@ static void root_port_req(hcd_port_handle_t root_port_hdl)
             return;
         }
 
-        ESP_ERROR_CHECK(hcd_port_command(p_hub_driver_obj->constant.root_port_hdl, HCD_PORT_CMD_SUSPEND));
+        const esp_err_t port_cmd_err = hcd_port_command(p_hub_driver_obj->constant.root_port_hdl, HCD_PORT_CMD_SUSPEND);
+        switch (port_cmd_err) {
+        case ESP_OK:
+            // Root port suspended correctly
+            break;
+        case ESP_ERR_INVALID_RESPONSE:
+            // Root port's state machine changed it's state during suspend command execution (port disconnect)
+            // The root port is already in recovery state, which was set by dconn event interrupt, no further action needed
+            return;
+        default:
+            // Fatal error occurred: Do ESP_ERROR_CHECK for backtrace
+            ESP_ERROR_CHECK(port_cmd_err);
+            return;
+        }
 
+        // Suspend command executed successfully, finish the suspend procedure
         HUB_DRIVER_ENTER_CRITICAL();
         p_hub_driver_obj->dynamic.root_port_state = ROOT_PORT_STATE_SUSPENDED;
         HUB_DRIVER_EXIT_CRITICAL();
@@ -534,8 +549,22 @@ static void root_port_req(hcd_port_handle_t root_port_hdl)
             return;
         }
 
-        ESP_ERROR_CHECK(hcd_port_command(p_hub_driver_obj->constant.root_port_hdl, HCD_PORT_CMD_RESUME));
+        const esp_err_t port_cmd_err = hcd_port_command(p_hub_driver_obj->constant.root_port_hdl, HCD_PORT_CMD_RESUME);
+        switch (port_cmd_err) {
+        case ESP_OK:
+            // Root port resumed correctly
+            break;
+        case ESP_ERR_INVALID_RESPONSE:
+            // Root port's state machine changed it's state during suspend command execution (port disconnect)
+            // The root port is already in recovery state, which was set by dconn event interrupt, no further action needed
+            return;
+        default:
+            // Fatal error occurred: Do ESP_ERROR_CHECK for backtrace
+            ESP_ERROR_CHECK(port_cmd_err);
+            return;
+        }
 
+        // Resume command executed successfully, finish the resume procedure
         HUB_DRIVER_ENTER_CRITICAL();
         p_hub_driver_obj->dynamic.root_port_state = ROOT_PORT_STATE_ENABLED;
         HUB_DRIVER_EXIT_CRITICAL();


### PR DESCRIPTION
## Description

Fix aborting during suspend/resume sequence when a disconnection occurs.

In such a case, there is no action needed, because the root port is already in recovery state, so we leave the host lib to  do the rest.

## Related

- Blocks #345 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens suspend/resume robustness and expands test coverage.
> 
> - **Hub**: `root_port_req()` now handles `ESP_ERR_INVALID_RESPONSE` from `HCD_PORT_CMD_SUSPEND/RESUME` (e.g., disconnect during transition) by returning early instead of aborting; completes state updates only on success.
> - **HCD (DWC)**: In `hcd_port_recover()`, ungates internal clock before soft reset to allow reconnection.
> - **Tests (CDC-ACM host)**: Refactors app event queue into structured `test_event_t`, adds precise wait helpers with file/line diagnostics, and parameterizes driver install. Updates existing tests to use new helpers and event types.
> - **New test scenarios**: Adds mock TinyUSB CDC device with suspend/resume callbacks to trigger controlled disconnect/reconnect; introduces host tests for sudden disconnect during suspend/resume, auto-suspend timer, resume-by-transfer, and multi-thread cases; updates pytest to run device modes (`dual_iface`, `suspend_dconn`, `resume_dconn`).
> - Misc: Bumps SPDX years to 2026.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bab9d2581c061c132f167abaf022a4288ccc27b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->