### PR TITLE
docs(host): Add note about max transfer size

### DIFF
--- a/host/usb/include/usb/usb_host.h
+++ b/host/usb/include/usb/usb_host.h
@@ -662,6 +662,11 @@ esp_err_t usb_host_endpoint_clear(usb_device_handle_t dev_hdl, uint8_t bEndpoint
  * - A transfer object can be re-used indefinitely
  * - A transfer can be submitted using usb_host_transfer_submit() or usb_host_transfer_submit_control()
  *
+ * @note Maximum transfer size depends on hardware configuration and endpoint bMaxPacketSize, thus it is not checked on allocation.
+ *       Maximum transfer size is determined as follows:
+ *       - ESP32-S2, S3, H4, P4-OTG1.1 and P4-OTG2.0 revision < 3 = MIN(65535,   127 * bMaxPacketSize)
+ *       - ESP32-P4-OTG2.0 revision >= 3                          = MIN(524287, 1023 * bMaxPacketSize)
+ *
  * @param[in] data_buffer_size Size of the transfer's data buffer
  * @param[in] num_isoc_packets Number of isochronous packets in transfer (set to 0 for non-isochronous transfers)
  * @param[out] transfer Transfer object


### PR DESCRIPTION
Added a note about maximum transfer sizes.

We will check this in runtime after relevant changes in esp-idf/esp_hal_usb are merged.

## Related
- Original bug report https://github.com/espressif/esp-idf/issues/17927
- Original PR with fix https://github.com/espressif/esp-usb/pull/347