### PR TITLE
fix(host): List also suspended devices in usb_host_device_addr_list_fill call

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
@@ -377,7 +377,7 @@ TEST_CASE("read_write", "[cdc_acm]")
     for (int i = 0; i < NUM_ITERATIONS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_data_tx_blocking(cdc_dev, tx_buf, sizeof(tx_buf), 1000));
     }
-    vTaskDelay(10); // Wait until responses are processed
+    vTaskDelay(20); // Wait until responses are processed
 
     TEST_ASSERT_EQUAL(NUM_ITERATIONS, nb_of_responses);
 
@@ -1098,7 +1098,7 @@ TEST_CASE("device_close_while_suspended", "[cdc_acm]")
     // Close the suspended device
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_close(cdc_dev));
     // Try to open the still suspended device
-    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, cdc_acm_host_open(0x303A, 0x4002, 0, &dev_config, &cdc_dev)); // 0x303A:0x4002 (TinyUSB Dual CDC device)
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, cdc_acm_host_open(0x303A, 0x4002, 0, &dev_config, &cdc_dev)); // 0x303A:0x4002 (TinyUSB Dual CDC device)
 
     // Cleanup
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_uninstall());
@@ -1127,7 +1127,7 @@ TEST_CASE("device_open_while_suspended", "[cdc_acm]")
     const cdc_acm_host_device_config_t dev_config = default_dev_config;
 
     printf("Opening CDC-ACM device\n");
-    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, cdc_acm_host_open(0x303A, 0x4002, 0, &dev_config, &cdc_dev)); // 0x303A:0x4002 (TinyUSB Dual CDC device)
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, cdc_acm_host_open(0x303A, 0x4002, 0, &dev_config, &cdc_dev)); // 0x303A:0x4002 (TinyUSB Dual CDC device)
     TEST_ASSERT_NULL(cdc_dev);
 
     // Resume the device

--- a/host/class/uvc/usb_host_uvc/test_app/main/test_uvc_host_pm.c
+++ b/host/class/uvc/usb_host_uvc/test_app/main/test_uvc_host_pm.c
@@ -569,7 +569,7 @@ TEST_CASE("Device close while suspended", "[uvc]")
     TEST_ASSERT_EQUAL(ESP_OK, uvc_host_stream_close(stream));
 
     // Try to open still suspended device
-    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, uvc_host_stream_open(&default_stream_config, 100, &stream));
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, uvc_host_stream_open(&default_stream_config, 100, &stream));
     test_teardown();
 }
 
@@ -625,7 +625,7 @@ TEST_CASE("Device open while suspended", "[uvc]")
     const uvc_host_stream_config_t stream_config = default_stream_config;
 
     // Try to open the suspended device
-    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, uvc_host_stream_open(&stream_config, 100, &stream));
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, uvc_host_stream_open(&stream_config, 100, &stream));
     TEST_ASSERT_NULL(stream);
 
     // Resume the root port, but do not expect any event, since the device was never opened

--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- List also suspended devices in `usb_host_device_addr_list_fill()` function
+
 ## [1.4.0] - 2026-04-02
 
 ### Added

--- a/host/usb/src/usbh.c
+++ b/host/usb/src/usbh.c
@@ -879,16 +879,15 @@ esp_err_t usbh_devs_addr_list_fill(int list_len, uint8_t *dev_addr_list, int *nu
     USBH_ENTER_CRITICAL();
     /*
     Fill list with devices from idle tailq and pending tailq. Only devices that
-    are fully enumerated are added to the list. Thus, the following devices are
-    not excluded:
+    are fully enumerated are added to the list. Thus, the following devices are excluded:
     - Devices with their enum_lock set
-    - Devices not in the configured state
+    - Devices not in the configured or suspended state
     - Devices with address 0
     */
     TAILQ_FOREACH(dev_obj, &p_usbh_obj->dynamic.devs_idle_tailq, dynamic.tailq_entry) {
         if (num_filled < list_len) {
             if (!dev_obj->dynamic.flags.enum_lock &&
-                    dev_obj->dynamic.state == USB_DEVICE_STATE_CONFIGURED &&
+                    (dev_obj->dynamic.state == USB_DEVICE_STATE_CONFIGURED || dev_obj->dynamic.state == USB_DEVICE_STATE_SUSPENDED) &&
                     dev_obj->constant.address != 0) {
                 dev_addr_list[num_filled] = dev_obj->constant.address;
                 num_filled++;
@@ -902,7 +901,7 @@ esp_err_t usbh_devs_addr_list_fill(int list_len, uint8_t *dev_addr_list, int *nu
     TAILQ_FOREACH(dev_obj, &p_usbh_obj->dynamic.devs_pending_tailq, dynamic.tailq_entry) {
         if (num_filled < list_len) {
             if (!dev_obj->dynamic.flags.enum_lock &&
-                    dev_obj->dynamic.state == USB_DEVICE_STATE_CONFIGURED &&
+                    (dev_obj->dynamic.state == USB_DEVICE_STATE_CONFIGURED || dev_obj->dynamic.state == USB_DEVICE_STATE_SUSPENDED) &&
                     dev_obj->constant.address != 0) {
                 dev_addr_list[num_filled] = dev_obj->constant.address;
                 num_filled++;


### PR DESCRIPTION
List also suspended devices in `usb_host_device_addr_list_fill()` function

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized filter change that only affects which device addresses are returned; no new APIs or data-handling logic.
> 
> **Overview**
> `usbh_devs_addr_list_fill()` now includes devices in `USB_DEVICE_STATE_SUSPENDED` when building the device address list from the idle and pending queues (previously only `USB_DEVICE_STATE_CONFIGURED` devices were returned).
> 
> Adds an *Unreleased* changelog entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50dae3e9cf62edc68cc9c57769e8a6960f73e12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->