### PR TITLE
feat(esp_tinyusb): Add Kconfig option for Vendor specific buffers

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - esp_tinyusb: Fixed VBUS monitoring feature on ESP32-P4 USB OTG 2.0 (HS)
+- Vendor class: Add configuration options for TX/RX buffers
 
 ## 2.1.0
 

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -318,5 +318,41 @@ menu "TinyUSB Stack"
             range 0 2
             help
                 Setting value greater than 0 will enable TinyUSB Vendor specific feature.
+
+        config TINYUSB_VENDOR_RX_BUFSIZE
+            depends on (TINYUSB_VENDOR_COUNT > 0)
+            int "Vendor specific FIFO size of RX channel"
+            default 512 if IDF_TARGET_ESP32P4
+            default 64
+            range 0 32768
+            help
+                This buffer size defines maximum data length in bytes that you can receive at once.
+
+                Note: Unlike other USB classes, the vendor class supports setting buffer sizes to 0
+                to disable internal buffering. When disabled, RX data goes directly to tud_vendor_rx_cb(),
+                the tud_vendor_read() function is not available and application must handle data in the callback.
+
+        config TINYUSB_VENDOR_TX_BUFSIZE
+            depends on (TINYUSB_VENDOR_COUNT > 0)
+            int "Vendor specific FIFO size of TX channel"
+            default 512 if IDF_TARGET_ESP32P4
+            default 64
+            range 0 32768
+            help
+                This buffer size defines maximum data length in bytes that you can transmit at once.
+
+                Note: Unlike other USB classes, the vendor class supports setting buffer sizes to 0
+                to disable internal buffering. When disabled, tud_vendor_write() bypasses internal software FIFO.
+
+        config TINYUSB_VENDOR_EPSIZE
+            depends on (TINYUSB_VENDOR_COUNT > 0)
+            int "Vendor specific Endpoint buffer size"
+            default 512 if IDF_TARGET_ESP32P4
+            default 64
+            range 64 32768
+            help
+                This low layer buffer has the most significant impact on performance. Set to 8192 for best performance.
+                Sizes above 8192 bytes bring only little performance improvement.
+
     endmenu # "Vendor Specific Interface"
 endmenu # "TinyUSB Stack"

--- a/device/esp_tinyusb/include/tusb_config.h
+++ b/device/esp_tinyusb/include/tusb_config.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2019 Ha Thach (tinyusb.org),
- * SPDX-FileContributor: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileContributor: 2020-2026 Espressif Systems (Shanghai) CO LTD
  * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org),
@@ -30,6 +30,7 @@
 
 #include "tusb_option.h"
 #include "sdkconfig.h"
+#include "esp_assert.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -156,8 +157,24 @@ extern "C" {
 #define CFG_TUD_MIDI_TX_BUFSIZE     64
 
 // Vendor FIFO size of TX and RX
-#define CFG_TUD_VENDOR_RX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
-#define CFG_TUD_VENDOR_TX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_VENDOR_RX_BUFSIZE   CONFIG_TINYUSB_VENDOR_RX_BUFSIZE
+#define CFG_TUD_VENDOR_TX_BUFSIZE   CONFIG_TINYUSB_VENDOR_TX_BUFSIZE
+#define CFG_TUD_VENDOR_EPSIZE       CONFIG_TINYUSB_VENDOR_EPSIZE
+
+#if (CFG_TUD_VENDOR > 0)
+#if (CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED)
+#define EP_SIZE_VENDOR   512
+#else
+#define EP_SIZE_VENDOR   64
+#endif
+ESP_STATIC_ASSERT(CFG_TUD_VENDOR_EPSIZE >= EP_SIZE_VENDOR, "Vendor EP size must be at least 64 for FS and 512 for HS");
+#if (CFG_TUD_VENDOR_RX_BUFSIZE > 0)
+ESP_STATIC_ASSERT(CFG_TUD_VENDOR_RX_BUFSIZE >= EP_SIZE_VENDOR, "Vendor RX buffer size must be at least equal to EP size");
+#endif
+#if (CFG_TUD_VENDOR_TX_BUFSIZE > 0)
+ESP_STATIC_ASSERT(CFG_TUD_VENDOR_TX_BUFSIZE >= EP_SIZE_VENDOR, "Vendor TX buffer size must be at least equal to EP size");
+#endif
+#endif
 
 // DFU macros
 #define CFG_TUD_DFU_XFER_BUFSIZE    CONFIG_TINYUSB_DFU_BUFSIZE


### PR DESCRIPTION
Add option to configure Vendor specific class buffer via menuconfig

Closes https://github.com/espressif/esp-usb/pull/426