### PR TITLE
Fix VBUS monitoring on ESP32-P4

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- esp_tinyusb: Fixed VBUS monitoring feature on ESP32-P4 USB OTG 2.0 (HS)
+
 ## 2.1.0
 
 - Added configurable Suspend/Resume device event support using TinyUSB callbacks `tud_suspend_cb` and `tud_resume_cb`
@@ -10,7 +14,7 @@
 ## 2.0.1
 
 - esp_tinyusb: Added ESP32H4 support
-- esp_tinyusb: Fixed an assertion failure on the GetOtherSpeedDescriptor() request for ESP32P4 when the OTG1.1 port is used
+- esp_tinyusb: Fixed an assertion failure on the GetOtherSpeedDescriptor() request for ESP32-P4 when the OTG1.1 port is used
 - MSC: Added dynamic member and storage operation multitask protection
 - MSC: Used `esp_vfs_fat_register_cfg` function prototype for esp-idf v5.3 and higher
 

--- a/device/esp_tinyusb/CMakeLists.txt
+++ b/device/esp_tinyusb/CMakeLists.txt
@@ -1,3 +1,6 @@
+idf_build_get_property(target IDF_TARGET)
+set(IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
+
 set(srcs
     "descriptors_control.c"
     "tinyusb.c"
@@ -7,8 +10,12 @@ set(srcs
 
 set(priv_req "")
 
-if(${IDF_VERSION_MAJOR} LESS 6)
-    list(APPEND priv_req "usb")
+# USB-PHY driver
+# For IDF 6.x and later, usb_phy driver is moved from usb to esp_hw_support
+if(IDF_VERSION VERSION_LESS "6.0.0")
+    list(APPEND priv_req usb)
+else()
+    list(APPEND priv_req esp_hw_support)
 endif()
 
 if(CONFIG_TINYUSB_CDC_ENABLED)
@@ -42,6 +49,18 @@ if(CONFIG_TINYUSB_NET_MODE_NCM)
          "tinyusb_net.c"
          )
 endif() # CONFIG_TINYUSB_NET_MODE_NCM
+
+# Software VBUS monitoring is available only on esp32p4
+if(${target} STREQUAL "esp32p4")
+    list(APPEND srcs "tinyusb_vbus_monitor.c")
+
+    # VBUS monitoring on ESP32-P4 requires GPIO driver
+    if(IDF_VERSION VERSION_GREATER_EQUAL "5.3")
+        list(APPEND priv_req esp_driver_gpio)
+    else()
+        list(APPEND priv_req driver)
+    endif()
+endif() # esp32p4
 
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"

--- a/device/esp_tinyusb/include/tinyusb.h
+++ b/device/esp_tinyusb/include/tinyusb.h
@@ -36,22 +36,21 @@ typedef enum {
 } tinyusb_port_t;
 
 /**
- * @brief TinyUSB PHY configuration
+ * @brief TinyUSB PHY and VBUS monitoring configuration
  *
- * @note This structure is used to configure the USB PHY. The user can set the parameters
- *       according to their requirements.
+ * @note On ESP32-P4 High Speed port, GPIO ISR service must be installed with gpio_install_isr_service() before calling tinyusb_driver_install().
  */
 typedef struct {
     bool skip_setup;                       /*!< If set, the esp_tinyusb will not configure the USB PHY thus allowing
                                                 the user to manually configure the USB PHY before calling tinyusb_driver_install().
                                                 Users should set this if they want to use an external USB PHY. Otherwise,
                                                 the esp_tinyusb will automatically configure the internal USB PHY */
-    // Relevant only when skip_setup is false
-    bool self_powered;                        /*!< USB specification mandates self-powered devices to monitor USB VBUS to detect connection/disconnection events.
+    bool self_powered;                     /*!< USB specification mandates self-powered devices to monitor USB VBUS to detect connection/disconnection events.
                                                 To use this feature, connect VBUS to any free GPIO through a voltage divider or voltage comparator.
                                                 The voltage divider output should be (0.75 * Vdd) if VBUS is 4.4V (lowest valid voltage at device port).
-                                                The comparator thresholds should be set with hysteresis: 4.35V (falling edge) and 4.75V (raising edge). */
-    int vbus_monitor_io;                      /*!< GPIO for VBUS monitoring, 3.3 V tolerant (use a comparator or a resistior divider to detect the VBUS valid condition). Ignored if not self_powered. */
+                                                The comparator thresholds should be set with hysteresis: 4.35V (falling edge) and 4.75V (raising edge).
+                                                On ESP32-P4 High Speed port, GPIO ISR service must be installed with gpio_install_isr_service() before calling tinyusb_driver_install(). */
+    int vbus_monitor_io;                   /*!< GPIO for VBUS monitoring, 3.3 V tolerant (use a comparator or a resistor divider to detect the VBUS valid condition). Ignored if not self_powered. */
 } tinyusb_phy_config_t;
 
 /**

--- a/device/esp_tinyusb/include_private/tinyusb_vbus_monitor.h
+++ b/device/esp_tinyusb/include_private/tinyusb_vbus_monitor.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int         gpio_num;          /*!< GPIO number used for VBUS monitoring, 3.3 V tolerant */
+    int         port;              /*!< USB port number */
+} tinyusb_vbus_monitor_config_t;
+
+/**
+ * @brief Initialize VBUS monitoring on the specified GPIO
+ *
+ * @note GPIO interrupt service must be installed with gpio_install_isr_service() before calling this function.
+ *
+ * @param[in] config VBUS monitoring configuration
+ * @return
+ *    - ESP_ERR_INVALID_ARG:   Config is NULL or GPIO number is invalid
+ *    - ESP_ERR_INVALID_STATE: VBUS monitoring was already initialized or GPIO interrupt service is not installed
+ *    - ESP_OK:                VBUS monitoring initialized successfully
+ */
+esp_err_t tinyusb_vbus_monitor_init(const tinyusb_vbus_monitor_config_t *config);
+
+/**
+ * @brief De-initialize VBUS monitoring
+ */
+void tinyusb_vbus_monitor_deinit(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/device/esp_tinyusb/test_apps/dconn_detection/main/test_app_main.c
+++ b/device/esp_tinyusb/test_apps/dconn_detection/main/test_app_main.c
@@ -1,14 +1,14 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
-#include <string.h>
 #include "unity.h"
 #include "unity_test_runner.h"
 #include "unity_test_utils_memory.h"
+#include "esp_newlib.h"
 
 void app_main(void)
 {
@@ -45,7 +45,7 @@ void app_main(void)
     printf("  \\_/ \\____/\\____/  \\_/                            \n");
 
     unity_utils_setup_heap_record(80);
-    unity_utils_set_leak_level(128);
+    unity_utils_set_leak_level(80);
     unity_run_menu();
 }
 
@@ -58,5 +58,6 @@ void setUp(void)
 /* tearDown runs after every test */
 void tearDown(void)
 {
+    esp_reent_cleanup();    //clean up some of the newlib's lazy allocations
     unity_utils_evaluate_leaks();
 }

--- a/device/esp_tinyusb/test_apps/dconn_detection/pytest_dconn_detection.py
+++ b/device/esp_tinyusb/test_apps/dconn_detection/pytest_dconn_detection.py
@@ -5,7 +5,8 @@ import pytest
 from pytest_embedded_idf.dut import IdfDut
 from pytest_embedded_idf.utils import idf_parametrize
 
-#@pytest.mark.usb_device             Disable in CI: unavailable teardown for P4
+
+@pytest.mark.usb_device
 @idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
 def test_usb_device_dconn_detection(dut: IdfDut) -> None:
     dut.run_all_single_board_cases(group='dconn')

--- a/device/esp_tinyusb/test_apps/dconn_detection/sdkconfig.defaults
+++ b/device/esp_tinyusb/test_apps/dconn_detection/sdkconfig.defaults
@@ -1,17 +1,11 @@
-# Configure TinyUSB, it will be used to mock USB devices
-CONFIG_TINYUSB_MSC_ENABLED=n
-CONFIG_TINYUSB_CDC_ENABLED=n
-CONFIG_TINYUSB_CDC_COUNT=0
-CONFIG_TINYUSB_HID_COUNT=0
-
-# Disable watchdogs, they'd get triggered during unity interactive menu
-# CONFIG_ESP_TASK_WDT_INIT is not set
-
-# Run-time checks of Heap and Stack
-CONFIG_HEAP_POISONING_COMPREHENSIVE=y
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) 6.1.0 Project Minimal Configuration
+#
+# default:
 CONFIG_COMPILER_STACK_CHECK_MODE_STRONG=y
-CONFIG_COMPILER_STACK_CHECK=y
-
+CONFIG_ESP_TASK_WDT_INIT=n
+CONFIG_HEAP_POISONING_COMPREHENSIVE=y
 CONFIG_UNITY_ENABLE_BACKTRACE_ON_FAIL=y
-
-CONFIG_COMPILER_CXX_EXCEPTIONS=y
+CONFIG_TINYUSB_SUSPEND_CALLBACK=y
+CONFIG_TINYUSB_RESUME_CALLBACK=y
+CONFIG_TINYUSB_CDC_ENABLED=y

--- a/device/esp_tinyusb/tinyusb_vbus_monitor.c
+++ b/device/esp_tinyusb/tinyusb_vbus_monitor.c
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp_log.h"
+#include "esp_err.h"
+#include "esp_check.h"
+#include "tinyusb_vbus_monitor.h"
+
+#include "driver/gpio.h"     // This implementation of VBUS monitoring is based on GPIO interrupt
+#include "device/dcd.h"      // For sending events to TinyUSB DCD layer
+
+const static char *TAG = "VBUS mon";
+
+/**
+ * @brief VBUS monitoring context
+ *
+ * Only one instance of VBUS monitoring is supported at the moment.
+ */
+typedef struct {
+    gpio_num_t gpio_num;            /*!< GPIO number used for VBUS monitoring */
+    int port;                        /*!< USB port number */
+} vbus_monitor_context_t;
+
+static vbus_monitor_context_t s_vbus_ctx = {
+    .gpio_num = GPIO_NUM_NC,
+    .port = 0,
+};
+
+// -------------- VBUS Internal Logic ------------------
+
+/**
+ * @brief GPIO interrupt handler for VBUS monitoring io
+ *
+ * @param arg VBUS monitoring context
+ */
+static void vbus_io_cb(void *arg)
+{
+    vbus_monitor_context_t *ctx = (vbus_monitor_context_t *)arg;
+    if (ctx == NULL) {
+        return;
+    }
+    gpio_intr_disable(ctx->gpio_num);
+
+    const bool vbus_curr_state = gpio_get_level(ctx->gpio_num);
+
+    if (!vbus_curr_state) {
+        dcd_event_bus_signal(ctx->port, DCD_EVENT_UNPLUGGED, true);
+    }
+    gpio_intr_enable(ctx->gpio_num);
+}
+
+// -------------- Public API ------------------
+
+esp_err_t tinyusb_vbus_monitor_init(const tinyusb_vbus_monitor_config_t *config)
+{
+    esp_err_t ret = ESP_OK;
+    ESP_RETURN_ON_FALSE(config != NULL, ESP_ERR_INVALID_ARG, TAG, "Invalid argument: config is NULL");
+    ESP_RETURN_ON_FALSE(s_vbus_ctx.gpio_num == GPIO_NUM_NC, ESP_ERR_INVALID_STATE, TAG, "Already initialized");
+
+    // Init gpio IRQ for VBUS monitoring
+    const gpio_config_t vbus_io_cfg = {
+        .pin_bit_mask = BIT64(config->gpio_num),
+        .mode = GPIO_MODE_INPUT,
+        .intr_type = GPIO_INTR_NEGEDGE,
+        .hys_ctrl_mode = GPIO_HYS_SOFT_ENABLE, // Enable hysteresis. Low->High = 1.7V, High->Low = 1.4V
+    };
+
+    ESP_RETURN_ON_ERROR(gpio_config(&vbus_io_cfg), TAG, "Failed to configure VBUS GPIO%d", config->gpio_num);
+    ESP_GOTO_ON_ERROR(gpio_isr_handler_add(config->gpio_num, vbus_io_cb, (void *)&s_vbus_ctx),
+                      isr_err,
+                      TAG,
+                      "Failed to add ISR handler. Please install ISR service with gpio_install_isr_service().");
+
+    s_vbus_ctx.gpio_num   = config->gpio_num;
+    s_vbus_ctx.port       = config->port;
+
+    return ESP_OK;
+
+isr_err:
+    gpio_reset_pin(config->gpio_num);
+    return ret;
+}
+
+void tinyusb_vbus_monitor_deinit(void)
+{
+    if (s_vbus_ctx.gpio_num == GPIO_NUM_NC) {
+        return;
+    }
+    // Reset GPIO to the default state
+    gpio_reset_pin(s_vbus_ctx.gpio_num);
+    // Remove gpio IRQ for VBUS monitoring - this can fail only if another thread uninstalled GPIO ISR service-> nothing to do if it fails
+    gpio_isr_handler_remove(s_vbus_ctx.gpio_num);
+    s_vbus_ctx.gpio_num = GPIO_NUM_NC;
+}

--- a/host/class/msc/usb_host_msc/test_app/main/msc_device.c
+++ b/host/class/msc/usb_host_msc/test_app/main/msc_device.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -102,21 +102,6 @@ static char const *string_desc_arr[] = {
     //"123456",                       // 3: Serials
     //"Test MSC",                  // 4. MSC
 };
-/*********************************************************************** TinyUSB descriptors*/
-
-#define VBUS_MONITORING_GPIO_NUM GPIO_NUM_4
-static void configure_vbus_monitoring(void)
-{
-    // Configure GPIO Pin for vbus monitoring
-    const gpio_config_t vbus_gpio_config = {
-        .pin_bit_mask = BIT64(VBUS_MONITORING_GPIO_NUM),
-        .mode = GPIO_MODE_INPUT,
-        .intr_type = GPIO_INTR_DISABLE,
-        .pull_up_en = true,
-        .pull_down_en = false,
-    };
-    ESP_ERROR_CHECK(gpio_config(&vbus_gpio_config));
-}
 
 static void storage_init(void)
 {
@@ -131,8 +116,6 @@ static void storage_init(void)
 #endif // TUD_OPT_HIGH_SPEED
     tusb_cfg.descriptor.string = string_desc_arr;
     tusb_cfg.descriptor.string_count = sizeof(string_desc_arr) / sizeof(string_desc_arr[0]);
-    tusb_cfg.phy.self_powered = true;
-    tusb_cfg.phy.vbus_monitor_io = VBUS_MONITORING_GPIO_NUM;
 
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
     ESP_LOGI(TAG, "USB initialization DONE");
@@ -154,7 +137,6 @@ static esp_err_t storage_init_spiflash(wl_handle_t *wl_handle)
 void device_app(void)
 {
     ESP_LOGI(TAG, "Initializing storage...");
-    configure_vbus_monitoring();
 
     static wl_handle_t wl_handle = WL_INVALID_HANDLE;
     ESP_ERROR_CHECK(storage_init_spiflash(&wl_handle));
@@ -246,7 +228,6 @@ clean:
 void device_app_sdmmc(void)
 {
     ESP_LOGI(TAG, "Initializing storage...");
-    configure_vbus_monitoring();
     static sdmmc_card_t *card = NULL;
     ESP_ERROR_CHECK(storage_init_sdmmc(&card));
 


### PR DESCRIPTION
## Implements VBUS monitoring on P4 targets

Compared to S2 and S3, P4 has UTMI PHY and USB-OTG peripheral v4.30a (from silicon revision v3 upwards). This changes how we propagate unplugged events. We can no longer trigger unplugged events from the USB-OTG peripheral (it misses connection to PHY and does not have bvalid signaling).

Instead, we monitor the VBUS with GPIO driver. On falling edge we inject `DCD_EVENT_UNPLUGGED` event to TinyUSB DCD layer, which handles USB peripheral state and then informs the user about unplugged event from TinyUSB task

## Related
- Supersedes #305 
- Supersedes #307 
- Supersedes #313

## TODO
- [x] Test with TinyUSB MSC example
- [x] Pass CI
- [x] Clean-up git history