### PR TITLE
feat(ci): Run idf examples in CI on IDF 5.4 release

### DIFF
--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -15,14 +15,14 @@
 # Run:
 #   - usb device examples:
 #     - usb_device target runners, with matrix of all listed releases
-#     - IDF Releases: Latest, IDF 6.0, IDF 5.5
+#     - IDF Releases: Latest, IDF 6.0, IDF 5.5, IDF 5.4
 #   - usb host examples:
 #     - usb_host_examples target runners, with matrix of all listed releases
-#     - IDF Releases: Latest, IDF 6.0, IDF 5.5
+#     - IDF Releases: Latest, IDF 6.0, IDF 5.5, IDF 5.4
 #
 # Temporarily disabled tests and TODOs of this workflow:
 # - USB Device NCM example run: Ignored due to GH Runner configuration (docker needs --net=host to access host network namespace)
-# - Examples runs on targets enabled only for IDF >= 5.5
+# - Examples runs on targets enabled only for IDF >= 5.4
 
 name: Build and Run ESP-IDF USB examples
 
@@ -178,21 +178,41 @@ jobs:
       matrix:
         idf_ver:
           [
-            # Only run for IDF >= 5.5,
+            # Only run for IDF >= 5.4,
             # For lower IDF versions, running pytest files from esp-idf outside of esp-idf container is too complicated
+            "release-v5.4",
             "release-v5.5",
             "release-v6.0",
             "latest",
           ]
         idf_target: ["esp32s2", "esp32p4"]
         runner_tag: ["usb_host_flash_disk", "usb_device"]
+        eco_ver: ["eco_default", "eco4"]
         include:
           # Assign a folder structure to a target runner
           - runner_tag: usb_host_flash_disk
             example: host
           - runner_tag: usb_device
             example: device
-    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}", eco_default]
+        exclude:
+          # Exclude eco4 version for esp32s2
+          - idf_target: "esp32s2"
+            eco_ver: "eco4"
+          # Exclude eco_default for older IDF versions, esp32p4 ECO6 support starts in IDF 5.5
+          - idf_target: "esp32p4"
+            eco_ver: "eco_default"
+            idf_ver: "release-v5.4"
+          # Exclude eco4 for newer IDF versions, esp32p4 ECO6 is default in IDF 5.5 and later
+          - idf_target: "esp32p4"
+            eco_ver: "eco4"
+            idf_ver: "release-v5.5"
+          - idf_target: "esp32p4"
+            eco_ver: "eco4"
+            idf_ver: "release-v6.0"
+          - idf_target: "esp32p4"
+            eco_ver: "eco4"
+            idf_ver: "latest"
+    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}", "${{ matrix.eco_ver }}"]
     container:
       image: python:3.11-bookworm
       options: --privileged --device-cgroup-rule="c 188:* rmw" --device-cgroup-rule="c 166:* rmw"
@@ -211,7 +231,7 @@ jobs:
       - name: Setup IDF Examples path
       # Create matrix-specific directory name and save it's path to the EXAMPLES_PATH variable
         run: |
-          EXAMPLES_DIR="idf_examples_${{ matrix.idf_ver }}_${{ matrix.idf_target }}_${{ matrix.runner_tag }}"
+          EXAMPLES_DIR="idf_examples_${{ matrix.idf_ver }}_${{ matrix.idf_target }}_${{ matrix.runner_tag }}_${{ matrix.eco_ver }}"
           mkdir -p "$EXAMPLES_DIR" && cd "$EXAMPLES_DIR" && pwd
           echo "EXAMPLES_PATH=$(pwd)" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v7


### PR DESCRIPTION
Adding run of esp-idf examples for IDF 5.4 release.

After esp-idf commit [f739525](https://github.com/espressif/esp-idf/commit/f7395255da5df129958070e54ba78651f00d8df6) 

Pytest files in `IDF 5.4` use `@idf_parametrize` decorator, allowing us to run the `IDF 5.4` pytest files in `esp-usb` CI infrastructure. 

### Before
```py
@pytest.mark.esp32s2
@pytest.mark.esp32s3
@pytest.mark.esp32p4
@pytest.mark.temp_skip_ci(targets=['esp32s3'], reason='lack of runners with usb_device tag')
@pytest.mark.usb_device
def test_usb_device_serial_example(dut: Dut) -> None:
...
```

### Now
```py
@pytest.mark.temp_skip_ci(targets=['esp32s3'], reason='lack of runners with usb_device tag')
@pytest.mark.usb_device
@idf_parametrize('target', ['esp32s2', 'esp32s3', 'esp32p4'], indirect=['target'])
def test_usb_device_serial_example(dut: Dut) -> None:
...
```


## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate CI risk: expands the `run` job matrix (adds `release-v5.4` plus ECO-specific runner tags) which can increase CI load and potentially surface runner/target selection or artifact-path issues, but changes are limited to workflow logic.
> 
> **Overview**
> Extends the GitHub Actions workflow to **run USB example tests on ESP-IDF `release-v5.4`** (lowering the run-job gating from 5.5 to 5.4).
> 
> Updates the `run` job matrix to include an `eco_ver` dimension and adjusts `runs-on`/working directory naming accordingly, with explicit exclusions to avoid invalid target/ECO/IDF combinations (e.g., no `eco4` on `esp32s2`, and `esp32p4` ECO selection varying by IDF version).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87af259423bfc1040bce9040b35974d95e09151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->