### PR TITLE
feat(ci): Run idf examples in CI on IDF 5.3 release

### DIFF
--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -17,14 +17,14 @@
 # Run:
 #   - usb device examples:
 #     - usb_device target runners, with matrix of all listed releases
-#     - IDF Releases: Latest, IDF 6.0, IDF 5.5, IDF 5.4
+#     - IDF Releases: IDF >= 5.3
 #   - usb host examples:
 #     - usb_host_examples target runners, with matrix of all listed releases
-#     - IDF Releases: Latest, IDF 6.0, IDF 5.5, IDF 5.4
+#     - IDF Releases: IDF >= 5.3
 #
 # Temporarily disabled tests and TODOs of this workflow:
 # - USB Device NCM example run: Ignored due to GH Runner configuration (docker needs --net=host to access host network namespace)
-# - Examples runs on targets enabled only for IDF >= 5.4
+# - Examples runs on targets enabled only for IDF >= 5.3
 
 name: Build and Run ESP-IDF USB examples
 
@@ -190,8 +190,9 @@ jobs:
       matrix:
         idf_ver:
           [
-            # Only run for IDF >= 5.4,
+            # Only run for IDF >= 5.3,
             # For lower IDF versions, running pytest files from esp-idf outside of esp-idf container is too complicated
+            "release-v5.3",
             "release-v5.4",
             "release-v5.5",
             "release-v6.0",
@@ -214,6 +215,9 @@ jobs:
           - idf_target: "esp32p4"
             eco_ver: "eco_default"
             idf_ver: "release-v5.4"
+          - idf_target: "esp32p4"
+            eco_ver: "eco_default"
+            idf_ver: "release-v5.3"
           # Exclude eco4 for newer IDF versions, esp32p4 ECO6 is default in IDF 5.5 and later
           - idf_target: "esp32p4"
             eco_ver: "eco4"


### PR DESCRIPTION
Adding run of esp-idf examples for IDF 5.3 release.

After esp-idf commit [59f62ad](https://github.com/espressif/esp-idf/commit/59f62ad15f3b4cea8e822851aa84b50db4dbd4be)

Pytest files in IDF 5.3 use @idf_parametrize decorator, allowing us to run the IDF 5.3 pytest files in esp-usb CI infrastructure.

## Related
- follow-up for #466 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
