### PR TITLE
usb_host_uvc urb_size clamp inverted (IEC-505)

### DIFF
--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -836,7 +836,7 @@ esp_err_t uvc_host_stream_open(const uvc_host_stream_config_t *stream_config, in
         err, TAG, "Failed to negotiate requested Video Stream format");
 
     // check if the urb_size is smaller than the maximum payload transfer size
-    size_t urb_size = stream_config->advanced.urb_size > vs_result.dwMaxPayloadTransferSize ?
+    size_t urb_size = stream_config->advanced.urb_size < vs_result.dwMaxPayloadTransferSize ?
                       vs_result.dwMaxPayloadTransferSize : stream_config->advanced.urb_size;
     // Allocate USB transfers
     ESP_GOTO_ON_ERROR(


### PR DESCRIPTION
## Description

`dwMaxPayloadTransferSize` is the max bytes in one isochronous payload, not one URB. With the clamp inverted, every ISOC URB is forced to exactly 1 packet.

On a Full-Speed host (1ms bus frames) this means the UVC driver task must complete and resubmit each URB within 1ms to catch consecutive slots.

On single-core chips (ESP32-S2) running WiFi at priority 23, this deadline cannot be met -- every packet is marked `USB_TRANSFER_STATUS_SKIPPED`, which `uvc_isoc.c` silently ignores. Result: `frame_cb` never fires, zero frames,
no error.

The comment above the change in this PR already states correctly "check if urb_size is *smaller* than maximum payload transfer size".

## Testing

Observed: 256×196 YUY2 camera, dwMaxPayloadTransferSize=524.
Current `master` yields 1 pkt/URB, `cb=0`.
With the fix in this PR applied: 8 pkts/URB (48ms pipeline), URBs complete at full rate.

