### PR TITLE
feat(usb_host): Propagate remote wakeup HAL changes presence to public API

### DIFF
--- a/host/usb/CMakeLists.txt
+++ b/host/usb/CMakeLists.txt
@@ -72,3 +72,24 @@ idf_component_register(SRCS ${srcs}
 if(CONFIG_COMPILER_STATIC_ANALYZER AND CMAKE_C_COMPILER_ID STREQUAL "GNU") # TODO GCC-366 (segfault)
     set_property(SOURCE usb_host.c PROPERTY COMPILE_FLAGS -fno-analyzer)
 endif()
+
+# Create public symbol representing remote wakeup changes availability based on IDF version
+# Remote wakeup HAL changes are present:
+# On IDF 5.4.x from IDF 5.4.4
+# On IDF 5.5.x from IDF 5.5.3
+# On IDF 6.0.x from IDF 6.0.0
+set(REMOTE_WAKE_HAL_SUPPORTED OFF)
+set(IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
+
+# IDF 5.4.x from 5.4.4
+if(IDF_VERSION VERSION_GREATER_EQUAL "5.4.4" AND IDF_VERSION VERSION_LESS "5.5.0")
+    set(REMOTE_WAKE_HAL_SUPPORTED ON)
+
+# IDF 5.5.x from 5.5.3 and all 6.x+
+elseif(IDF_VERSION VERSION_GREATER_EQUAL "5.5.3")
+    set(REMOTE_WAKE_HAL_SUPPORTED ON)
+endif()
+
+if(REMOTE_WAKE_HAL_SUPPORTED)
+    target_compile_definitions(${COMPONENT_LIB} PUBLIC REMOTE_WAKE_HAL_SUPPORTED)
+endif()

--- a/host/usb/private_include/hcd.h
+++ b/host/usb/private_include/hcd.h
@@ -20,19 +20,6 @@ extern "C" {
 
 // ------------------------------------------------- Macros & Types ----------------------------------------------------
 
-// --------------------- IDF Versioning compatibility -------------------------
-
-// Remote wakeup HAL changes are present
-// On IDF 5.4.x from IDF 5.4.4
-// On IDF 5.5.x from IDF 5.5.3
-// On IDF 6.0.x from IDF 6.0.0
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 4) && ESP_IDF_VERSION <  ESP_IDF_VERSION_VAL(5, 5, 0)
-#define REMOTE_WAKE_HAL_SUPPORTED
-#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 3)
-#define REMOTE_WAKE_HAL_SUPPORTED
-#endif
-
-
 // ----------------------- States --------------------------
 
 /**

--- a/host/usb/src/hcd_dwc.c
+++ b/host/usb/src/hcd_dwc.c
@@ -1173,6 +1173,9 @@ static inline bool _is_fifo_config_by_bias(const usb_dwc_hal_fifo_config_t *cfg)
 /**
  * @brief Gate internal clock
  *
+ * @note HAL functions used in this function were backported together with remote wakeup changes, we are guarding the
+ *       presence of both using the same public define
+ *
  * @param[in] port Pointer to the port object
  * @param[in] enable enable/disable internal clock gating
  * @return True internal clk successfully gated/un-gated
@@ -1180,6 +1183,7 @@ static inline bool _is_fifo_config_by_bias(const usb_dwc_hal_fifo_config_t *cfg)
  */
 static inline bool _internal_clk_gate(port_t *port, bool enable)
 {
+#ifdef REMOTE_WAKE_HAL_SUPPORTED
     // Stop PHY Clock and gate HCLK
     usb_dwc_hal_pwr_clk_internal_clock_gate(port->hal, enable);
 
@@ -1196,6 +1200,9 @@ static inline bool _internal_clk_gate(port_t *port, bool enable)
         return true;
     }
     return false;
+#else
+    return true;
+#endif // REMOTE_WAKE_HAL_SUPPORTED
 }
 
 // ---------------------- Commands -------------------------


### PR DESCRIPTION
## Description

Propagating `REMOTE_WAKE_HAL_SUPPORTED` publicly

## Changes

### Closing content of `_internal_clk_gate` to `#ifdef REMOTE_WAKE_HAL_SUPPORTED`
 
`_internal_clk_gate` accesses dwc clock gating `usb_dwc_hal_` functions which were added together with their `usb_dwc_ll_` functions. Clock gating HAL and LL are available:
- On `IDF 5.5.x` from `IDF 5.5.2` (already released) 
- On `IDF 5.4.x` from `IDF 5.4.4` (not released)

Whereas Remote wakeup HAL changes are avalilable:
- On `IDF 5.5.x` from `IDF 5.5.3` (not released)
- On `IDF 5.4.x` from `IDF 5.4.4` (not released)

We can use the same symbol `REMOTE_WAKE_HAL_SUPPORTED` to guard availability of both HAL/LL chagnes (Clock gating and Remote wakeup)

### Creating `REMOTE_WAKE_HAL_SUPPORTED` publicly available

- To be able to use the `REMOTE_WAKE_HAL_SUPPORTED` both, internally in `usb` component and externally in class drivers, propagating the symbol through CMake, instead through header files due to `private/inlcude` vs  `include`

## Related

Cherry-picked this commit to both remote wakeup MRs to tests propagation of the public symbol
- Tested by #345 
- Tested by #385 

## Limitations

No remote-wakeup related test apps are run for current `release/v5.5` and `release/v5.4`. As well as the feature is not available yet in the `release/v5.x` branches:
- `release/v5.5` is officially still `v5.5.2` (latest release) and this PR sets HAL changes availability IDF >= 5.5.3
- `release/v5.4` is officially still `v5.4.3` (latest release) and this PR sets HAL changes availability IDF >= 5.4.4

Since neither `v5.5.3` nor `v5.4.4` was released. 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
