### PR TITLE
release(cdc): Release usb_host_cdc_acm 2.4.0

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.0] - 2026-04-14
 
 ### Added
 
 - Added remote wakeup feature
 - Added option to open a CDC device with specific USB address
+- Added support for ESP32-S31
 
 ## [2.3.0] - 2026-01-23
 

--- a/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
@@ -826,7 +826,7 @@ static void in_xfer_cb(usb_transfer_t *transfer)
 #else
             // For targets that must sync internal memory through L1CACHE, we cannot change the data_buffer
             // because it would lead to unaligned cache sync, which is not allowed
-            ESP_LOGW(TAG, "RX buffer append is not yet supported on ESP32-P4!");
+            ESP_LOGW(TAG, "RX buffer append is not supported on this target!");
 #endif
         } else {
             cdc_acm_reset_in_transfer(cdc_dev);

--- a/host/class/cdc/usb_host_cdc_acm/idf_component.yml
+++ b/host/class/cdc/usb_host_cdc_acm/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.3.0"
+version: "2.4.0"
 description: USB Host CDC-ACM driver
 tags:
   - usb
@@ -24,6 +24,7 @@ targets:
   - esp32s3
   - esp32p4
   - esp32h4
+  - esp32s31
   - linux
 files:
   exclude:

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
@@ -722,7 +722,7 @@ TEST_CASE("rx_buffer", "[cdc_acm]")
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_data_tx_blocking(cdc_dev, tx_data, sizeof(tx_data), 1000));
     vTaskDelay(5);
 
-#ifdef CONFIG_IDF_TARGET_ESP32P4    // RX buffer append is not yet supported on ESP32-P4
+#if SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE
     TEST_ASSERT_FALSE_MESSAGE(rx_overflow, "RX overflow");
 #else
     TEST_ASSERT_TRUE_MESSAGE(rx_overflow, "RX did not overflow");


### PR DESCRIPTION
Closes https://github.com/espressif/esp-usb/milestone/28

## TODO
- [x] Update release date
- [x] Test on S31 hardware

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a version/metadata update plus a minor log/test conditional change; runtime behavior is effectively unchanged aside from the warning string and platform gating.
> 
> **Overview**
> Updates the `usb_host_cdc_acm` component release to **v2.4.0** (manifest version bump and changelog release entry dated 2026-04-14), including explicit *ESP32-S31* support in the component targets.
> 
> Adjusts RX-buffer-append handling messaging/expectations on targets that sync internal memory via L1 cache: the driver warning is generalized, and the `rx_buffer` test now gates overflow assertions on `SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE` instead of a hardcoded `ESP32P4` check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9759dfe1508dabb215cf283a6dd3559aeb75df28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->