### PR TITLE
fix(uvc): Provide default URB size based on MPS

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed regression from version 2.5.0 where unreasonably large URBs could be allocated, leading to out-of-memory scenarios. Now, if urb_size == 0, we allocate URB of size 4x MPS. For other urb_sizes, user's value is used to provide flexibility.
+
 ## [2.5.0] - 2026-04-13
 
 ### Added

--- a/host/class/uvc/usb_host_uvc/host_test/main/opening/test_opening.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/opening/test_opening.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "usb/uvc_host.h"
+#include "uvc_types_priv.h" // For uvc_host_stream_s internals
+
 #include "mock_add_usb_device.h"
 #include "test_fixtures.hpp"
 
@@ -40,7 +42,7 @@ static void _add_mocked_devices(void)
     ADD_MOCK_DEV(4, customer_camera_dual);
 }
 
-SCENARIO("UVC driver install/uninstall")
+SCENARIO("UVC driver install/uninstall", "[installing]")
 {
     WHEN("UVC driver is not installed") {
         THEN("Stream cannot be opened") {
@@ -77,7 +79,7 @@ SCENARIO("UVC driver install/uninstall")
     }
 }
 
-SCENARIO("Test mocked device opening and closing")
+SCENARIO("Test mocked device opening and closing", "[opening]")
 {
     // We will put device adding to the SECTION, to run it just once, not repeatedly for all the following SECTIONs
     // (if multiple sections are present)
@@ -198,7 +200,7 @@ SCENARIO("Test mocked device opening and closing")
     }
 }
 
-SCENARIO("Test mocked device format negotiation")
+SCENARIO("Test mocked device format negotiation", "[opening]")
 {
     // We will put device adding to the SECTION, to run it just once, not repeatedly for all the following SECTIONs
     // (if multiple sections are present)
@@ -262,6 +264,109 @@ SCENARIO("Test mocked device format negotiation")
         //     REQUIRE(ESP_OK == test_uvc_host_stream_open(&stream_config, 0, &stream, true));
         //     REQUIRE(ESP_OK == test_uvc_host_stream_close(stream));
         // }
+
+        REQUIRE(ESP_OK == test_uvc_host_uninstall());
+    }
+}
+
+#define NUMBER_OF_URBS 4
+SCENARIO("Test mocked device URB allocation", "[opening]")
+{
+    // We will put device adding to the SECTION, to run it just once, not repeatedly for all the following SECTIONs
+    // (if multiple sections are present)
+    SECTION("Add mocked devices") {
+        _add_mocked_devices();
+
+        // Optionally, print all the devices
+        //usb_host_mock_print_mocked_devices(0xFF);
+    }
+
+    SECTION("Install the UVC driver") {
+        const uvc_host_driver_config_t uvc_driver_config = {
+            .driver_task_stack_size = 4 * 1024,
+            .driver_task_priority = 10,
+            .xCoreID = tskNO_AFFINITY,
+            .create_background_task = true,
+            .event_cb = nullptr,
+            .user_ctx = nullptr,
+        };
+        REQUIRE(ESP_OK == test_uvc_host_install(&uvc_driver_config));
+
+        uvc_host_stream_config_t stream_config = {
+            .event_cb = nullptr,
+            .frame_cb = nullptr,
+            .user_ctx = nullptr,
+            .usb = {
+                .dev_addr = UVC_HOST_ANY_DEV_ADDR,
+                .vid = UVC_HOST_ANY_VID,
+                .pid = UVC_HOST_ANY_PID,
+                .uvc_stream_index = 0,
+            },
+            .vs_format = {
+                .h_res = 1280,
+                .v_res = 720,
+                .fps = 15,
+                .format = UVC_VS_FORMAT_MJPEG,
+            },
+            .advanced = {
+                .number_of_frame_buffers = 3,
+                .frame_size = 0,
+                .frame_heap_caps = 0,
+                .number_of_urbs = NUMBER_OF_URBS,
+                .urb_size = 0,
+                .user_frame_buffers = NULL,
+            },
+        };
+
+        THEN("URB size default") {
+            uvc_host_stream_hdl_t stream = nullptr;
+            REQUIRE(ESP_OK == test_uvc_host_stream_open(&stream_config, 0, &stream, true));
+            REQUIRE(stream->constant.num_of_xfers == NUMBER_OF_URBS);
+            // This camera offers 1020 MPS with 2 extra transaction in a microframe, so 3 * 1020 = 3060
+            // Default URB size is 4 * MPS, so 4 * 3060 = 12240
+            REQUIRE(stream->constant.xfers[0]->data_buffer_size == 4 * 3060);
+            REQUIRE(ESP_OK == test_uvc_host_stream_close(stream));
+        }
+
+        THEN("URB size greater than MPS") {
+            uvc_host_stream_hdl_t stream = nullptr;
+            stream_config.advanced.urb_size = 2 * 3060; // 2 * MPS
+            REQUIRE(ESP_OK == test_uvc_host_stream_open(&stream_config, 0, &stream, true));
+            REQUIRE(stream->constant.num_of_xfers == NUMBER_OF_URBS);
+            REQUIRE(stream->constant.xfers[0]->data_buffer_size == 2 * 3060);
+            REQUIRE(ESP_OK == test_uvc_host_stream_close(stream));
+        }
+
+        THEN("URB size greater than default") {
+            uvc_host_stream_hdl_t stream = nullptr;
+            stream_config.advanced.urb_size = 6 * 3060; // 6 * MPS
+            REQUIRE(ESP_OK == test_uvc_host_stream_open(&stream_config, 0, &stream, true));
+            REQUIRE(stream->constant.num_of_xfers == NUMBER_OF_URBS);
+            REQUIRE(stream->constant.xfers[0]->data_buffer_size == 6 * 3060);
+            REQUIRE(ESP_OK == test_uvc_host_stream_close(stream));
+        }
+
+        THEN("URB size cannot be smaller than MPS") {
+            uvc_host_stream_hdl_t stream = nullptr;
+            stream_config.advanced.urb_size = 500;
+            REQUIRE(ESP_OK == test_uvc_host_stream_open(&stream_config, 0, &stream, true));
+            REQUIRE(stream->constant.num_of_xfers == NUMBER_OF_URBS);
+            // This camera offers 1020 MPS with 2 extra transaction in a microframe, so 3 * 1020 = 3060
+            // This is the minimum URB size, even if user requested smaller
+            REQUIRE(stream->constant.xfers[0]->data_buffer_size == 3060);
+            REQUIRE(ESP_OK == test_uvc_host_stream_close(stream));
+        }
+
+        THEN("URB size must be integer multiple of MPS") {
+            uvc_host_stream_hdl_t stream = nullptr;
+            stream_config.advanced.urb_size = 3500;
+            REQUIRE(ESP_OK == test_uvc_host_stream_open(&stream_config, 0, &stream, true));
+            REQUIRE(stream->constant.num_of_xfers == NUMBER_OF_URBS);
+            // This camera offers 1020 MPS with 2 extra transaction in a microframe, so 3 * 1020 = 3060
+            // The driver should round up the requested URB size to the nearest multiple of MPS, which is 6120
+            REQUIRE(stream->constant.xfers[0]->data_buffer_size == 2 * 3060);
+            REQUIRE(ESP_OK == test_uvc_host_stream_close(stream));
+        }
 
         REQUIRE(ESP_OK == test_uvc_host_uninstall());
     }

--- a/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
+++ b/host/class/uvc/usb_host_uvc/include/usb/uvc_host.h
@@ -199,7 +199,7 @@ typedef struct {
         size_t frame_size;           /*!< Frame buffer size. Use 0 to take dwMaxVideoFrameSize from negotiation. */
         uint32_t frame_heap_caps;    /*!< Memory capabilities for frame buffers passed to heap_caps_malloc(). */
         int number_of_urbs;          /*!< Number of URBs used by this stream. Triple buffering is recommended. */
-        size_t urb_size;             /*!< Size in bytes of one URB. Larger values trade memory for fewer interrupts. */
+        size_t urb_size;             /*!< Size in bytes of one URB. Larger values trade memory for fewer interrupts. Set to 0 to use the default size, which is 4x MPS */
         uint8_t **user_frame_buffers; /*!< Optional user-provided frame buffers. NULL lets the driver allocate them. */
     } advanced;                       /*!< Advanced buffering and transfer settings. */
 } uvc_host_stream_config_t;

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -355,7 +355,7 @@ static void uvc_transfers_free(uvc_stream_t *uvc_stream)
  *
  * @param[in] uvc_stream       Pointer to UVC stream
  * @param[in] num_of_transfers Number of USB transfers allocated for this stream
- * @param[in] transfer_size    Size of 1 USB transfer in bytes
+ * @param[in] transfer_size    Size of 1 USB transfer in bytes. If 0, the transfer size will be set to 4 times MPS
  * @param[in] ep_desc          Descriptor of the streaming endpoint
  * @return
  *     - ESP_OK:              Success
@@ -374,6 +374,15 @@ static esp_err_t uvc_transfers_allocate(uvc_stream_t *uvc_stream, unsigned num_o
     if (is_isoc) {
         // Multiply MPS by number of transactions in microframe: This is the minimum size we can request in IN transfer
         max_packet_size *= (USB_EP_DESC_GET_MULT(ep_desc) + 1);
+    }
+
+    if (transfer_size == 0) {
+        // If the caller doesn't specify transfer size, we will allocate 4 MPS buffer
+        // This is a reasonable compromise between performance and memory consumption
+        transfer_size = 4 * max_packet_size;
+    }
+
+    if (is_isoc) {
         // Divide the transfer data buffer into ISOC packets
         num_isoc_packets = usb_round_up_to_mps(transfer_size, max_packet_size) / max_packet_size;
     }
@@ -835,12 +844,9 @@ esp_err_t uvc_host_stream_open(const uvc_host_stream_config_t *stream_config, in
         uvc_host_stream_control_probe(uvc_stream, &real_format, &vs_result),
         err, TAG, "Failed to negotiate requested Video Stream format");
 
-    // check if the urb_size is smaller than the maximum payload transfer size
-    size_t urb_size = stream_config->advanced.urb_size < vs_result.dwMaxPayloadTransferSize ?
-                      vs_result.dwMaxPayloadTransferSize : stream_config->advanced.urb_size;
     // Allocate USB transfers
     ESP_GOTO_ON_ERROR(
-        uvc_transfers_allocate(uvc_stream, stream_config->advanced.number_of_urbs, urb_size, ep_desc),
+        uvc_transfers_allocate(uvc_stream, stream_config->advanced.number_of_urbs, stream_config->advanced.urb_size, ep_desc),
         err, TAG,);
     // Allocate Frame buffers
     ESP_GOTO_ON_ERROR(


### PR DESCRIPTION
Previously we checked user provided URB size against dwMaxPayloadTransferSize. However, some cameras could return unreasonably large or small values, limiting configuration flexibility.
Now we provide a default URB size of 4x MPS, which is a reasonable starting point.

Changes https://github.com/espressif/esp-usb/pull/450
