### PR TITLE
release(cdc): Release usb_host_cdc_acm 2.3.0

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.3.0] - 2026-01-23
 
 ### Added
 

--- a/host/class/cdc/usb_host_cdc_acm/idf_component.yml
+++ b/host/class/cdc/usb_host_cdc_acm/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.2.0"
+version: "2.3.0"
 description: USB Host CDC-ACM driver
 tags:
   - usb


### PR DESCRIPTION
Release CDC-ACM driver 2.3.0

Contains #380 and #381 

Closes https://github.com/espressif/esp-usb/milestone/24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases `usb_host_cdc_acm` v2.3.0 with small feature additions.
> 
> - **Changelog:** Adds CTS signal in `cdc_acm_uart_state_t` and support for user-defined, device-specific data via `cdc_acm_host_interface.h`
> - **Metadata:** Bumps `idf_component.yml` version to `2.3.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a528e3d89c1fc1a457308e0c014cd610127d4e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->