### PR TITLE
fix(usb_host): Fix const qualifier violations for CI builds (IEC-480)

### DIFF
--- a/host/usb/src/ext_port.c
+++ b/host/usb/src/ext_port.c
@@ -782,7 +782,7 @@ static void handle_port_state(ext_port_t *ext_port)
                                     ? USB_SPEED_HIGH
                                     : USB_SPEED_FULL;
                     }
-                    ESP_LOGD(EXT_PORT_TAG, "Device speed %s", (char *[]) {
+                    ESP_LOGD(EXT_PORT_TAG, "Device speed %s", (const char *[]) {
                         "Low", "Full", "High"
                     }[dev_speed]);
                     ext_port->dev_state = PORT_DEV_PRESENT;

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -361,7 +361,7 @@ static void ext_port_event_callback(ext_port_hdl_t port_hdl, ext_port_event_data
         if (parent_speed == USB_SPEED_HIGH) {
             if (port_speed != parent_speed) {
                 ESP_LOGE(HUB_DRIVER_TAG, "Connected device is %s, transaction translator (TT) is not supported",
-                (char *[]) {
+                (const char *[]) {
                     "LS", "FS", "HS"
                 }[port_speed]);
                 goto new_ds_dev_err;


### PR DESCRIPTION
## Description
ESP-IDF MR 45069 enables -Wwrite-strings and -Werror=discarded-qualifiers in CI builds. This PR fixes const qualifier violations in examples that use `espressif/usb` managed component causing build failures.

## Related
- https://github.com/espressif/esp-idf/issues/18120

## Testing

- Tested ESP-IDF build locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures const-correct logging to pass stricter CI compiler flags.
> 
> - Update debug/error logs in `host/usb/src/ext_port.c` and `host/usb/src/hub.c` to use `(const char*[])` for string literal arrays
> - Change is limited to logging; no functional or behavioral impact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba6e70bbb5b44985e20ba7d541a44f399e1fc8a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->