### PR TITLE
docs: Fix outdated CDC example links

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/README.md
+++ b/host/class/cdc/usb_host_cdc_acm/README.md
@@ -47,6 +47,5 @@ Use `CDC_HOST_ANY_*` macros to signal to `cdc_acm_host_open()` function that you
 
 ## Examples
 
-- For an example with a CDC-ACM device, refer to [cdc_acm_host](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc/cdc_acm_host)
-- For an example with Virtual COM devices, refer to [cdc_acm_vcp](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc/cdc_acm_vcp)
+- For an example with a CDC-ACM device, or Virtual COM Port device refer to [cdc example in esp-idf](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc)
 - For examples with [esp_modem](https://components.espressif.com/components/espressif/esp_modem), refer to [esp_modem examples](https://github.com/espressif/esp-protocols/tree/master/components/esp_modem/examples)

--- a/host/usb/README.md
+++ b/host/usb/README.md
@@ -62,8 +62,7 @@ usb_host_install(&host_config);
 
 Refer to following examples, using USB Host library from esp-idf:
 
-- [CDC-ACM Host](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc/cdc_acm_host)
-- [CDC-ACM VCP](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc/cdc_acm_vcp)
+- [CDC Host](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc)
 - [HID Host](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/hid)
 - [MSC Host](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/msc)
 - [USB Host Library](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/usb_host_lib)


### PR DESCRIPTION
Documentation in .rst file was update, but I forgot about 2 .md files