### PR TITLE
refactor(host): Move usb_helpers test to host_test

### DIFF
--- a/host/usb/test/host_test/usb_host_layer_test/main/CMakeLists.txt
+++ b/host/usb/test/host_test/usb_host_layer_test/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(srcs)
 list(APPEND srcs "test_main.cpp"
                  "usb_host_install_unit_test.cpp"
+                 "usb_helpers_descriptor_parsing_test.cpp"
                  )
 
 idf_component_register(SRCS  ${srcs}

--- a/host/usb/test/target_test/enum/main/test_app_main.c
+++ b/host/usb/test/target_test/enum/main/test_app_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -11,6 +11,7 @@
 #include "freertos/task.h"
 #include "esp_private/usb_phy.h"
 #include "unity.h"
+#include "esp_newlib.h"
 
 static usb_phy_handle_t phy_hdl = NULL;
 
@@ -34,6 +35,7 @@ void tearDown(void)
     // Deinitialize the internal USB PHY
     TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, usb_del_phy(phy_hdl), "Failed to delete USB Device PHY");
     phy_hdl = NULL;
+    esp_reent_cleanup();    //clean up some of the newlib's lazy allocations
     unity_utils_evaluate_leaks();
 }
 

--- a/host/usb/test/target_test/ext_port/main/test_app_main.c
+++ b/host/usb/test/target_test/ext_port/main/test_app_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -12,6 +12,7 @@
 #include "hcd_common.h"
 #include "hub_common.h"
 #include "ext_port_common.h"
+#include "esp_newlib.h"
 
 static hcd_port_handle_t _root_port_hdl;
 
@@ -37,6 +38,7 @@ void tearDown(void)
     test_hcd_teardown(_root_port_hdl);
     // Short delay to allow task to be cleaned up after client uninstall
     vTaskDelay(10);
+    esp_reent_cleanup();    //clean up some of the newlib's lazy allocations
     unity_utils_evaluate_leaks();
 }
 

--- a/host/usb/test/target_test/hcd/main/test_app_main.c
+++ b/host/usb/test/target_test/hcd/main/test_app_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -12,6 +12,7 @@
 #include "dev_msc.h"
 #include "dev_hid.h"
 #include "hcd_common.h"
+#include "esp_newlib.h"
 
 void setUp(void)
 {
@@ -27,6 +28,7 @@ void tearDown(void)
     vTaskDelay(10);
     test_hcd_teardown(port_hdl);
     port_hdl = NULL;
+    esp_reent_cleanup();    //clean up some of the newlib's lazy allocations
     unity_utils_evaluate_leaks();
 }
 

--- a/host/usb/test/target_test/usb_host/main/test_app_main.c
+++ b/host/usb/test/target_test/usb_host/main/test_app_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -9,6 +9,7 @@
 #include "unity_test_utils_memory.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_newlib.h"
 #include "dev_msc.h"
 #include "phy_common.h"
 #include "usb/usb_host.h"
@@ -58,6 +59,7 @@ void tearDown(void)
     test_delete_usb_phy();
     // Short delay to allow task to be cleaned up after client uninstall
     vTaskDelay(10);
+    esp_reent_cleanup();    //clean up some of the newlib's lazy allocations
     unity_utils_evaluate_leaks();
 }
 


### PR DESCRIPTION
* Move usb_helpers test from HCD to host_test.
This will save some runner time and prepare us for future expansion of host_tests
* Also add reent_cleanup call to all target test_apps