### PR TITLE
fix(usb_host_test): Fix target tests build for esp32s31

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -67,6 +67,16 @@ host/usb:
     - if: IDF_VERSION < "5.4.0"
       reason: We will support component overriding only in service releases
 
+host/usb/test/target_test/enum:
+  depends_filepatterns:
+    - 'host/usb/**'
+  enable:
+    - if: SOC_USB_OTG_SUPPORTED == 1 and ENV_VAR_USB_COMP_MANAGED == "yes" and IDF_TARGET not in ["esp32s31"]
+      reason: Test uses FSLS PHY interface to emulate device attach/detach which the esp32s31 lacks
+  disable:
+    - if: IDF_VERSION < "5.4.0"
+      reason: We will support component overriding only in service releases
+
 # Host tests
 .host_test_enable_rules: &host_test_enable_rules
   enable:

--- a/host/usb/test/target_test/common/hcd_common.c
+++ b/host/usb/test/target_test/common/hcd_common.c
@@ -9,7 +9,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"
-#include "soc/usb_wrap_struct.h"
 #include "esp_intr_alloc.h"
 #include "esp_err.h"
 #include "esp_attr.h"


### PR DESCRIPTION
## Description

### USB Host target test: enum
Fixing build of usb host enum test for esp32s31. Failing in CI with following log:

<details>
<summary> CI error log </summary>

```sh
/__w/esp-usb/esp-usb/host/usb/test/target_test/enum/main/mock_dev.c: In function 'mock_dev_insert':
/__w/esp-usb/esp-usb/host/usb/test/target_test/enum/main/mock_dev.c:50:69: error: 'USB_SRP_BVALID_IN_IDX' undeclared (first use in this function)
   50 |         esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ONE_INPUT, USB_SRP_BVALID_IN_IDX, false);
      |                                                                     ^~~~~~~~~~~~~~~~~~~~~
/__w/esp-usb/esp-usb/host/usb/test/target_test/enum/main/mock_dev.c:50:69: note: each undeclared identifier is reported only once for each function it appears in
/__w/esp-usb/esp-usb/host/usb/test/target_test/enum/main/mock_dev.c: In function 'mock_dev_remove':
/__w/esp-usb/esp-usb/host/usb/test/target_test/enum/main/mock_dev.c:59:70: error: 'USB_SRP_BVALID_IN_IDX' undeclared (first use in this function)
   59 |         esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ZERO_INPUT, USB_SRP_BVALID_IN_IDX, false);
      |                                                                      ^~~~~~~~~~~~~~~~~~~~~
[662/674] Building C object esp-idf/main/CMakeFiles/__idf_main.dir/test_addr.c.obj
```

</details>

### USB Host target test: HCD

Fixing build of usb host HCD test for esp32s31. Failing in CI with following log:

<details>
<summary> CI error log </summary>

```sh
/esp/esp-usb/host/usb/test/target_test/common/hcd_common.c
/home/peter/esp/esp-usb/host/usb/test/target_test/common/hcd_common.c:12:10: fatal error: soc/usb_wrap_struct.h: No such file or directory
   12 | #include "soc/usb_wrap_struct.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

</details>

## Related
- Fixing #467 
- Fixing #461 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI test enablement rules and a test-only include cleanup, with no impact on production USB stack behavior.
> 
> **Overview**
> Resolves esp32s31 target-test build failures by **disabling the USB host enumeration target test** on `esp32s31` via `.build-test-rules.yml` (it relies on FSLS PHY attach/detach emulation signals not present on that target).
> 
> Also fixes the USB host HCD target test build by **removing the `soc/usb_wrap_struct.h` include** from `host/usb/test/target_test/common/hcd_common.c`, avoiding a missing-header error on esp32s31.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0d9d382a6f4562bd09985ff1287db2e85f246f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->