### PR TITLE
fix(cdc/ftdi): correct divisor selection in 1 MBaud to 2 MBaud range (IEC-534)

### DIFF
--- a/host/class/cdc/usb_host_ftdi_vcp/usb_host_ftdi_vcp.c
+++ b/host/class/cdc/usb_host_ftdi_vcp/usb_host_ftdi_vcp.c
@@ -136,16 +136,16 @@ static void ftdi_event(const cdc_acm_host_dev_event_data_t *event, void *user_ct
 static int calculate_baudrate(uint32_t baudrate, uint16_t *wValue, uint16_t *wIndex)
 {
     int baudrate_real;
-    if (baudrate > 2000000) {
-        // set to 3000000
+    if (baudrate >= 3000000) {
+        // Divisor 0 is a special case for 3 MBaud
         *wValue = 0;
         *wIndex = 0;
         baudrate_real = 3000000;
-    } else if (baudrate >= 1000000) {
-        // set to 1000000
+    } else if (baudrate >= 2000000) {
+        // Divisor 1 is a special case for 2 MBaud
         *wValue = 1;
         *wIndex = 0;
-        baudrate_real = 1000000;
+        baudrate_real = 2000000;
     } else {
         const float ftdi_fractal[] = {0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1};
         const uint8_t ftdi_fractal_bits[] = {0, 0x03, 0x02, 0x04, 0x01, 0x05, 0x06, 0x07};


### PR DESCRIPTION
fix(cdc/ftdi): correct divisor selection in 1 MBaud to 2 MBaud range

## Description
Previously, baud rates between above 1 MBaud were short-circuited to a special case divisor (either 0 or 1), but had the wrong reported realized rate. In the case of `baudrate >= 1000000`, the selected divisor was 1, which programs the chip at 2 MBaud (per AN232B-05), not 1 MBaud as claimed in the comment and set as `baudrate_real`. In addition, rates that the general divisor path could have handled (notably including 1.5 MBaud, which uses even divisor of 2) were being silently coerced to 2 MBaud.

This PR corrects the two special case divisors and allows baud rates below 2 MBaud to be handled by the general divisor path. This allows 1.5 MBaud to work properly.

## Testing
Confirmed that an FT232R, which previously was not successfully able to function at a requested 1.5 MBaud, is now working properly at 1.5 MBaud.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.