### PR TITLE
fix(ci): Run CI with multiple sdkconfigs

### DIFF
--- a/.github/workflows/build_and_run_host_test.yml
+++ b/.github/workflows/build_and_run_host_test.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install pytest pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyusb idf-build-apps==2.13.3 --upgrade
+          pip install pytest pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyusb idf-ci idf-build-apps==2.13.3 --upgrade
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -176,4 +176,4 @@ jobs:
           fi
           # Run pytest with the configured target and marker
           echo "Running pytest with target: $TARGET_ARG and marker: ${{ matrix.runner_tag }}"
-          pytest --ignore-no-tests-collected-error $TARGET_ARG -m "${{ matrix.runner_tag }}" --build-dir=build_${{ matrix.idf_target }}_default
+          pytest --ignore-no-tests-collected-error $TARGET_ARG -m "${{ matrix.runner_tag }}" --build-dir=build_${{ matrix.idf_target }}_

--- a/host/class/uac/usb_host_uac/test_app/pytest_usb_host_uac.py
+++ b/host/class/uac/usb_host_uac/test_app/pytest_usb_host_uac.py
@@ -7,7 +7,11 @@ from pytest_embedded_idf.utils import idf_parametrize
 
 
 # No runner marker, unable to mock UAC 1.0 device with tinyusb
-@idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
+@idf_parametrize(
+    'config,target',
+    [('default', 'esp32s2'), ('default', 'esp32s3'), ('default', 'esp32p4'), ('esp32p4_psram', 'esp32p4')],
+    indirect=['config', 'target'],
+)
 def test_usb_host_uac(dut: IdfDut) -> None:
     dut.expect_exact('Press ENTER to see the list of tests.')
     dut.write('[uac_host]')

--- a/host/usb/test/target_test/hcd/pytest_usb_hcd.py
+++ b/host/usb/test/target_test/hcd/pytest_usb_hcd.py
@@ -7,13 +7,11 @@ from pytest_embedded_idf.utils import idf_parametrize
 
 
 @pytest.mark.usb_host_flash_disk
-@idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
-# No build for different configs yet, leaving this commented out
-#@idf_parametrize(
-#    'config,target',
-#    [('default', 'esp32s2'), ('default', 'esp32s3'), ('default', 'esp32p4'), ('esp32p4_psram', 'esp32p4')],
-#    indirect=['config', 'target'],
-#)
+@idf_parametrize(
+    'config,target',
+    [('default', 'esp32s2'), ('default', 'esp32s3'), ('default', 'esp32p4'), ('esp32p4_psram', 'esp32p4')],
+    indirect=['config', 'target'],
+)
 def test_usb_hcd(dut: IdfDut) -> None:
     if dut.target == 'esp32p4':
         dut.run_all_single_board_cases(group='high_speed', reset=True)


### PR DESCRIPTION
## Description

Running target tests with multiple sdkconfigs.
Below is a CI log from hcd target test running both binaries in CI: 
- `build_esp32p4_default`
- `build_esp32p4_esp32p4_psram`

<details>
<summary> CI log </summary>


```bash
[02/12/26 14:51:22] INFO     Found valid binary path: /__w/esp-usb/esp-usb/host/usb/test/target_test/hcd/build_esp32p4_default
host/usb/test/target_test/hcd/pytest_usb_hcd.py::test_usb_hcd[default-esp32p4] 
-------------------------------- live log setup --------------------------------
2026-02-12 14:51:22 INFO Target: esp32p4, Port: /dev/ttyUSB0


[02/12/26 14:52:21] INFO     Found valid binary path: /__w/esp-usb/esp-usb/host/usb/test/target_test/hcd/build_esp32p4_esp32p4_psram
host/usb/test/target_test/hcd/pytest_usb_hcd.py::test_usb_hcd[esp32p4_psram-esp32p4] 
-------------------------------- live log setup --------------------------------
2026-02-12 14:52:22 INFO Target: esp32p4, Port: /dev/ttyUSB0
```

</details>


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
