### PR TITLE
docs: Update links for esp-usb documentation

### DIFF
--- a/device/esp_tinyusb/README.md
+++ b/device/esp_tinyusb/README.md
@@ -60,8 +60,6 @@ idf.py add-dependency esp_tinyusb~2.0.0
 
 ## USB Device Stack: usage, installation & configuration
 
-Hardware-related documentation can be found in the [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html).
-
 ### Structure overview
 
 The Device Stack is built on top of TinyUSB and provides:

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
-documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
+documentation: "https://docs.espressif.com/projects/esp-usb/en/latest/esp32p4/usb_device.html"
 version: "2.1.0"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 targets:

--- a/host/class/cdc/usb_host_cdc_acm/README.md
+++ b/host/class/cdc/usb_host_cdc_acm/README.md
@@ -2,7 +2,7 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_cdc_acm/badge.svg)](https://components.espressif.com/components/espressif/usb_host_cdc_acm) ![maintenance-status](https://img.shields.io/badge/maintenance-passively--maintained-yellowgreen.svg) ![changelog](https://img.shields.io/badge/Keep_a_Changelog-blue?logo=keepachangelog&logoColor=E05735)
 
-This component contains an implementation of a USB CDC-ACM Host Class Driver that is implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
+This component contains an implementation of a USB CDC-ACM Host Class Driver that is implemented on top of the [USB Host Library](https://components.espressif.com/components/espressif/usb).
 
 ## Supported Devices
 

--- a/host/class/hid/usb_host_hid/README.md
+++ b/host/class/hid/usb_host_hid/README.md
@@ -2,7 +2,7 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_hid/badge.svg)](https://components.espressif.com/components/espressif/usb_host_hid)
 
-This directory contains an implementation of a USB HID Driver implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
+This directory contains an implementation of a USB HID Driver implemented on top of the [USB Host Library](https://components.espressif.com/components/espressif/usb).
 
 HID driver allows access to HID devices.
 

--- a/host/class/msc/usb_host_msc/README.md
+++ b/host/class/msc/usb_host_msc/README.md
@@ -2,7 +2,7 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_msc/badge.svg)](https://components.espressif.com/components/espressif/usb_host_msc)
 
-This directory contains an implementation of a USB Mass Storage Class Driver implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
+This directory contains an implementation of a USB Mass Storage Class Driver implemented on top of the [USB Host Library](https://components.espressif.com/components/espressif/usb).
 
 MSC driver allows access to USB flash drivers using the BOT (Bulk-Only Transport) protocol and the Transparent SCSI command set.
 

--- a/host/class/uac/usb_host_uac/README.md
+++ b/host/class/uac/usb_host_uac/README.md
@@ -2,7 +2,7 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_uac/badge.svg)](https://components.espressif.com/components/espressif/usb_host_uac) ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg) ![changelog](https://img.shields.io/badge/Keep_a_Changelog-blue?logo=keepachangelog&logoColor=E05735)
 
-This directory contains an implementation of a USB UAC Driver implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
+This directory contains an implementation of a USB UAC Driver implemented on top of the [USB Host Library](https://components.espressif.com/components/espressif/usb).
 
 UAC driver allows access to UAC 1.0 devices.
 

--- a/host/class/uvc/usb_host_uvc/README.md
+++ b/host/class/uvc/usb_host_uvc/README.md
@@ -2,7 +2,7 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_uvc/badge.svg)](https://components.espressif.com/components/espressif/usb_host_uvc) ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg) ![changelog](https://img.shields.io/badge/Keep_a_Changelog-blue?logo=keepachangelog&logoColor=E05735)
 
-This component contains an implementation of a USB Host UVC Class Driver that is implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
+This component contains an implementation of a USB Host UVC Class Driver that is implemented on top of the [USB Host Library](https://components.espressif.com/components/espressif/usb).
 
 The UVC driver allows video streaming from USB cameras.
 

--- a/host/usb/idf_component.yml
+++ b/host/usb/idf_component.yml
@@ -2,7 +2,7 @@
 description: USB Host library
 version: "1.2.0"
 url: https://github.com/espressif/esp-usb/tree/master/host/usb
-documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html"
+documentation: "https://docs.espressif.com/projects/esp-usb/en/latest/esp32p4/usb_host.html"
 issues: "https://github.com/espressif/esp-usb/issues"
 repository: "https://github.com/espressif/esp-usb.git"
 repository_info:


### PR DESCRIPTION
This is part of docs migration from IDF programming guide to docs.espressif.com/esp-usb