### PR TITLE
feat(ci): Use esp32p4 ECO runners

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -141,8 +141,14 @@ jobs:
             idf_ver: "release-v6.0"
           - test_app: host_native
             idf_ver: "latest"
+        include:
+          # Use only ECO4 runners by default for now
+          - idf_target: "esp32p4"
+            eco: "eco4"
+          - idf_target: "esp32s2"
+            eco: "ARM64"
 
-    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
+    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}", "${{ matrix.eco}}"]
     container:
       image: python:3.11-bookworm
       options: --privileged --device-cgroup-rule="c 188:* rmw" --device-cgroup-rule="c 166:* rmw"


### PR DESCRIPTION
## Description

New ECO6 runners were added to the CI. Use just ECO4, as the default build is for ECO4 until #407 is finalized

## Related

- #407 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that affects runner selection; main risk is mislabeling matrix values causing jobs to not find a matching runner.
> 
> **Overview**
> Routes the USB test-app `run` job to specific self-hosted runner pools by adding an `eco` dimension to the job matrix and appending it to `runs-on`.
> 
> Defaults `esp32p4` runs to `eco4` runners (and sets `esp32s2` to `ARM64`) to avoid picking up newly added ECO6 runners while ECO4 remains the intended default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e0af2773bc6bcaa670f163233c39b557e402379. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->