### PR TITLE
fix(ci): Run idf examples in CI

### DIFF
--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -199,23 +199,25 @@ jobs:
     env:
       EXAMPLES_PATH: ${{ github.workspace }}
     steps:
+      - uses: actions/checkout@v5
       - name: ⚙️ Install System tools
         run: |
           apt-get update -y
           apt-get install -y --no-install-recommends net-tools
+      - name: ⚙️ Install Python packages
+        env:
+          PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
+        run: pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb netifaces idf-ci pytest-ignore-test-results
       - name: Setup IDF Examples path
       # Create matrix-specific directory name and save it's path to the EXAMPLES_PATH variable
         run: |
           EXAMPLES_DIR="idf_examples_${{ matrix.idf_ver }}_${{ matrix.idf_target }}_${{ matrix.runner_tag }}"
           mkdir -p "$EXAMPLES_DIR" && cd "$EXAMPLES_DIR" && pwd
           echo "EXAMPLES_PATH=$(pwd)" >> "$GITHUB_ENV"
-      - name: ⚙️ Install Python packages
-        env:
-          PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
-        run: pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb netifaces idf-ci pytest-ignore-test-results
       - uses: actions/download-artifact@v7
         with:
           name: usb_examples_bin_${{ matrix.idf_ver }}
           path: ${{ env.EXAMPLES_PATH }}
       - name: Run USB Test App on target
-        run: pytest ${{ env.EXAMPLES_PATH }}/${{ matrix.example }} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases="*ncm_example*" --ignore-no-tests-collected-error
+        run: |
+          pytest ${{ env.EXAMPLES_PATH }}/${{ matrix.example }} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases="*ncm_example*"

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ markers =
   host_test: linux host test
   eco_default: target runner with latest ECO version
   esp32p4_eco4: esp32p4 runner with esp32p4 ECO4 version
+  temp_skip_ci: to remove esp-idf examples CI run warnings about unknown markers
 
 # ignore PytestExperimentalApiWarning for record_xml_attribute
 filterwarnings =


### PR DESCRIPTION
## Description

idf-examples are not run on target CI runners

```sh
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
rootdir: /__w/esp-usb/esp-usb
configfile: pytest.ini
plugins: idf-ci-0.7.0, ignore-test-results-0.3.0, embedded-2.6.0, timeout-2.4.0, rerunfailures-16.1
collected 20 items / 20 deselected / 0 selected

=============================== warnings summary ===============================
```

Pytest files are collected correctly, but all are deselected and no tests are run.

This PR:
- Fixes the tests collection
- Removes `--ignore-no-tests-collected-error` which was giving us false positive test pass (even though no tests were run)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
