### PR TITLE
fix(ci): Update codeql-action to v4

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -50,7 +50,7 @@ jobs:
             results.sarif
             results.sarif.raw
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
           category: clang-tidy


### PR DESCRIPTION
## Description

Update `codeql-action` to v4 to remove CI run warnings/errors.

```sh
Warning: CodeQL Action v3 will be deprecated in December 2026. Please update all occurrences of the CodeQL Action in your workflow files to v4. For more information, see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/
Warning: This run of the CodeQL Action does not have permission to access the CodeQL Action API endpoints. This could be because the Action is running on a pull request from a fork. If not, please ensure the workflow has at least the 'security-events: read' permission. Details: Resource not accessible by integration - https://docs.github.com/rest
```

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
