### PR TITLE
MR: tinyusb_net — sync TX backpressure + thread-safe send_sync

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+- NCM (`tinyusb_net`): Reworked `tinyusb_net_send_sync` to wait for `tud_network_can_xmit` in the caller and defer only `tud_network_xmit`, so a momentarily full NCM TX path no longer returns immediate `ESP_FAIL` from the USB task (improves LwIP/TCP under load).
+- NCM (`tinyusb_net`): Sync path is now thread-safe (mutex + completion signaling), and `timeout` applies to the whole operation via `vTaskSetTimeOutState` / `xTaskCheckForTimeOut`; expiry returns `ESP_ERR_TIMEOUT`.
+
 ## 2.1.1
 
 - esp_tinyusb: Fixed VBUS monitoring feature on ESP32-P4 USB OTG 2.0 (HS)

--- a/device/esp_tinyusb/include/tinyusb_net.h
+++ b/device/esp_tinyusb/include/tinyusb_net.h
@@ -74,19 +74,24 @@ void tinyusb_net_deinit(void);
  * @brief Send a packet synchronously through the TinyUSB NET interface.
  *
  * @note Synchronous and asynchronous sends can be mixed.
- * @note The first synchronous send allocates synchronization primitives, which
- *       increases heap usage.
+ * @note The first synchronous send allocates a mutex and a shared completion semaphore;
+ *       each call uses a small on-stack control block for the deferred transmit.
+ * @note The same @p timeout budget covers waiting for NCM TX space (`tud_network_can_xmit`)
+ *       in the caller task and waiting for the deferred transmit on the USB stack.
+ *       With `timeout == 0`, at least one TX-ready wait iteration still runs before the
+ *       tick deadline is applied.
+ * @note If the overall deadline expires (including while waiting for TX space or for USB
+ *       completion), the function returns @ref ESP_ERR_TIMEOUT.
  *
  * @param[in] buffer Packet payload buffer.
  * @param[in] len Packet length in bytes.
  * @param[in] buff_free_arg User token passed to `free_tx_buffer`, typically the
  *                          packet buffer pointer.
- * @param[in] timeout Timeout in RTOS ticks.
+ * @param[in] timeout Timeout in RTOS ticks for the entire operation (see notes).
  *
  * @return
  *      - ESP_OK if the packet is accepted by TinyUSB for transmission
- *      - ESP_FAIL if the USB interface cannot accept the packet
- *      - ESP_ERR_TIMEOUT if the transmission does not complete before `timeout`
+ *      - ESP_ERR_TIMEOUT if TX space or USB completion does not occur within `timeout`
  *      - ESP_ERR_INVALID_STATE if the TinyUSB NET interface is not mounted
  *      - ESP_ERR_NO_MEM if internal synchronization objects cannot be allocated
  */

--- a/device/esp_tinyusb/tinyusb_net.c
+++ b/device/esp_tinyusb/tinyusb_net.c
@@ -1,10 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <assert.h>
+#include <stdlib.h>
 #include "freertos/FreeRTOS.h"
-#include "freertos/event_groups.h"
+#include "freertos/task.h"
 #include "tinyusb_net.h"
 #include "descriptors_control.h"
 #include "usb_descriptors.h"
@@ -13,6 +15,9 @@
 
 #define MAC_ADDR_LEN 6
 
+/** Yield / 1 ms delay cadence while waiting for `tud_network_can_xmit` (caller task only). */
+#define TUSB_NET_SYNC_SPIN_DELAY_EVERY 3
+
 typedef struct packet {
     void *buffer;
     void *buff_free_arg;
@@ -20,38 +25,65 @@ typedef struct packet {
     esp_err_t result;
 } packet_t;
 
+typedef struct sync_tx_job {
+    packet_t packet;
+    SemaphoreHandle_t done;
+} sync_tx_job_t;
+
 struct tinyusb_net_handle {
     bool initialized;
-    SemaphoreHandle_t buffer_sema;
-    EventGroupHandle_t  tx_flags;
+    SemaphoreHandle_t sync_mutex;
+    SemaphoreHandle_t sync_done_sem;
     tusb_net_rx_cb_t    rx_cb;
     tusb_net_free_tx_cb_t tx_buff_free_cb;
     tusb_net_init_cb_t init_cb;
     char mac_str[2 * MAC_ADDR_LEN + 1];
     void *ctx;
-    packet_t *packet_to_send;
 };
 
-const static int TX_FINISHED_BIT = BIT0;
 static struct tinyusb_net_handle s_net_obj = { };
 static const char *TAG = "tusb_net";
 
+/**
+ * @brief Wait until TinyUSB reports TX space for this length, or RTOS tick deadline expires.
+ *
+ * Wait until TinyUSB reports TX space for this length, or RTOS tick deadline expires.
+ * Caller task only. @p pxTicksToWait is the remaining budget for the entire send_sync call.
+ * At least one @c tud_network_can_xmit check runs before @c xTaskCheckForTimeOut is evaluated
+ * in the @c while (so @c timeout==0 performs a single attempt). Loop continues while the
+ * deadline has not expired.
+
+ * @param[in]    len Packet length in bytes.
+ * @param[in]    pxTimeOut Pointer to the time out structure.
+ * @param[inout] pxTicksToWait Pointer to the remaining budget for the entire send_sync call.
+ * @return true if TX space is available, false if the deadline expires.
+ */
+static bool tinyusb_net_wait_tx_ready(uint16_t len, TimeOut_t *pxTimeOut, TickType_t *pxTicksToWait)
+{
+    unsigned spin = 0;
+    do {
+        if (tud_network_can_xmit(len)) {
+            return true;
+        }
+        if (spin % TUSB_NET_SYNC_SPIN_DELAY_EVERY == (TUSB_NET_SYNC_SPIN_DELAY_EVERY - 1)) {
+            const TickType_t d = pdMS_TO_TICKS(1);
+            vTaskDelay(d > 0 ? d : 1);
+        } else {
+            taskYIELD();
+        }
+        spin++;
+    } while (xTaskCheckForTimeOut(pxTimeOut, pxTicksToWait) == pdFALSE);
+    return false;
+}
+
 static void do_send_sync(void *ctx)
 {
-    (void) ctx;
-    if (xSemaphoreTake(s_net_obj.buffer_sema, 0) != pdTRUE || s_net_obj.packet_to_send == NULL) {
-        return;
-    }
+    sync_tx_job_t *job = (sync_tx_job_t *)ctx;
 
-    packet_t *packet = s_net_obj.packet_to_send;
-    if (tud_network_can_xmit(packet->len)) {
-        tud_network_xmit(packet, packet->len);
-        packet->result = ESP_OK;
-    } else {
-        packet->result = ESP_FAIL;
-    }
-    xSemaphoreGive(s_net_obj.buffer_sema);
-    xEventGroupSetBits(s_net_obj.tx_flags, TX_FINISHED_BIT);
+    assert(tud_network_can_xmit(job->packet.len));
+    tud_network_xmit(&job->packet, job->packet.len);
+    job->packet.result = ESP_OK;
+    xSemaphoreGive(job->done);
 }
 
 static void do_send_async(void *ctx)
@@ -88,41 +120,58 @@ esp_err_t tinyusb_net_send_sync(void *buffer, uint16_t len, void *buff_free_arg,
     }
 
     // Lazy init the flags and semaphores, as they might not be needed (if async approach is used)
-    if (!s_net_obj.tx_flags) {
-        s_net_obj.tx_flags = xEventGroupCreate();
-        ESP_RETURN_ON_FALSE(s_net_obj.tx_flags, ESP_ERR_NO_MEM, TAG, "Failed to allocate event flags");
+    if (!s_net_obj.sync_mutex) {
+        s_net_obj.sync_mutex = xSemaphoreCreateMutex();
+        ESP_RETURN_ON_FALSE(s_net_obj.sync_mutex, ESP_ERR_NO_MEM, TAG, "Failed to allocate sync mutex");
     }
-    if (!s_net_obj.buffer_sema) {
-        s_net_obj.buffer_sema = xSemaphoreCreateBinary();
-        ESP_RETURN_ON_FALSE(s_net_obj.buffer_sema, ESP_ERR_NO_MEM, TAG, "Failed to allocate buffer semaphore");
+    if (!s_net_obj.sync_done_sem) {
+        s_net_obj.sync_done_sem = xSemaphoreCreateBinary();
+        ESP_RETURN_ON_FALSE(s_net_obj.sync_done_sem, ESP_ERR_NO_MEM, TAG, "Failed to allocate sync done semaphore");
     }
 
-    packet_t packet = {
-        .buffer = buffer,
-        .len = len,
-        .buff_free_arg = buff_free_arg
+    TimeOut_t time_out;
+    TickType_t ticks_remaining = timeout;
+    vTaskSetTimeOutState(&time_out);
+
+    if (!tinyusb_net_wait_tx_ready(len, &time_out, &ticks_remaining)) {
+        return ESP_ERR_TIMEOUT;
+    }
+    if (xSemaphoreTake(s_net_obj.sync_mutex, ticks_remaining) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+    (void)xTaskCheckForTimeOut(&time_out, &ticks_remaining);
+
+    // Defensive programming: make sure the semaphore is not given by another task.
+    while (xSemaphoreTake(s_net_obj.sync_done_sem, 0) == pdTRUE);
+
+    sync_tx_job_t job = {
+        .packet = {
+            .buffer = buffer,
+            .len = len,
+            .buff_free_arg = buff_free_arg,
+            .result = ESP_OK,
+        },
+        .done = s_net_obj.sync_done_sem,
     };
-    s_net_obj.packet_to_send = &packet;
-    xSemaphoreGive(s_net_obj.buffer_sema);  // now the packet is ready, let's mark it available to tusb send
 
-    // to execute the send function in tinyUSB task context
-    usbd_defer_func(do_send_sync, NULL, false);  // arg=NULL -> sync send, we keep the packet inside the object
+    usbd_defer_func(do_send_sync, &job, false);
 
-    // wait wor completion with defined timeout
-    EventBits_t bits = xEventGroupWaitBits(s_net_obj.tx_flags, TX_FINISHED_BIT, pdTRUE, pdTRUE, timeout);
-    xSemaphoreTake(s_net_obj.buffer_sema, portMAX_DELAY);   // if tusb sending already started, we have wait before ditching the packet
-    s_net_obj.packet_to_send = NULL;        // invalidate the argument
-    if (bits & TX_FINISHED_BIT) {   // If transaction finished, return error code
-        return packet.result;
+    BaseType_t waited = xSemaphoreTake(job.done, ticks_remaining);
+    if (waited != pdTRUE) {
+        (void)xSemaphoreTake(job.done, portMAX_DELAY);
+        xSemaphoreGive(s_net_obj.sync_mutex);
+        return ESP_ERR_TIMEOUT;
     }
-    return ESP_ERR_TIMEOUT;
+
+    esp_err_t out = job.packet.result;
+    xSemaphoreGive(s_net_obj.sync_mutex);
+    return out;
 }
 
 esp_err_t tinyusb_net_init(const tinyusb_net_config_t *cfg)
 {
     ESP_RETURN_ON_FALSE(s_net_obj.initialized == false, ESP_ERR_INVALID_STATE, TAG, "TinyUSB Net class is already initialized");
 
-    // the semaphore and event flags are initialized only if needed
     s_net_obj.rx_cb = cfg->on_recv_callback;
     s_net_obj.init_cb = cfg->on_init_callback;
     s_net_obj.tx_buff_free_cb = cfg->free_tx_buffer;
@@ -132,7 +181,6 @@ esp_err_t tinyusb_net_init(const tinyusb_net_config_t *cfg)
     snprintf(s_net_obj.mac_str, sizeof(s_net_obj.mac_str), "%02X%02X%02X%02X%02X%02X",
              mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
     uint8_t mac_id = tusb_get_mac_string_id();
-    // Pass it to Descriptor control module
     tinyusb_descriptors_set_string(s_net_obj.mac_str, mac_id);
 
     s_net_obj.initialized = true;
@@ -142,20 +190,19 @@ esp_err_t tinyusb_net_init(const tinyusb_net_config_t *cfg)
 
 void tinyusb_net_deinit(void)
 {
-    if (s_net_obj.buffer_sema) {
-        vSemaphoreDelete(s_net_obj.buffer_sema);
-        s_net_obj.buffer_sema = NULL;
+    if (s_net_obj.sync_done_sem) {
+        vSemaphoreDelete(s_net_obj.sync_done_sem);
+        s_net_obj.sync_done_sem = NULL;
     }
-    if (s_net_obj.tx_flags) {
-        vEventGroupDelete(s_net_obj.tx_flags);
-        s_net_obj.tx_flags = NULL;
+    if (s_net_obj.sync_mutex) {
+        vSemaphoreDelete(s_net_obj.sync_mutex);
+        s_net_obj.sync_mutex = NULL;
     }
     s_net_obj.initialized = false;
     s_net_obj.rx_cb = NULL;
     s_net_obj.init_cb = NULL;
     s_net_obj.tx_buff_free_cb = NULL;
     s_net_obj.ctx = NULL;
-    s_net_obj.packet_to_send = NULL;
     memset(s_net_obj.mac_str, 0, sizeof(s_net_obj.mac_str));
 }
 


### PR DESCRIPTION
### Why
* NCM busy: do_send_sync used to fail the frame when tud_network_can_xmit was false, returning ESP_FAIL. LwIP can react badly (e.g. TCP stalls). We must not block/spin on the USB task either.
* Concurrency: One global packet_to_send + stack packet + old handshake was not safe if several tasks called tinyusb_net_send_sync.
* Timeouts: Needed one clear deadline for “wait for TX” + “wait for deferred xmit done”.

### What changed
* Caller runs tinyusb_net_wait_tx_ready(): poll tud_network_can_xmit(len) under vTaskSetTimeOutState / xTaskCheckForTimeOut, yield + periodic 1 ms delay; on deadline → ESP_ERR_TIMEOUT (no defer).
* USBD task (do_send_sync): tud_network_xmit only, after assert(tud_network_can_xmit) (debug). No FIFO-full ESP_FAIL from this path.
* Sync path: sync_mutex + stack sync_tx_job_t + shared sync_done_sem completion; drop event group / old buffer_sema / global packet_to_send. Drain done-sem before defer to avoid a stale Give. Mutex and completion Take use ticks_remaining so one budget covers the whole call.
* tinyusb_net.h: notes for full-call timeout and ESP_ERR_TIMEOUT. Async behaviour unchanged in design.

### TODO
- [ ] Test with esp-idf example tusb_ncm
- [ ] Test with esp-idf example sta2eth

### Related
Closes https://github.com/espressif/esp-idf/issues/18374