### PR TITLE
feat(ci): Build network examples form esp-idf

### DIFF
--- a/.github/ci/.idf-build-examples-rules.yml
+++ b/.github/ci/.idf-build-examples-rules.yml
@@ -21,3 +21,7 @@ examples/peripherals/usb/host/uvc:
       reason: Run UVC example starts using UVC driver 2.0 only on IDF version 5.5
   disable:
     - if: SOC_USB_OTG_SUPPORTED != 1
+
+examples/network/sta2eth:
+  disable:
+    - if: SOC_USB_OTG_SUPPORTED != 1 or SOC_WIFI_SUPPORTED != 1

--- a/.github/ci/.idf_build_examples_config.toml
+++ b/.github/ci/.idf_build_examples_config.toml
@@ -3,6 +3,7 @@
 paths = [
     "examples/peripherals/usb/device",      # USB Device examples
     "examples/peripherals/usb/host",        # USB Host examples
+    "examples/network/sta2eth",             # Networking example using USB Device
 ]
 
 # exclude cherryusb build

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -9,6 +9,8 @@
 #     - Overridden class drivers from esp-usb/host/class
 #       - All (service + maintenance IDF releases)
 #
+#    - Networking example using USB Device: with overridden esp_tinyusb from esp-usb/device/esp_tinyusb
+#
 #   - cherryusb examples are ignored
 #   - usb_host_lib example -> manifest file must be created for IDF < 6.0 to override usb component
 #
@@ -55,7 +57,8 @@ jobs:
     env:
       CONFIG_PATH: ${{ github.workspace }}/.github/ci/.idf_build_examples_config.toml
       MANIFEST_PATH: ${{ github.workspace }}/.github/ci/.idf-build-examples-rules.yml
-      EXAMPLES_PATH: ${{ github.workspace }}  # Will be set-up in "Setup IDF Examples path" step
+      USB_EXAMPLES_PATH: ${{ github.workspace }}  # Will be set-up in "Setup IDF Examples path" step
+      NETWORK_EXAMPLES_PATH: ${{ github.workspace }}  # Will be set-up in "Setup IDF Examples path" step
     steps:
       - uses: actions/checkout@v5
         with:
@@ -66,11 +69,18 @@ jobs:
           . ${IDF_PATH}/export.sh
           pip install --no-cache-dir idf-build-apps==3.0.1 pyyaml --upgrade
       - name: Setup IDF Examples path
-        run: echo "EXAMPLES_PATH=${IDF_PATH}/examples/peripherals/usb" >> $GITHUB_ENV
+        run: |
+
+          # USB Host and USB Device examples path
+          echo "USB_EXAMPLES_PATH=${IDF_PATH}/examples/peripherals/usb" >> $GITHUB_ENV
+
+          # Networking example using USB Device path
+          echo "NETWORK_EXAMPLES_PATH=${IDF_PATH}/examples/network/sta2eth" >> $GITHUB_ENV
       - name: Override device component
         run: |
           . ${IDF_PATH}/export.sh
-          python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${{ env.EXAMPLES_PATH }}/device/*
+          python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${{ env.USB_EXAMPLES_PATH }}/device/*
+          python .github/ci/override_managed_component.py esp_tinyusb device/esp_tinyusb ${{ env.NETWORK_EXAMPLES_PATH }}
       - name: Override class components
         # Override all class drivers for all IDF releases
         run: |
@@ -78,16 +88,16 @@ jobs:
 
           # cdc_acm_host example was merged with cdc_acm_vcp example in IDF 6.1
           # Check if the path to the cdc_acm_vcp example exist
-          if [[ -d "${{ env.EXAMPLES_PATH }}/host/cdc/cdc_acm_vcp" ]]; then
+          if [[ -d "${{ env.USB_EXAMPLES_PATH }}/host/cdc/cdc_acm_vcp" ]]; then
             VCP_EXAMPLE_EXIST=true
-            CDC_VCP_EXAMPLE_PATH="${{ env.EXAMPLES_PATH }}/host/cdc/cdc_acm_vcp"
+            CDC_VCP_EXAMPLE_PATH="${{ env.USB_EXAMPLES_PATH }}/host/cdc/cdc_acm_vcp"
           else
             VCP_EXAMPLE_EXIST=false
-            CDC_VCP_EXAMPLE_PATH="${{ env.EXAMPLES_PATH }}/host/cdc"
+            CDC_VCP_EXAMPLE_PATH="${{ env.USB_EXAMPLES_PATH }}/host/cdc"
           fi
 
           # usb_host_cdc_acm component
-          python .github/ci/override_managed_component.py usb_host_cdc_acm host/class/cdc/usb_host_cdc_acm "${{ env.EXAMPLES_PATH }}/host/cdc"
+          python .github/ci/override_managed_component.py usb_host_cdc_acm host/class/cdc/usb_host_cdc_acm "${{ env.USB_EXAMPLES_PATH }}/host/cdc"
 
           # usb_host_ch34x_vcp component
           python .github/ci/override_managed_component.py usb_host_ch34x_vcp host/class/cdc/usb_host_ch34x_vcp "$CDC_VCP_EXAMPLE_PATH"
@@ -104,19 +114,19 @@ jobs:
           fi
 
           # usb_host_hid component
-          python .github/ci/override_managed_component.py usb_host_hid host/class/hid/usb_host_hid "${{ env.EXAMPLES_PATH }}/host/hid"
+          python .github/ci/override_managed_component.py usb_host_hid host/class/hid/usb_host_hid "${{ env.USB_EXAMPLES_PATH }}/host/hid"
 
           # usb_host_msc component
-          python .github/ci/override_managed_component.py usb_host_msc host/class/msc/usb_host_msc "${{ env.EXAMPLES_PATH }}/host/msc"
+          python .github/ci/override_managed_component.py usb_host_msc host/class/msc/usb_host_msc "${{ env.USB_EXAMPLES_PATH }}/host/msc"
 
           # usb_host_uvc component
-          python .github/ci/override_managed_component.py usb_host_uvc host/class/uvc/usb_host_uvc "${{ env.EXAMPLES_PATH }}/host/uvc"
+          python .github/ci/override_managed_component.py usb_host_uvc host/class/uvc/usb_host_uvc "${{ env.USB_EXAMPLES_PATH }}/host/uvc"
 
       - name: Create component manifest file for usb_host_lib
         # Create manifest file for usb_host_lib example, because the examples do not have it for IDF < 6.0
         # and we need to override the usb component
         if: contains('release-v5.4 release-v5.5', matrix.idf_ver)
-        working-directory: ${{ env.EXAMPLES_PATH }}/host/usb_host_lib/main
+        working-directory: ${{ env.USB_EXAMPLES_PATH }}/host/usb_host_lib/main
         run: |
           python3 - << 'EOF'
           content = """## IDF Component Manager Manifest File
@@ -138,7 +148,7 @@ jobs:
         if: contains('release-v5.4 release-v5.5 release-v6.0 latest', matrix.idf_ver)
         run: |
           . ${IDF_PATH}/export.sh
-          python .github/ci/override_managed_component.py usb host/usb ${{ env.EXAMPLES_PATH }}/host/*
+          python .github/ci/override_managed_component.py usb host/usb ${{ env.USB_EXAMPLES_PATH }}/host/*
       - name: Build ESP-IDF ${{ matrix.idf_ver }} USB examples
         # Build esp-idf examples with overridden components
         shell: bash
@@ -155,18 +165,19 @@ jobs:
           idf-build-apps build --config-file ${CONFIG_PATH} --manifest-file ${MANIFEST_PATH}
 
       - uses: actions/upload-artifact@v6
-        # Upload build files, pytest files and sdkconfig files
+        # Upload build files, pytest files and sdkconfig files, only from USB Host and USB Device examples
         with:
           name: usb_examples_bin_${{ matrix.idf_ver }}
           path: |
-            ${{ env.EXAMPLES_PATH }}/**/build_esp*/bootloader/bootloader.bin
-            ${{ env.EXAMPLES_PATH }}/**/build_esp*/partition_table/partition-table.bin
-            ${{ env.EXAMPLES_PATH }}/**/build_esp*/*.bin
-            ${{ env.EXAMPLES_PATH }}/**/build_esp*/*.elf
-            ${{ env.EXAMPLES_PATH }}/**/build_esp*/flasher_args.json
-            ${{ env.EXAMPLES_PATH }}/**/build_esp*/config/sdkconfig.json
-            ${{ env.EXAMPLES_PATH }}/**/pytest_*.py
-            ${{ env.EXAMPLES_PATH }}/**/sdkconfig.*
+            ${{ env.USB_EXAMPLES_PATH }}/**/build_esp*/bootloader/bootloader.bin
+            ${{ env.USB_EXAMPLES_PATH }}/**/build_esp*/partition_table/partition-table.bin
+            ${{ env.USB_EXAMPLES_PATH }}/**/build_esp*/*.bin
+            ${{ env.USB_EXAMPLES_PATH }}/**/build_esp*/*.elf
+            ${{ env.USB_EXAMPLES_PATH }}/**/build_esp*/flasher_args.json
+            ${{ env.USB_EXAMPLES_PATH }}/**/build_esp*/config/sdkconfig.json
+            ${{ env.USB_EXAMPLES_PATH }}/**/pytest_*.py
+            ${{ env.USB_EXAMPLES_PATH }}/**/sdkconfig.*
+            !${{ env.USB_EXAMPLES_PATH }}/**/managed_components/**
           if-no-files-found: error
 
   run:
@@ -217,7 +228,7 @@ jobs:
       image: python:3.11-bookworm
       options: --privileged --device-cgroup-rule="c 188:* rmw" --device-cgroup-rule="c 166:* rmw"
     env:
-      EXAMPLES_PATH: ${{ github.workspace }}
+      USB_EXAMPLES_PATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v5
       - name: ⚙️ Install System tools
@@ -229,15 +240,15 @@ jobs:
           PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
         run: pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb netifaces idf-ci pytest-ignore-test-results
       - name: Setup IDF Examples path
-      # Create matrix-specific directory name and save it's path to the EXAMPLES_PATH variable
+      # Create matrix-specific directory name and save it's path to the USB_EXAMPLES_PATH variable
         run: |
           EXAMPLES_DIR="idf_examples_${{ matrix.idf_ver }}_${{ matrix.idf_target }}_${{ matrix.runner_tag }}_${{ matrix.eco_ver }}"
           mkdir -p "$EXAMPLES_DIR" && cd "$EXAMPLES_DIR" && pwd
-          echo "EXAMPLES_PATH=$(pwd)" >> "$GITHUB_ENV"
+          echo "USB_EXAMPLES_PATH=$(pwd)" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v7
         with:
           name: usb_examples_bin_${{ matrix.idf_ver }}
-          path: ${{ env.EXAMPLES_PATH }}
+          path: ${{ env.USB_EXAMPLES_PATH }}
       - name: Run USB Test App on target
         run: |
-          pytest ${{ env.EXAMPLES_PATH }}/${{ matrix.example }} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases="*ncm_example*"
+          pytest ${{ env.USB_EXAMPLES_PATH }}/${{ matrix.example }} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases="*ncm_example*"


### PR DESCRIPTION
## Description

Build esp-idf network examples using [usb device component](https://github.com/espressif/esp-idf/blob/master/examples/network/sta2eth/main/idf_component.yml#L3)
 
`examples/network/sta2eth` correctly built

```sh
2026-04-15T09:12:48.2445150Z (cmake) App examples/network/sta2eth, target esp32s2, sdkconfig (default), build in examples/network/sta2eth/build_esp32s2_default
2026-04-15T09:12:48.2446539Z (cmake) App examples/network/sta2eth, target esp32s3, sdkconfig (default), build in examples/network/sta2eth/build_esp32s3_default
```

## Related

- Same approach as implemented in https://github.com/espressif/tinyusb/pull/79

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI configuration/workflow wiring; main risk is inadvertently breaking the build matrix or artifact paths for existing USB example jobs.
> 
> **Overview**
> Extends the IDF examples CI to include building the networking example `examples/network/sta2eth` (in addition to existing USB host/device examples) and disables it when USB OTG or Wi‑Fi are unavailable.
> 
> Updates `build_and_run_idf_examples.yml` to manage separate `USB_EXAMPLES_PATH` and `NETWORK_EXAMPLES_PATH`, apply the `esp_tinyusb` override to `sta2eth`, and adjust artifact upload/run steps to continue operating only on USB example outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f332d2caa9986ef0f3aa7f2211fe938aed8e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->