### PR TITLE
feat(cdc): Add suppport for storing device-specific data

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -9,8 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added missing CTS signal definition in `cdc_acm_uart_state_t` to complete RS-232 set
+- Added support for storing user-defined, device-specific data within CDC-ACM-like driver implementations via `cdc_acm_host_interface.h`
 
-## [2.1.2] - 2025-12-16
+## [2.2.0] - 2025-12-16
 
 ### Added
 

--- a/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -241,6 +241,9 @@ static void cdc_acm_transfers_free(cdc_dev_t *cdc_dev);
 static void cdc_acm_device_remove(cdc_dev_t *cdc_dev)
 {
     assert(cdc_dev);
+    if (cdc_dev->intf_func.del) {
+        cdc_dev->intf_func.del(cdc_dev);
+    }
     cdc_acm_transfers_free(cdc_dev);
     free(cdc_dev->cdc_func_desc);
     // We don't check the error code of usb_host_device_close, as the close might fail, if someone else is still using the device (not all interfaces are released)

--- a/host/class/cdc/usb_host_cdc_acm/interface/usb/cdc_acm_host_interface.h
+++ b/host/class/cdc/usb_host_cdc_acm/interface/usb/cdc_acm_host_interface.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,8 @@ struct cdc_acm_intf_t {
     esp_err_t (*line_coding_get)(cdc_acm_dev_hdl_t cdc_hdl, cdc_acm_line_coding_t *line_coding);
     esp_err_t (*set_control_line_state)(cdc_acm_dev_hdl_t cdc_hdl, bool dtr, bool rts);
     esp_err_t (*send_break)(cdc_acm_dev_hdl_t cdc_hdl, uint16_t duration_ms);
+    void *user_data;                        // Can be used to store device-specific data
+    void (*del)(cdc_acm_dev_hdl_t cdc_hdl); // Called when the device is closed, to free any resources allocated by the device
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Small change that will allow us to use this CDC interface together with [FTDI driver](https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_ftdi_vcp), the only Virtual COM Port driver that does not offer C API yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds extensibility for CDC-ACM-like drivers and ensures proper cleanup.
> 
> - Extend `cdc_acm_intf_t` in `interface/usb/cdc_acm_host_interface.h` with `user_data` and `del` to store device-specific data and free it on close
> - Invoke `intf_func.del` in `cdc_acm_device_remove()` (`cdc_acm_host.c`) so implementations can release resources
> - Update `CHANGELOG.md` to `2.2.0` with entry for user-defined, device-specific data support; refresh SPDX years
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06537e62b8575a4e02dda20e4d08a70ddfd48a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->