### PR TITLE
fix(ci): Mark pm tests as flaky

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -164,7 +164,7 @@ jobs:
         if: success() && steps.download_artifact.outcome == 'success'
         env:
           PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
-        run: pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf idf-ci pytest-ignore-test-results pyserial pyusb
+        run: pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf idf-ci pytest-ignore-test-results pytest-rerunfailures pyserial pyusb
       - name: Run USB Test App on target
         if: success() && steps.download_artifact.outcome == 'success'
         run: |

--- a/device/esp_tinyusb/test_apps/power_management/main/test_app_main.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_app_main.c
@@ -9,6 +9,11 @@
 #include "unity.h"
 #include "unity_test_runner.h"
 #include "unity_test_utils_memory.h"
+#include "esp_log.h"
+
+#include "tinyusb.h"
+#include "tinyusb_cdc_acm.h"
+const static char *TAG = "PM_Device_main_app";
 
 void app_main(void)
 {
@@ -58,5 +63,8 @@ void setUp(void)
 /* tearDown runs after every test */
 void tearDown(void)
 {
+    ESP_LOGI(TAG, "Cleanup");
+    tinyusb_cdcacm_deinit(TINYUSB_CDC_ACM_0);
+    tinyusb_driver_uninstall();
     unity_utils_evaluate_leaks();
 }

--- a/device/esp_tinyusb/test_apps/power_management/main/test_device_pm.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_device_pm.c
@@ -153,7 +153,7 @@ TEST_CASE("tinyusb_suspend_resume_events", "[esp_tinyusb][device_pm_suspend_resu
     int test_iterations = 0;
     do {
         // Wait for new data from the host (Sent by pytest)
-        if (pdTRUE == ulTaskNotifyTake(true, pdMS_TO_TICKS(5000))) {
+        if (pdTRUE == ulTaskNotifyTake(true, pdMS_TO_TICKS(10000))) {
 
             size_t rx_size = 0;
             ESP_ERROR_CHECK(tinyusb_cdcacm_read(TINYUSB_CDC_ACM_0, buf, TINYUSB_CDC_RX_BUFSIZE, &rx_size));
@@ -172,10 +172,6 @@ TEST_CASE("tinyusb_suspend_resume_events", "[esp_tinyusb][device_pm_suspend_resu
             TEST_FAIL_MESSAGE("RX Data CB not received on time");
         }
     } while (test_iterations <= SUSPEND_RESUME_TEST_ITERATIONS);
-
-    ESP_LOGI(TAG, "Cleanup");
-    tinyusb_cdcacm_deinit(TINYUSB_CDC_ACM_0);
-    tinyusb_driver_uninstall();
 }
 
 /**
@@ -302,10 +298,6 @@ TEST_CASE("tinyusb_remote_wakeup_reporting", "[esp_tinyusb][device_pm_remote_wak
     // Signalize remote wakeup and expect resume event
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_remote_wakeup());
     expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
-
-    ESP_LOGI(TAG, "Cleanup");
-    tinyusb_cdcacm_deinit(TINYUSB_CDC_ACM_0);
-    tinyusb_driver_uninstall();
 }
 
 #endif

--- a/device/esp_tinyusb/test_apps/power_management/pytest_usb_pm.py
+++ b/device/esp_tinyusb/test_apps/power_management/pytest_usb_pm.py
@@ -38,6 +38,7 @@ TINYUSB_EVENTS = {
 }
 
 @pytest.mark.usb_device
+@pytest.mark.flaky(reruns=1, reruns_delay=10)
 @idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
 def test_usb_device_suspend_resume(dut: IdfDut) -> None:
     '''
@@ -53,6 +54,7 @@ def test_usb_device_suspend_resume(dut: IdfDut) -> None:
     4. Suspend: Device enters suspended state after some time of inactivity
     5. Resume: Device is resumed by accessing it (sending some data to it)
     '''
+    sleep(5) # When rerunning flaky test, to re-initialize the device
     dut.expect_exact('Press ENTER to see the list of tests.')
     dut.write('[device_pm_suspend_resume]')
     dut.expect_exact('TinyUSB: TinyUSB Driver installed')
@@ -72,6 +74,9 @@ def test_usb_device_suspend_resume(dut: IdfDut) -> None:
             dut.expect_exact(TINYUSB_EVENTS['attached'])
 
             # Wait for auto suspend (set to 3 seconds)
+            # This expect_exact is ignored by pytest when running second rerun of flaky test (unknown reason),
+            # making the test fail in further steps, adding explicit sleep(3) to wait for the suspend events
+            sleep(3)
             dut.expect_exact(TINYUSB_EVENTS['suspended'])
 
             for i in range(0, 5):
@@ -92,7 +97,6 @@ def test_usb_device_suspend_resume(dut: IdfDut) -> None:
 
     except SerialException as e:
         raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
-
 
 def set_remote_wake_on_device(VID: int, PID: int) -> None:
     '''
@@ -166,6 +170,7 @@ def check_remote_wake_feature(VID: int, PID: int, has_remote_wake: bool) -> None
         raise RuntimeError("Device resources not released") from e
 
 @pytest.mark.usb_device
+@pytest.mark.flaky(reruns=1, reruns_delay=10)
 @idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
 def test_usb_device_remote_wakeup_en(dut: IdfDut) -> None:
     '''
@@ -180,6 +185,7 @@ def test_usb_device_remote_wakeup_en(dut: IdfDut) -> None:
     3. Check the device's configuration descriptor, if it reports remote wakeup functionality
     4. Enable the remote wakeup by sending a ctrl transfer
     '''
+    sleep(5)
     dut.expect_exact('Press ENTER to see the list of tests.')
     dut.write('[device_pm_remote_wake]')
     dut.expect_exact('TinyUSB: TinyUSB Driver installed')


### PR DESCRIPTION
## Description

Marking power management tests as flaky, since they have been randomly failing, but passed after manual rerun. 

Tested only locally by inducing an error state to make the test app fail for the firs time which triggers automatic rerun. Did not manage to catch the error in CI after 6 reruns of the whole CI.


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
