### PR TITLE
fix(ci): Ignore python warnings in CI build

### DIFF
--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -59,6 +59,7 @@ jobs:
       MANIFEST_PATH: ${{ github.workspace }}/.github/ci/.idf-build-examples-rules.yml
       USB_EXAMPLES_PATH: ${{ github.workspace }}  # Will be set-up in "Setup IDF Examples path" step
       NETWORK_EXAMPLES_PATH: ${{ github.workspace }}  # Will be set-up in "Setup IDF Examples path" step
+      PYTHONWARNINGS: "ignore"
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Description

Ignore python warnings in build idf examples CI workflow. The warnings are treated as build errors. Also are [ignored](https://github.com/espressif/esp-idf/blob/master/.gitlab/ci/common.yml#L95) in the `esp-idf` GL CI, thus no added risk of breaking esp-idf CI is added.

An example of failing CI log [here](https://github.com/espressif/esp-usb/actions/runs/24748489171/job/72449199992#step:10:149)

<details>
<summary> CI error log </summary>

```sh
Running cmake in directory /opt/esp/idf/examples/network/sta2eth/build_esp32s2_default
Executing "cmake -G Ninja -B /opt/esp/idf/examples/network/sta2eth/build_esp32s2_default -DPYTHON_DEPS_CHECKED=1 -DPYTHON=/opt/esp/python_env/idf6.1_py3.12_env/bin/python -DESP_PLATFORM=1 -DIDF_TARGET=esp32s2 -DSDKCONFIG_DEFAULTS=/opt/esp/idf/examples/network/sta2eth/sdkconfig.defaults -DCCACHE_ENABLE=True /opt/esp/idf/examples/network/sta2eth"...
-- Found Git: /usr/bin/git (found version "2.43.0")
-- Component directory /opt/esp/idf/components/idf_test does not contain a CMakeLists.txt file. No component will be added
-- Minimal build - ON
-- ccache will be used for faster recompilation
-- The C compiler identification is GNU 15.2.0
-- The CXX compiler identification is GNU 15.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /opt/esp/tools/xtensa-esp-elf/esp-15.2.0_20251204/xtensa-esp-elf/bin/xtensa-esp32s2-elf-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/esp/tools/xtensa-esp-elf/esp-15.2.0_20251204/xtensa-esp-elf/bin/xtensa-esp32s2-elf-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/esp/tools/xtensa-esp-elf/esp-15.2.0_20251204/xtensa-esp-elf/bin/xtensa-esp32s2-elf-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building ESP-IDF components for target esp32s2
NOTICE: Dependencies lock doesn't exist, solving dependencies.
NOTICE: Using component placed at /opt/esp/idf/examples/protocols/http_server/captive_portal/components/dns_server for dependency "dns_server", specified in /opt/esp/idf/examples/network/sta2eth/main/idf_component.yml
NOTICE: Using component placed at /__w/esp-usb/esp-usb/device/esp_tinyusb for dependency "espressif/esp_tinyusb", specified in /opt/esp/idf/examples/network/sta2eth/main/idf_component.yml
.....NOTICE: Skipping optional dependency: espressif/dp83848
NOTICE: Skipping optional dependency: espressif/ip101
NOTICE: Skipping optional dependency: espressif/ksz80xx
NOTICE: Skipping optional dependency: espressif/lan867x
NOTICE: Skipping optional dependency: espressif/lan87xx
NOTICE: Skipping optional dependency: espressif/rtl8201
.....NOTICE: Updating lock file at /opt/esp/idf/examples/network/sta2eth/dependencies.lock
NOTICE: Processing 7 dependencies:
NOTICE: [1/7] dns_server (*) (/opt/esp/idf/examples/protocols/http_server/captive_portal/components/dns_server)
NOTICE: [2/7] espressif/cjson (1.7.19~2)
NOTICE: [3/7] espressif/esp_tinyusb (2.1.1) (/__w/esp-usb/esp-usb/device/esp_tinyusb)
NOTICE: [4/7] espressif/ethernet_init (1.3.0)
NOTICE: [5/7] espressif/network_provisioning (1.2.4)
NOTICE: [6/7] espressif/tinyusb (0.19.0~3)
NOTICE: [7/7] idf (6.1.0)
CMake Warning at /opt/esp/idf/tools/cmake/build.cmake:695 (message):
  
  /opt/esp/python_env/idf6.1_py3.12_env/lib/python3.12/site-packages/pydantic/main.py:475:
  UserWarning: Pydantic serializer warnings:

    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version=No...=None, pre_release=None), input_type=DependencyItem])
    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version='*...=None, pre_release=None), input_type=DependencyItem])
    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version='^...=None, pre_release=None), input_type=DependencyItem])
    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version='^...=None, pre_release=None), input_type=DependencyItem])
    return self.__pydantic_serializer__.to_python(

  
  /opt/esp/python_env/idf6.1_py3.12_env/lib/python3.12/site-packages/pydantic/main.py:475:
  UserWarning: Pydantic serializer warnings:

    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version='>...=None, pre_release=None), input_type=DependencyItem])
    return self.__pydantic_serializer__.to_python(

  
  /opt/esp/python_env/idf6.1_py3.12_env/lib/python3.12/site-packages/pydantic/main.py:542:
  UserWarning: Pydantic serializer warnings:

    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version=No...=None, pre_release=None), input_type=DependencyItem])
    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version='*...=None, pre_release=None), input_type=DependencyItem])
    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version='^...=None, pre_release=None), input_type=DependencyItem])
    PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=DependencyItem(version='^...=None, pre_release=None), input_type=DependencyItem])
    return self.__pydantic_serializer__.to_json(

Call Stack (most recent call first):
  /opt/esp/idf/tools/cmake/project.cmake:773 (idf_build_process)
  CMakeLists.txt:9 (project)
  ```

</details>

## Related

- First appeared in #467 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that just sets `PYTHONWARNINGS=ignore`, which may hide new warning signals but does not affect production code.
> 
> **Overview**
> Stops Python warnings from failing the IDF examples build by setting `PYTHONWARNINGS: "ignore"` in `.github/workflows/build_and_run_idf_examples.yml` for the `build` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f825dcd46f78cc284f4968f0300eeb564d96a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->