### PR TITLE
feat(cdc): Added missing CTS signal definition

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -4,13 +4,21 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added missing CTS signal definition in `cdc_acm_uart_state_t` to complete RS-232 set
+
 ## [2.1.2] - 2025-12-16
 
 ### Added
+
 - Added global suspend/resume support
 - Added support for transmitting data larger than the configured output buffer size
 
 ### Fixed
+
 - Fixed opening of CDC devices with any VID/PID when connected through a USB hub
 
 ## [2.1.1] - 2025-09-24

--- a/host/class/cdc/usb_host_cdc_acm/include/usb/usb_types_cdc.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/usb/usb_types_cdc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -260,6 +260,10 @@ typedef struct {
 
 /**
  * @brief UART State Bitmap
+ *
+ * This state bitmap is based on USB CDC-PSTN specification.
+ * It was extended with CTS signal, which is the only missing input signal from RS-232 set.
+ *
  * @see Table 31, USB CDC-PSTN specification rev. 1.2
  */
 typedef union {
@@ -271,7 +275,10 @@ typedef union {
         uint16_t bFraming : 1;    // A framing error has occurred.
         uint16_t bParity : 1;     // A parity error has occurred.
         uint16_t bOverRun : 1;    // Received data has been discarded due to overrun in the device.
-        uint16_t reserved : 9;
+        uint16_t reserved : 8;
+
+        // Following bits are not defined in the USB specification.
+        uint16_t bClearToSend : 1;    // State of Clear To Send (CTS) signal
     };
     uint16_t val;
 } cdc_acm_uart_state_t;


### PR DESCRIPTION
CTS (clear to send) is the only signal from the RS-232 set that is not defined in USB CDC specification.

Added to UART state notification

Need for https://github.com/espressif/esp-usb/issues/360

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces CTS support in the CDC-ACM UART state and updates docs/metadata.
> 
> - Adds `bClearToSend` (CTS) bit to `cdc_acm_uart_state_t` and reduces `reserved` bits accordingly; notes this extension beyond USB CDC-PSTN
> - Updates `CHANGELOG.md` under **Unreleased** to mention the CTS addition
> - Bumps SPDX copyright year in `usb_types_cdc.h`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 035ea963e5ea9b89b7e41063c05f6a4a05687614. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->