### PR TITLE
fix(host): Limit max endpoints in interface to 32

### DIFF
--- a/host/usb/include/usb/usb_helpers.h
+++ b/host/usb/include/usb/usb_helpers.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -79,7 +79,7 @@ int usb_parse_interface_number_of_alternate(const usb_config_desc_t *config_desc
  * @param[in] bInterfaceNumber Interface number
  * @param[in] bAlternateSetting Alternate setting number
  * @param[out] offset Byte offset of the interface descriptor relative to the start of the configuration descriptor. Can be NULL.
- * @return const usb_intf_desc_t* Pointer to interface descriptor, NULL if not found.
+ * @return const usb_intf_desc_t* Pointer to interface descriptor, NULL if not found or invalid (e.g., too many endpoints) descriptor
  */
 const usb_intf_desc_t *usb_parse_interface_descriptor(const usb_config_desc_t *config_desc, uint8_t bInterfaceNumber, uint8_t bAlternateSetting, int *offset);
 

--- a/host/usb/include/usb/usb_types_ch9.h
+++ b/host/usb/include/usb/usb_types_ch9.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -431,6 +431,11 @@ ESP_STATIC_ASSERT(sizeof(usb_iad_desc_t) == USB_IAD_DESC_SIZE, "Size of usb_iad_
  * @brief Size of a USB interface descriptor in bytes
  */
 #define USB_INTF_DESC_SIZE      9
+
+/**
+ * @brief Maximum number of endpoints in a USB interface descriptor
+ */
+#define USB_MAX_ENDPOINTS_PER_INTERFACE  32 // 16 IN and 16 OUT
 
 /**
  * @brief Structure representing a USB interface descriptor

--- a/host/usb/src/usb_helpers.c
+++ b/host/usb/src/usb_helpers.c
@@ -107,8 +107,16 @@ const usb_intf_desc_t *usb_parse_interface_descriptor(const usb_config_desc_t *c
         // Get the next interface descriptor
         next_intf_desc = (const usb_intf_desc_t *)usb_parse_next_descriptor_of_type((const usb_standard_desc_t *)next_intf_desc, config_desc->wTotalLength, USB_B_DESCRIPTOR_TYPE_INTERFACE, &offset_temp);
     }
-    if (next_intf_desc != NULL && offset != NULL) {
-        *offset = offset_temp;
+
+    if (next_intf_desc != NULL) {
+        // In case offset was provided, set it
+        if (offset != NULL) {
+            *offset = offset_temp;
+        }
+        // Check if the interface descriptor has too many endpoints
+        if (next_intf_desc->bNumEndpoints > USB_MAX_ENDPOINTS_PER_INTERFACE) {
+            return NULL;    // Too many endpoints, invalid descriptor
+        }
     }
     return next_intf_desc;
 }


### PR DESCRIPTION
fix(host): Limit max endpoints in interface to 32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches USB descriptor parsing used by interface claiming/allocation; while the change is small and guarded by tests, it can cause previously-accepted (but likely invalid) devices/descriptors to be rejected.
> 
> **Overview**
> USB host descriptor parsing now **rejects interface descriptors with more than 32 endpoints**.
> 
> This introduces `USB_MAX_ENDPOINTS_PER_INTERFACE` (32) and updates `usb_parse_interface_descriptor()` to return `NULL` when `bNumEndpoints` exceeds that limit, with a new unit test covering the invalid-descriptor case; header comments are updated to document the new failure mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c546816048e449f11c57ca9a1e0541e592d04c07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->