### PR TITLE
Revert "ci: Temporarily disable S31 device examples builds"

### DIFF
--- a/.github/ci/.idf-build-examples-rules.yml
+++ b/.github/ci/.idf-build-examples-rules.yml
@@ -3,9 +3,6 @@
 examples/peripherals/usb/device:
   disable:
     - if: SOC_USB_OTG_SUPPORTED != 1
-    - if: IDF_TARGET == "esp32s31"
-      temporary: true
-      reason: USB device examples do not support esp32s31 yet
 
 examples/peripherals/usb/device/tusb_ncm:
   disable:

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -81,8 +81,8 @@ jobs:
             MODIFIED_FILES_FLAG="--modified-files=$CHANGED_FILES"
           fi
 
-          idf-build-apps find --paths ${{ matrix.path }} --disable-targets linux esp32s31 $MODIFIED_FILES_FLAG
-          idf-build-apps build --paths ${{ matrix.path }} --disable-targets linux esp32s31 $MODIFIED_FILES_FLAG --collect-app-info="app_info_${{ github.run_id }}.txt"
+          idf-build-apps find --paths ${{ matrix.path }} --disable-targets linux $MODIFIED_FILES_FLAG
+          idf-build-apps build --paths ${{ matrix.path }} --disable-targets linux $MODIFIED_FILES_FLAG --collect-app-info="app_info_${{ github.run_id }}.txt"
       - name: Check if build artifacts exist
         id: check_build_artifacts
         shell: bash


### PR DESCRIPTION
This reverts commit c45eddeb952ec3edeb0dd416fbda753d1399bfb9 and https://github.com/espressif/esp-usb/commit/eb6597a3b1bb7d647888d9449d2a2bc0bade0cb5

## Related
- Created by #460 
- Blocked by https://github.com/espressif/tinyusb/pull/81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enables CI builds for `esp32s31` USB device examples, which may reintroduce previously failing builds if support is still incomplete.
> 
> **Overview**
> Removes the temporary CI disablement for `esp32s31` USB *device* examples by deleting the `esp32s31` rule from `.idf-build-examples-rules.yml`.
> 
> Updates the USB test-app workflow to stop passing `esp32s31` in `idf-build-apps --disable-targets`, allowing `esp32s31` builds to run again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c4b0e7978a6582e92cff6949456dcd2f709199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->