### PR TITLE
fix(cdc_acm_test): Fix auto_suspend_multiple_threads test

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
@@ -985,6 +985,9 @@ TEST_CASE("automatic_suspend_timer", "[cdc_acm]")
         TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_data_tx_blocking(cdc_dev, tx_buf, sizeof(tx_buf), 1000));
     }
 
+    // Let the transfer to finish before disabling the timer, to make sure that the timer won't interfere with the ongoing transfer
+    vTaskDelay(10);
+
     // Disable the Periodic auto suspend timer
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_auto_suspend(USB_HOST_LIB_AUTO_SUSPEND_PERIODIC, 0));
     // Make sure no event is delivered


### PR DESCRIPTION
## Fixing test cases

- auto_suspend_multiple_threads
    - failing test esp32p4 ECO6
- automatic_suspend_timer
    - failing on esp32s2 (ongoing transfer was retriggering timer after the suspend timer was disabled)


<details>
<summary> automatic_suspend_timer </summary>

```bash
Running automatic_suspend_timer...
USB Host installed
Installing CDC-ACM driver
Opening CDC-ACM device
Get AUTO_SUSPEND
W (915456) USB HOST: Suspending the root port but transfers still submitted
Device suspended event
Device resumed event
Get AUTO_SUSPEND
W (918526) USB HOST: Suspending the root port but transfers still submitted
Device suspended event
Device resumed event
Data received
Get AUTO_SUSPEND
W (919596) USB HOST: Suspending the root port but transfers still submitted
Device suspended event
Device resumed event
Data received
Get AUTO_SUSPEND
W (920666) USB HOST: Suspending the root port but transfers still submitted
Device suspended event
Device resumed event
Data received
Get AUTO_SUSPEND
W (921736) USB HOST: Suspending the root port but transfers still submitted
Device suspended event
./main/test_cdc_acm_host.cpp:341:automatic_suspend_timer:FAIL:Function [cdc_acm].  Expecting NO event, but a device event 4 delivered at ./main/test_cdc_acm_host.cpp:991\nMALLOC_CAP_8BIT usage: Free memory delta: -29500 Leak threshold: -40 
MALLOC_CAP_8BIT critical leak: Before 240860 bytes free, After 211360 bytes free (delta 29500)

Test ran in 7862ms

-----------------------
1 Tests 1 Failures 0 Ignored 
FAIL
Enter next test, or 'enter' to see menu
```

</details>



## Related

- Closes IDF-15358

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
