### PR TITLE
fix(host/usb): Fixed possible out-of-bounds read in usb_parse_next_descriptor

### DIFF
--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed possible out-of-bounds read in `usb_parse_next_descriptor()` in case of malicious Configuration descriptor
+
 ## [1.3.0] - 2026-03-04
 
 ### Added

--- a/host/usb/src/usb_helpers.c
+++ b/host/usb/src/usb_helpers.c
@@ -26,12 +26,18 @@ const usb_standard_desc_t *usb_parse_next_descriptor(const usb_standard_desc_t *
     if (*offset >= wTotalLength) {
         return NULL;    // We have traversed the entire configuration descriptor
     }
-    if (*offset + cur_desc->bLength >= wTotalLength) {
-        return NULL;    // Next descriptor is out of bounds
+    /*
+     * The returned pointer must address at least sizeof(usb_standard_desc_t) bytes,
+     * because callers read bLength and bDescriptorType immediately (e.g. usb_print_config_descriptor()).
+     * Reject advancing when fewer than that many bytes remain in [next_offset, wTotalLength).
+     */
+    const int next_offset = *offset + cur_desc->bLength;
+    if (next_offset + (int)sizeof(usb_standard_desc_t) > (int)wTotalLength) {
+        return NULL;    // Next descriptor start out of bounds or trailing fragment < sizeof(usb_standard_desc_t)
     }
     // Return the next descriptor, update offset
     const usb_standard_desc_t *ret_desc = (const usb_standard_desc_t *)(((uintptr_t)cur_desc) + cur_desc->bLength);
-    *offset += cur_desc->bLength;
+    *offset = next_offset;
     return ret_desc;
 }
 
@@ -40,16 +46,36 @@ const usb_standard_desc_t *usb_parse_next_descriptor_of_type(const usb_standard_
     assert(cur_desc != NULL && offset != NULL);
     int offset_temp = *offset;      // We only want to update offset if we've actually found a descriptor
     // Keep stepping over descriptors until we find one of bDescriptorType or until we go out of bounds
-    const usb_standard_desc_t *ret_desc = usb_parse_next_descriptor(cur_desc, wTotalLength, &offset_temp);
-    while (ret_desc != NULL) {
+    const usb_standard_desc_t *ret_desc = cur_desc;
+    while ((ret_desc = usb_parse_next_descriptor(ret_desc, wTotalLength, &offset_temp)) != NULL) {
         if (ret_desc->bDescriptorType == bDescriptorType) {
+            switch (bDescriptorType) {
+            case USB_B_DESCRIPTOR_TYPE_CONFIGURATION:
+                if (ret_desc->bLength < sizeof(usb_config_desc_t)) {
+                    return NULL;
+                }
+                break;
+            case USB_B_DESCRIPTOR_TYPE_INTERFACE:
+                if (ret_desc->bLength < sizeof(usb_intf_desc_t)) {
+                    return NULL;
+                }
+                break;
+            case USB_B_DESCRIPTOR_TYPE_ENDPOINT:
+                if (ret_desc->bLength < sizeof(usb_ep_desc_t)) {
+                    return NULL;
+                }
+                break;
+            case USB_B_DESCRIPTOR_TYPE_INTERFACE_ASSOCIATION:
+                if (ret_desc->bLength < sizeof(usb_iad_desc_t)) {
+                    return NULL;
+                }
+                break;
+            default:
+                break;
+            }
+            *offset = offset_temp;  // Found: advance caller's offset past descriptors we stepped over
             break;
         }
-        ret_desc = usb_parse_next_descriptor(ret_desc, wTotalLength, &offset_temp);
-    }
-    if (ret_desc != NULL) {
-        // We've found a descriptor. Update the offset
-        *offset = offset_temp;
     }
     return ret_desc;
 }

--- a/host/usb/test/host_test/usb_host_layer_test/main/usb_helpers_descriptor_parsing_test.cpp
+++ b/host/usb/test/host_test/usb_host_layer_test/main/usb_helpers_descriptor_parsing_test.cpp
@@ -439,6 +439,37 @@ TEST_CASE("USB Helpers descriptor parsing", "[helpers]")
     test_parse_ep_by_address(config_desc);
 }
 
+TEST_CASE("USB parse_next_descriptor rejects trailing fragment smaller than usb_standard_desc_t", "[helpers]")
+{
+    /*
+     * wTotalLength = 13: config (9) + 3-byte descriptor fills bytes 0..11; only 1 byte remains at offset 12.
+     * Old logic allowed returning a "next" pointer at 12 while callers read 2 bytes (OOB read).
+     * Expect NULL on the second step so the next descriptor always has room for at least USB_STANDARD_DESC_SIZE bytes.
+     */
+    constexpr uint8_t wTotalLength = 13;
+    static const uint8_t tight_config_desc_bytes[] = {
+        0x09, 0x02, wTotalLength, 0x00, 0x01, 0x01, 0x00, 0x80, 0x32, // configuration descriptor, wTotalLength = wTotalLength
+        0x03, 0x24, 0x00,                                             // 3-byte class-specific stub (bytes 9..11)
+        0x01,                                                         // byte 12 is sole trailing byte (insufficient for next header)
+    };
+    static_assert(sizeof(tight_config_desc_bytes) == wTotalLength, "Descriptor layout must match wTotalLength");
+
+    const auto *config_desc = reinterpret_cast<const usb_config_desc_t *>(tight_config_desc_bytes);
+    REQUIRE(config_desc->wTotalLength == wTotalLength);
+
+    int offset = 0;
+    // Get first descriptor after configuration descriptor
+    const auto *cur = reinterpret_cast<const usb_standard_desc_t *>(config_desc);
+    cur = usb_parse_next_descriptor(cur, config_desc->wTotalLength, &offset);
+    REQUIRE(cur != nullptr);
+    REQUIRE(offset == 9);
+
+    // Getting second descriptor should return NULL
+    cur = usb_parse_next_descriptor(cur, config_desc->wTotalLength, &offset);
+    REQUIRE(cur == nullptr);
+    REQUIRE(offset == 9); // failure: offset must not advance past a non-existent next descriptor
+}
+
 TEST_CASE("USB descriptor parsing with bLength=0", "[helpers]")
 {
     // Minimal config descriptor containing a descriptor with bLength=0


### PR DESCRIPTION
Fixed possible out-of-bounds read in `usb_parse_next_descriptor()` in case of malicious Configuration descriptor