### PR TITLE
fix(cdc_acm_host): Fix device events handling in test app

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
@@ -54,7 +54,7 @@ typedef struct {
 } test_event_t;
 
 // Static app queue storage
-uint8_t ucQueueStorage[APP_QUEUE_LENGTH * sizeof(test_event_t)];
+static uint8_t ucQueueStorage[APP_QUEUE_LENGTH * sizeof(test_event_t)];
 
 // Default device config
 static const cdc_acm_host_device_config_t default_dev_config = {

--- a/host/class/cdc/usb_host_cdc_acm/test_app/sdkconfig.defaults
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/sdkconfig.defaults
@@ -7,6 +7,10 @@ CONFIG_TINYUSB_HID_COUNT=0
 # Disable watchdogs, they'd get triggered during unity interactive menu
 # CONFIG_ESP_TASK_WDT_INIT is not set
 
+# Register tinyusb suspend/resume callbacks in esp_tinyusb
+CONFIG_TINYUSB_SUSPEND_CALLBACK=y
+CONFIG_TINYUSB_RESUME_CALLBACK=y
+
 # Run-time checks of Heap and Stack
 CONFIG_COMPILER_STACK_CHECK_MODE_STRONG=y
 CONFIG_COMPILER_STACK_CHECK=y


### PR DESCRIPTION
## Description

As suspend/resume events were added to `esp_tinyusb` by #387 , we are fixing the cdc-acm host test app, by adding proper device events handling with event queue. Instead of registering the "custom" susepnd/resume events.

## Related

- Fixes #379 
- Needs #387 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
