### PR TITLE
feat(esp_tinyusb): Support ESP32-S31 as HS-only single-port device

### DIFF
--- a/device/esp_tinyusb/CMakeLists.txt
+++ b/device/esp_tinyusb/CMakeLists.txt
@@ -50,17 +50,17 @@ if(CONFIG_TINYUSB_NET_MODE_NCM)
          )
 endif() # CONFIG_TINYUSB_NET_MODE_NCM
 
-# Software VBUS monitoring is available only on esp32p4
-if(${target} STREQUAL "esp32p4")
+# Software VBUS monitoring is needed for chips with HS USB-OTG peripheral
+if(${target} STREQUAL "esp32p4" OR ${target} STREQUAL "esp32s31")
     list(APPEND srcs "tinyusb_vbus_monitor.c")
 
-    # VBUS monitoring on ESP32-P4 requires GPIO driver
+    # VBUS monitoring requires GPIO driver
     if(IDF_VERSION VERSION_GREATER_EQUAL "5.3")
         list(APPEND priv_req esp_driver_gpio)
     else()
         list(APPEND priv_req driver)
     endif()
-endif() # esp32p4
+endif() # esp32p4/esp32s31
 
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -137,9 +137,9 @@ menu "TinyUSB Stack"
             depends on TINYUSB_MSC_ENABLED
             int "MSC FIFO size"
             default 512 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32H4
-            default 8192 if IDF_TARGET_ESP32P4
+            default 8192 if IDF_TARGET_ESP32P4 || IDF_TARGET_ESP32S31
             range 64 8192 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32H4
-            range 64 32768 if IDF_TARGET_ESP32P4
+            range 64 32768 if IDF_TARGET_ESP32P4 || IDF_TARGET_ESP32S31
             help
                 MSC FIFO size, in bytes.
 
@@ -322,7 +322,7 @@ menu "TinyUSB Stack"
         config TINYUSB_VENDOR_RX_BUFSIZE
             depends on (TINYUSB_VENDOR_COUNT > 0)
             int "Vendor specific FIFO size of RX channel"
-            default 512 if IDF_TARGET_ESP32P4
+            default 512 if IDF_TARGET_ESP32P4 || IDF_TARGET_ESP32S31
             default 64
             range 0 32768
             help
@@ -335,7 +335,7 @@ menu "TinyUSB Stack"
         config TINYUSB_VENDOR_TX_BUFSIZE
             depends on (TINYUSB_VENDOR_COUNT > 0)
             int "Vendor specific FIFO size of TX channel"
-            default 512 if IDF_TARGET_ESP32P4
+            default 512 if IDF_TARGET_ESP32P4 || IDF_TARGET_ESP32S31
             default 64
             range 0 32768
             help
@@ -347,7 +347,7 @@ menu "TinyUSB Stack"
         config TINYUSB_VENDOR_EPSIZE
             depends on (TINYUSB_VENDOR_COUNT > 0)
             int "Vendor specific Endpoint buffer size"
-            default 512 if IDF_TARGET_ESP32P4
+            default 512 if IDF_TARGET_ESP32P4 || IDF_TARGET_ESP32S31
             default 64
             range 64 32768
             help

--- a/device/esp_tinyusb/descriptors_control.c
+++ b/device/esp_tinyusb/descriptors_control.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,18 @@
 #endif
 
 #define MAX_DESC_BUF_SIZE 32               // Max length of string descriptor (can be extended, USB supports lengths up to 255 bytes)
+
+// Whether the given port runs at High-Speed:
+//  - Multi-port chips (e.g. ESP32-P4): only TINYUSB_PORT_HIGH_SPEED_0 is HS.
+//  - Single-port HS-only chips (e.g. ESP32-S31): the only port is always HS.
+//  - Everything else: no HS port.
+#if (SOC_USB_OTG_PERIPH_NUM > 1)
+#define TINYUSB_PORT_IS_HS(port)    ((port) == TINYUSB_PORT_HIGH_SPEED_0)
+#elif CONFIG_IDF_TARGET_ESP32S31
+#define TINYUSB_PORT_IS_HS(port)    (true)
+#else
+#define TINYUSB_PORT_IS_HS(port)    (false)
+#endif
 
 static const char *TAG = "tusb_desc";
 
@@ -203,10 +215,10 @@ esp_err_t tinyusb_descriptors_set(tinyusb_port_t port, const tinyusb_desc_config
         s_desc_cfg.fs_cfg = config->full_speed_config;
     }
 
-#if (SOC_USB_OTG_PERIPH_NUM > 1)
-    // High-speed configuration descriptor
-    if (port == TINYUSB_PORT_HIGH_SPEED_0) {
 #if (TUD_OPT_HIGH_SPEED)
+    // High-speed configuration descriptor setup
+    // Needed for multi-port chips (e.g. P4 HS port) and HS-only single-port chips (e.g. S31)
+    if (TINYUSB_PORT_IS_HS(port)) {
         if (config->high_speed_config == NULL) {
 #if (CFG_TUD_CDC > 0 || CFG_TUD_MSC > 0 || CFG_TUD_NCM > 0)
             // We provide default config descriptors only for CDC, MSC and NCM classes
@@ -233,11 +245,10 @@ esp_err_t tinyusb_descriptors_set(tinyusb_port_t port, const tinyusb_desc_config
                                             ((tusb_desc_configuration_t *)s_desc_cfg.hs_cfg)->wTotalLength);
         s_desc_cfg.other_speed = calloc(1, other_speed_buf_size);
         ESP_GOTO_ON_FALSE(s_desc_cfg.other_speed, ESP_ERR_NO_MEM, fail, TAG, "Other speed memory allocation error");
-#endif // TUD_OPT_HIGH_SPEED
     } else {
         s_desc_cfg.hs_cfg = NULL;
     }
-#endif // (SOC_USB_OTG_PERIPH_NUM > 1)
+#endif // TUD_OPT_HIGH_SPEED
 
     // Select String Descriptors and count them
     if (config->string == NULL) {

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -11,8 +11,12 @@ targets:
   - esp32s3
   - esp32p4
   - esp32h4
+  - esp32s31
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
-    version: '>=0.17.0~2' # 0.17.0~2 is the first version that supports deinit
+    version: '>=0.19.0~3-rc1'
     public: true
+files:
+  exclude:
+    - "test_apps"

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -11,8 +11,9 @@ targets:
   - esp32s3
   - esp32p4
   - esp32h4
+  - esp32s31
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
-    version: '>=0.17.0~2' # 0.17.0~2 is the first version that supports deinit
+    version: '>=0.19.0~3-rc1'
     public: true

--- a/device/esp_tinyusb/include/tinyusb_default_config.h
+++ b/device/esp_tinyusb/include/tinyusb_default_config.h
@@ -28,7 +28,7 @@ extern "C" {
  * - `TINYUSB_DEFAULT_CONFIG(event_cb)`
  * - `TINYUSB_DEFAULT_CONFIG(event_cb, event_arg)`
  *
- * The default port is `TINYUSB_PORT_HIGH_SPEED_0` on ESP32-P4 and
+ * The default port is `TINYUSB_PORT_HIGH_SPEED_0` on ESP32-P4 and ESP32-S31.
  * `TINYUSB_PORT_FULL_SPEED_0` on other supported targets. The default task
  * settings come from TINYUSB_TASK_DEFAULT().
  */
@@ -40,7 +40,18 @@ extern "C" {
                                                                 )(__VA_ARGS__)
 
 /** @cond INTERNAL */
-#if CONFIG_IDF_TARGET_ESP32P4
+// Helper: default high-speed port index. Only defined on HS-capable targets:
+//  - Multi-port chips (e.g. ESP32-P4) have a dedicated HS port enum value.
+//  - Single-port HS-only chips (e.g. ESP32-S31) use port 0, which is inherently HS.
+// On FS-only targets (e.g. ESP32-S2/S3/H4) this macro is intentionally left
+// undefined so that any use of TINYUSB_CONFIG_HIGH_SPEED fails to compile.
+#if (SOC_USB_OTG_PERIPH_NUM > 1)
+#define TINYUSB_PORT_DEFAULT_HS  TINYUSB_PORT_HIGH_SPEED_0
+#elif CONFIG_IDF_TARGET_ESP32S31
+#define TINYUSB_PORT_DEFAULT_HS  TINYUSB_PORT_FULL_SPEED_0
+#endif
+
+#if CONFIG_IDF_TARGET_ESP32P4 || CONFIG_IDF_TARGET_ESP32S31
 #define TINYUSB_CONFIG_NO_ARG()                  TINYUSB_CONFIG_HIGH_SPEED(NULL, NULL)
 #define TINYUSB_CONFIG_EVENT(event_hdl)          TINYUSB_CONFIG_HIGH_SPEED(event_hdl, NULL)
 #define TINYUSB_CONFIG_EVENT_ARG(event_hdl, arg) TINYUSB_CONFIG_HIGH_SPEED(event_hdl, arg)
@@ -111,12 +122,17 @@ extern "C" {
  * settings from TINYUSB_TASK_DEFAULT(), and empty descriptor pointers so the
  * stack can fall back to built-in defaults when available.
  *
+ * @note Only defined on high-speed-capable targets (e.g. ESP32-P4, ESP32-S31).
+ *       Using this macro on a full-speed-only target results in a compile-time
+ *       error; use TINYUSB_CONFIG_FULL_SPEED() there instead.
+ *
  * @param event_hdl Event callback assigned to tinyusb_config_t.event_cb.
  * @param arg User argument assigned to tinyusb_config_t.event_arg.
  */
+#if (SOC_USB_OTG_PERIPH_NUM > 1) || CONFIG_IDF_TARGET_ESP32S31
 #define TINYUSB_CONFIG_HIGH_SPEED(event_hdl, arg)       \
     (tinyusb_config_t) {                                \
-        .port = TINYUSB_PORT_HIGH_SPEED_0,              \
+        .port = TINYUSB_PORT_DEFAULT_HS,                \
         .phy = {                                        \
             .skip_setup = false,                        \
             .self_powered = false,                      \
@@ -134,6 +150,7 @@ extern "C" {
         .event_cb = (event_hdl),                        \
         .event_arg = (arg),                             \
     }
+#endif // HS-capable target
 
 /**
  * @brief Initialize a TinyUSB task configuration with default values.

--- a/device/esp_tinyusb/include/tinyusb_default_config.h
+++ b/device/esp_tinyusb/include/tinyusb_default_config.h
@@ -40,7 +40,16 @@ extern "C" {
                                                                 )(__VA_ARGS__)
 
 /** @cond INTERNAL */
-#if CONFIG_IDF_TARGET_ESP32P4
+// Helper: default high-speed port index.
+// Multi-port chips (e.g. ESP32-P4) have a dedicated HS port enum value.
+// Single-port HS-only chips (e.g. ESP32-S31) use port 0 which is inherently HS.
+#if (SOC_USB_OTG_PERIPH_NUM > 1)
+#define TINYUSB_PORT_DEFAULT_HS  TINYUSB_PORT_HIGH_SPEED_0
+#else
+#define TINYUSB_PORT_DEFAULT_HS  TINYUSB_PORT_FULL_SPEED_0
+#endif
+
+#if CONFIG_IDF_TARGET_ESP32P4 || CONFIG_IDF_TARGET_ESP32S31
 #define TINYUSB_CONFIG_NO_ARG()                  TINYUSB_CONFIG_HIGH_SPEED(NULL, NULL)
 #define TINYUSB_CONFIG_EVENT(event_hdl)          TINYUSB_CONFIG_HIGH_SPEED(event_hdl, NULL)
 #define TINYUSB_CONFIG_EVENT_ARG(event_hdl, arg) TINYUSB_CONFIG_HIGH_SPEED(event_hdl, arg)
@@ -116,7 +125,7 @@ extern "C" {
  */
 #define TINYUSB_CONFIG_HIGH_SPEED(event_hdl, arg)       \
     (tinyusb_config_t) {                                \
-        .port = TINYUSB_PORT_HIGH_SPEED_0,              \
+        .port = TINYUSB_PORT_DEFAULT_HS,                \
         .phy = {                                        \
             .skip_setup = false,                        \
             .self_powered = false,                      \

--- a/device/esp_tinyusb/include/tusb_config.h
+++ b/device/esp_tinyusb/include/tusb_config.h
@@ -87,7 +87,7 @@ extern "C" {
 
 #define CFG_TUD_ENABLED                 1       // TinyUSB Device enabled
 
-#if (CONFIG_IDF_TARGET_ESP32P4)
+#if (CONFIG_IDF_TARGET_ESP32P4) || (CONFIG_IDF_TARGET_ESP32S31)
 #define CFG_TUD_MAX_SPEED               OPT_MODE_HIGH_SPEED
 #else
 #define CFG_TUD_MAX_SPEED               OPT_MODE_FULL_SPEED
@@ -105,16 +105,22 @@ extern "C" {
 // DMA Mode has a priority over Slave/IRQ mode and will be used if hardware supports it
 #define CFG_TUD_DWC2_DMA_ENABLE     1       // Enable DMA
 
-#if CONFIG_CACHE_L1_CACHE_LINE_SIZE
-// To enable the dcd_dcache clean/invalidate/clean_invalidate calls
+// DCache maintenance is only needed when the SoC actually reaches internal
+// SRAM (where TinyUSB DMA buffers live) via the L1 cache. Just having an L1
+// cache for flash/PSRAM (CONFIG_CACHE_L1_CACHE_LINE_SIZE != 0) is not enough;
+// e.g. ESP32-S31 has L1 cache but internal SRAM is not routed through it, so
+// dcache clean/invalidate calls on USB buffers must stay disabled there.
+#if CONFIG_CACHE_L1_CACHE_LINE_SIZE && CONFIG_SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE
+// Enable dcd_dcache clean/invalidate/clean_invalidate calls
 #   define CFG_TUD_MEM_DCACHE_ENABLE    1
 #define CFG_TUD_MEM_DCACHE_LINE_SIZE    CONFIG_CACHE_L1_CACHE_LINE_SIZE
 // NOTE: starting with esp-idf v5.3 there is specific attribute present: DRAM_DMA_ALIGNED_ATTR
 #   define CFG_TUSB_MEM_SECTION         __attribute__((aligned(CONFIG_CACHE_L1_CACHE_LINE_SIZE))) DRAM_ATTR
 #else
+#   define CFG_TUD_MEM_DCACHE_ENABLE    0
 #   define CFG_TUD_MEM_CACHE_ENABLE     0
 #   define CFG_TUSB_MEM_SECTION         TU_ATTR_ALIGNED(4) DRAM_ATTR
-#endif // CONFIG_CACHE_L1_CACHE_LINE_SIZE
+#endif // CONFIG_CACHE_L1_CACHE_LINE_SIZE && CONFIG_SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE
 #endif // CONFIG_TINYUSB_MODE_DMA
 
 #define CFG_TUSB_OS                 OPT_OS_FREERTOS

--- a/device/esp_tinyusb/tinyusb.c
+++ b/device/esp_tinyusb/tinyusb.c
@@ -171,13 +171,17 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
             .otg_speed = USB_PHY_SPEED_FULL,
         };
 
-#if (SOC_USB_OTG_PERIPH_NUM > 1)
+#if CONFIG_IDF_TARGET_ESP32S31
+        // ESP32-S31 has only UTMI (HS) PHY, no internal FSLS PHY
+        phy_conf.target = USB_PHY_TARGET_UTMI;
+        phy_conf.otg_speed = USB_PHY_SPEED_HIGH;
+#elif (SOC_USB_OTG_PERIPH_NUM > 1)
         if (config->port == TINYUSB_PORT_HIGH_SPEED_0) {
             // Default PHY for OTG2.0 is UTMI
             phy_conf.target = USB_PHY_TARGET_UTMI;
             phy_conf.otg_speed = USB_PHY_SPEED_HIGH;
         }
-#endif // (SOC_USB_OTG_PERIPH_NUM > 1)
+#endif // CONFIG_IDF_TARGET_ESP32S31
 
         // OTG IOs config
         const usb_phy_otg_io_conf_t otg_io_conf = USB_PHY_SELF_POWERED_DEVICE(config->phy.vbus_monitor_io);
@@ -189,12 +193,16 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     // Init TinyUSB stack in task
     ESP_GOTO_ON_ERROR(tinyusb_task_start(config->port, &config->task, &config->descriptor), del_phy, TAG, "Init TinyUSB task failed");
 
-#if (CONFIG_IDF_TARGET_ESP32P4)
-    // Due to hardware limitations on ESP32-P4, VBUS cannot be monitored automatically by the High-Speed USB-OTG peripheral,
+#if (CONFIG_IDF_TARGET_ESP32P4) || (CONFIG_IDF_TARGET_ESP32S31)
+    // Due to hardware limitations, VBUS cannot be monitored automatically by the High-Speed USB-OTG peripheral,
     // so we need to initialize VBUS GPIO monitoring manually.
 
     // Initialize VBUS monitoring only for High-Speed ports and self-powered devices
+#if (CONFIG_IDF_TARGET_ESP32P4)
     if (config->port == TINYUSB_PORT_HIGH_SPEED_0 && config->phy.self_powered) {
+#else
+    if (config->phy.self_powered) {
+#endif
         const tinyusb_vbus_monitor_config_t vbus_cfg = {
             .gpio_num = config->phy.vbus_monitor_io,
             .port = (int)config->port,
@@ -205,7 +213,7 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
             goto del_phy;
         }
     }
-#endif // CONFIG_IDF_TARGET_ESP32P4
+#endif // CONFIG_IDF_TARGET_ESP32P4 || CONFIG_IDF_TARGET_ESP32S31
 
     s_ctx.port = config->port;              // Save the port number
     s_ctx.phy_hdl = phy_hdl;                // Save the PHY handle for uninstallation
@@ -234,7 +242,9 @@ esp_err_t tinyusb_driver_uninstall(void)
     if (s_ctx.port == TINYUSB_PORT_HIGH_SPEED_0) {
         tinyusb_vbus_monitor_deinit();
     }
-#endif // CONFIG_IDF_TARGET_ESP32P4
+#elif (CONFIG_IDF_TARGET_ESP32S31)
+    tinyusb_vbus_monitor_deinit();
+#endif // CONFIG_IDF_TARGET_ESP32P4 || CONFIG_IDF_TARGET_ESP32S31
     return ESP_OK;
 }
 

--- a/device/esp_tinyusb/tinyusb_task.c
+++ b/device/esp_tinyusb/tinyusb_task.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -131,7 +131,12 @@ esp_err_t tinyusb_task_start(tinyusb_port_t port, const tinyusb_task_config_t *c
     task_ctx->handle = NULL;                                    // TinyUSB task is not started
     task_ctx->rhport = port;                                    // Peripheral port number
     task_ctx->rhport_init.role = TUSB_ROLE_DEVICE;              // Role selection: esp_tinyusb is always a device
-    task_ctx->rhport_init.speed = (port == TINYUSB_PORT_FULL_SPEED_0) ? TUSB_SPEED_FULL : TUSB_SPEED_HIGH; // Speed selection
+    // Speed selection: ESP32-S31 is HS-only single-port chip
+#if CONFIG_IDF_TARGET_ESP32S31
+    task_ctx->rhport_init.speed = TUSB_SPEED_HIGH;
+#else
+    task_ctx->rhport_init.speed = (port == TINYUSB_PORT_FULL_SPEED_0) ? TUSB_SPEED_FULL : TUSB_SPEED_HIGH;
+#endif
     task_ctx->desc_cfg = desc_cfg;
 
     TaskHandle_t task_hdl = NULL;


### PR DESCRIPTION
## Description
This PR enables `esp_tinyusb` on ESP32-S31, which has a single HS-only USB-OTG peripheral (UTMI PHY, no internal FSLS PHY).
Previously, HS handling in `esp_tinyusb` assumed that HS implies a multi-port chip (checked via `SOC_USB_OTG_PERIPH_NUM > 1`, with the HS port being `TINYUSB_PORT_HIGH_SPEED_0`). ESP32-S31 breaks that assumption: it has only one port, and that port is always HS. The refactor replaces those checks with two small helpers:
- `TINYUSB_PORT_IS_HS(port)` — used during descriptor selection in `descriptors_control.c`
- `TINYUSB_PORT_DEFAULT_HS` — used as the default port value in `TINYUSB_CONFIG_HIGH_SPEED()`
so both multi-port HS chips (e.g. ESP32-P4) and single-port HS-only chips (e.g. ESP32-S31) are handled uniformly.
Other notable changes:
- TinyUSB dependency is bumped to `>=0.19.0~3-rc1`, which is required for ESP32-S31 support.
- The DCache enable condition in `tusb_config.h` is tightened: having an L1 cache (`CONFIG_CACHE_L1_CACHE_LINE_SIZE != 0`) is no longer sufficient — internal SRAM must also be routed through it (`CONFIG_SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE`). Otherwise DCache clean/invalidate calls on TinyUSB DMA buffers (which live in internal SRAM) are unnecessary and incorrect on S31.
- Software VBUS monitoring (previously P4-only) is now also compiled in for ESP32-S31 and initialized unconditionally for self-powered devices on that target.
## Related
IDF-14703
## Testing
Manually verified on hardware:
- **ESP32-S31 (new target)**
  - `msc device example` — MSC device enumerates and works at high speed.
  - `hid device example` — HID device enumerates and works at high speed.
- **ESP32-S2 (regression check)**
  - `msc device example` — MSC device still enumerates and works at full speed, confirming the HS refactor does not break existing FS-only single-port targets.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends core USB init/descriptor and DMA-cache configuration logic to handle an HS-only target and bumps the TinyUSB dependency, which could affect enumeration and DMA behavior across supported chips if assumptions are wrong.
> 
> **Overview**
> Adds **ESP32-S31** as a supported target for `esp_tinyusb`, updating default config macros and descriptor selection to treat the single port as *always high-speed* (vs. the previous “HS implies multi-port” assumption).
> 
> Updates runtime init to use the UTMI PHY and HS speed on S31, enables software VBUS monitoring for S31 (and includes the GPIO dependency), and adjusts TinyUSB task port-speed selection accordingly.
> 
> Bumps the `tinyusb` component requirement to `>=0.19.0~3-rc1`, tightens the DMA DCache enable condition to require `CONFIG_SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE`, and updates Kconfig buffer-size defaults/ranges for HS-capable targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb9b4db804b3b5beb77dc1868fe76a94e3dc1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->