### PR TITLE
fix(usb_dte): Remove workaround for old esp_modem versions

### DIFF
--- a/host/class/cdc/esp_modem_usb_dte/CHANGELOG.md
+++ b/host/class/cdc/esp_modem_usb_dte/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a known issue with fragmented AT responses and ESP32-P4. The issue was fixed in [esp_modem 1.1.0](https://github.com/espressif/esp-protocols/pull/472) and the workaround was removed from esp_modem_usb_dte
+
 ## [1.3.0] - 2025-12-19
 
 ### Added

--- a/host/class/cdc/esp_modem_usb_dte/README.md
+++ b/host/class/cdc/esp_modem_usb_dte/README.md
@@ -1,8 +1,6 @@
 # USB DTE plugin for esp_modem
 
-[![Component Registry](https://components.espressif.com/components/espressif/esp_modem_usb_dte/badge.svg)](https://components.espressif.com/components/espressif/esp_modem_usb_dte) ![maintenance-status](https://img.shields.io/badge/maintenance-experimental-blue.svg) ![changelog](https://img.shields.io/badge/Keep_a_Changelog-blue?logo=keepachangelog&logoColor=E05735)
-
-> :warning: **Experimental feature**: USB DTE is under development!
+[![Component Registry](https://components.espressif.com/components/espressif/esp_modem_usb_dte/badge.svg)](https://components.espressif.com/components/espressif/esp_modem_usb_dte) ![maintenance-status](https://img.shields.io/badge/maintenance-passively--maintained-yellowgreen.svg) ![changelog](https://img.shields.io/badge/Keep_a_Changelog-blue?logo=keepachangelog&logoColor=E05735)
 
 This component extends [esp_modem](https://components.espressif.com/component/espressif/esp_modem) with USB DTE.
 
@@ -53,11 +51,11 @@ For simple cases with one AT port, you should be able to open communication with
 1. **USB VID and PID:** This can be found by plugging the modem to a PC and running `lsusb -v` on Linux or by [USB Device Tree Viewer](https://www.uwe-sieber.de/usbtreeview_e.html) on Windows.
 2. **AT port interface number:** USB modems have usually multiple CDC-ACM-like ports. One (or two) is dedicated for AT commands. You can find the correct interface number based on its string descriptor (using methods from point 1), from the modem's datasheet or by trial and error.
 
-Then, you can pass these constants to [ESP_MODEM_DEFAULT_USB_CONFIG](https://github.com/espressif/idf-extra-components/blob/master/usb/esp_modem_usb_dte/include/esp_modem_usb_config.h#L47) macro and start testing AT commands.
+Then, you can pass these constants to [ESP_MODEM_DEFAULT_USB_CONFIG](https://github.com/espressif/esp-usb/blob/master/host/class/cdc/esp_modem_usb_dte/include/esp_modem_usb_config.h#L60) macro and start testing AT commands.
 
 ## List of tested modems
 
-The following modems were tested with this component, their configurations can be found in [esp_modem_usb_config.h](https://github.com/espressif/idf-extra-components/blob/master/usb/esp_modem_usb_dte/include/esp_modem_usb_config.h):
+The following modems were tested with this component, their configurations can be found in [esp_modem_usb_config.h](https://github.com/espressif/esp-usb/blob/master/host/class/cdc/esp_modem_usb_dte/include/esp_modem_usb_config.h):
 
 - Quectel BG96
 - Quectel EC20

--- a/host/class/cdc/esp_modem_usb_dte/esp_modem_usb.cpp
+++ b/host/class/cdc/esp_modem_usb_dte/esp_modem_usb.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -137,11 +137,11 @@ private:
         ESP_LOG_BUFFER_HEXDUMP(TAG, data, data_len, ESP_LOG_DEBUG);
         auto *this_terminal = static_cast<UsbTerminal *>(user_arg);
         if (data_len > 0 && this_terminal->on_read) {
-            return this_terminal->on_read((uint8_t *)data, data_len);
+            this_terminal->on_read((uint8_t *)data, data_len);
         } else {
             ESP_LOGD(TAG, "Unhandled RX data");
-            return true;
         }
+        return true;
     }
 
     static void handle_notif(const cdc_acm_host_dev_event_data_t *event, void *user_ctx)

--- a/host/class/cdc/esp_modem_usb_dte/idf_component.yml
+++ b/host/class/cdc/esp_modem_usb_dte/idf_component.yml
@@ -16,4 +16,4 @@ dependencies:
   usb_host_cdc_acm:
     version: "^2.2"
     override_path: "../usb_host_cdc_acm"
-  esp_modem: ">=1,<3"
+  esp_modem: ">=1.1,<3"


### PR DESCRIPTION
The original issue was fixed in esp_modem v1.1 PR: https://github.com/espressif/esp-protocols/pull/472 so we can now safely remove the workaround in esp_mode_usb_dte

Closes https://github.com/espressif/esp-usb/issues/374
