### PR TITLE
fix(usb_host): Handle disconnect after device free

### DIFF
--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed race between root port disconnect handling and device recycle path that could abort with `ESP_ERR_NOT_FOUND` from `dev_tree_node_dev_gone()` (https://github.com/espressif/esp-idf/issues/18366)
 - List also suspended devices in `usb_host_device_addr_list_fill()` function
 
 ## [1.4.0] - 2026-04-02

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -65,7 +65,6 @@ typedef enum {
 typedef enum {
     ROOT_PORT_STATE_NOT_POWERED,    /**< Root port initialized and/or not powered */
     ROOT_PORT_STATE_POWERED,        /**< Root port is powered, device is not connected */
-    ROOT_PORT_STATE_DISABLED,       /**< A device is connected but is disabled (i.e., not reset, no SOFs are sent) */
     ROOT_PORT_STATE_ENABLED,        /**< A device is connected, port has been reset, SOFs are sent */
     ROOT_PORT_STATE_SUSPENDED,      /**< Root port is suspended, no SOFs are sent */
 } root_port_state_t;
@@ -477,7 +476,6 @@ reset_err:
         HUB_DRIVER_ENTER_CRITICAL();
         switch (root_hub_port->dynamic.state) {
         case ROOT_PORT_STATE_POWERED: // This occurred before enumeration
-        case ROOT_PORT_STATE_DISABLED: // This occurred after the device has already been disabled
             // Therefore, there's no device object to clean up, and we can go straight to port recovery
             root_hub_port->dynamic.reqs |= PORT_REQ_RECOVER;
             if (root_hub_port->constant.index == 0) {
@@ -502,7 +500,15 @@ reset_err:
         HUB_DRIVER_EXIT_CRITICAL();
 
         if (port_has_device) {
-            ESP_ERROR_CHECK(dev_tree_node_dev_gone(NULL, root_hub_port->constant.index));
+            // The dev tree node may have already been removed via the recycle path
+            // (USBH_EVENT_DEV_FREE -> hub_node_recycle) if the device was freed by
+            // its clients before this disconnect event was processed by the hub
+            // driver. In that case there is nothing more to report, so treat
+            // ESP_ERR_NOT_FOUND as benign.
+            const esp_err_t ret = dev_tree_node_dev_gone(NULL, root_hub_port->constant.index);
+            if (ret != ESP_OK && ret != ESP_ERR_NOT_FOUND) {
+                ESP_ERROR_CHECK(ret);
+            }
         }
 
         break;

--- a/host/usb/test/target_test/usb_host/main/test_usb_host_plugging.c
+++ b/host/usb/test/target_test/usb_host/main/test_usb_host_plugging.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -149,6 +149,86 @@ TEST_CASE("Test USB Host suspend + disconnection (no client)", "[usb_host][low_s
                 break;
             }
         }
+    }
+}
+
+/*
+Test USB Host Library disconnect after device free (no client)
+Purpose:
+- Regression test for the race between the root port disconnect handler and the
+  device recycle path that previously aborted with ESP_ERR_NOT_FOUND from
+  dev_tree_node_dev_gone() (espressif/esp-idf#18366).
+- Verify that a HCD_PORT_EVENT_DISCONNECTION raised after the dev_tree_node has
+  already been removed via USBH_EVENT_DEV_FREE -> hub_node_recycle is handled
+  gracefully instead of aborting via ESP_ERROR_CHECK.
+
+Procedure:
+- Install USB Host Library (no client registered)
+- Wait for the device to be auto-enumerated
+- Call usb_host_device_free_all() to free the device while it's still connected.
+  With no client (open_count == 0), USBH frees the device immediately, which
+  triggers USBH_EVENT_DEV_FREE -> hub_node_recycle:
+    - root_port_recycle() queues PORT_REQ_DISABLE
+    - dev_tree_node_remove_by_parent() removes the node
+  The hub task then processes PORT_REQ_DISABLE -> HCD_PORT_CMD_DISABLE.
+- Wait for USB_HOST_LIB_EVENT_FLAGS_ALL_FREE to make sure the recycle path has
+  completed and the dev_tree_node is gone.
+- Power OFF the root port. With a connected device this raises
+  HCD_PORT_EVENT_DISCONNECTION. The disconnect handler ends up calling
+  dev_tree_node_dev_gone(NULL, idx), which now returns ESP_ERR_NOT_FOUND.
+  Without the fix this aborts via ESP_ERROR_CHECK; with the fix the
+  ESP_ERR_NOT_FOUND is treated as benign.
+- Drain events for a short period; reaching the end of the loop without an
+  abort is the regression check.
+*/
+
+TEST_CASE("Test USB Host disconnect after device free (no client)", "[usb_host][low_speed][full_speed][high_speed]")
+{
+    // Wait for the device to be enumerated
+    while (1) {
+        uint32_t event_flags;
+        usb_host_lib_handle_events(pdMS_TO_TICKS(100), &event_flags);
+        usb_host_lib_info_t lib_info;
+        TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_info(&lib_info));
+        if (lib_info.num_devices == 1) {
+            break;
+        }
+    }
+    printf("Device enumerated\n");
+
+    // Free the device while still physically connected. This drives:
+    //   USBH_EVENT_DEV_FREE -> hub_node_recycle:
+    //       - root_port_recycle queues PORT_REQ_DISABLE
+    //       - dev_tree_node is removed
+    //   Hub task: PORT_REQ_DISABLE -> hcd_port_command(HCD_PORT_CMD_DISABLE)
+    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FINISHED, usb_host_device_free_all());
+
+    // Wait for ALL_FREE: dev_tree_node has been removed and the root port has
+    // been disabled.
+    while (1) {
+        uint32_t event_flags;
+        usb_host_lib_handle_events(portMAX_DELAY, &event_flags);
+        if (event_flags & USB_HOST_LIB_EVENT_FLAGS_ALL_FREE) {
+            break;
+        }
+    }
+    printf("All devices freed\n");
+    // Brief delay to let the hub task fully process PORT_REQ_DISABLE
+    vTaskDelay(pdMS_TO_TICKS(50));
+
+    // Power OFF the root port. With a connected device this raises
+    // HCD_PORT_EVENT_DISCONNECTION. Without the fix the disconnect handler
+    // would call dev_tree_node_dev_gone(NULL, idx), which now returns
+    // ESP_ERR_NOT_FOUND because the dev_tree_node was already removed by
+    // hub_node_recycle, and ESP_ERROR_CHECK would abort.
+    printf("Forcing Sudden Disconnect (root port power OFF)\n");
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(false));
+
+    // Drain events for ~500 ms so the disconnect event is fully handled.
+    // Reaching the end of this loop without an abort is the regression check.
+    for (int i = 0; i < 25; i++) {
+        uint32_t event_flags;
+        usb_host_lib_handle_events(pdMS_TO_TICKS(20), &event_flags);
     }
 }
 


### PR DESCRIPTION
## Description
Fixes a USB Host race where a device can be freed while it is still physically connected. In this flow, the recycle path can remove the dev tree node before the root port disconnect event is handled, which made `dev_tree_node_dev_gone()` return `ESP_ERR_NOT_FOUND` and abort through `ESP_ERROR_CHECK`.

This change treats `ESP_ERR_NOT_FOUND` as benign for that already-recycled disconnect path while keeping error checking for unexpected failures. It also adds a no-client regression test for disconnect-after-device-free and documents the fix in the changelog.

## Related
Closes https://github.com/espressif/esp-idf/issues/18366
Closes [IDFGH-17399](https://jira.espressif.com:8443/browse/IDFGH-17399)

## Testing

- Added target regression test: `Test USB Host disconnect after device free (no client)`