### PR TITLE
ci: Add esp-idf 6.1 to CI

### DIFF
--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -48,6 +48,7 @@ jobs:
             "release-v5.4",
             "release-v5.5",
             "release-v6.0",
+            "release-v6.1",
             "latest",
           ]
     runs-on: ubuntu-latest
@@ -196,6 +197,7 @@ jobs:
             "release-v5.4",
             "release-v5.5",
             "release-v6.0",
+            "release-v6.1",
             "latest",
           ]
         idf_target: ["esp32s2", "esp32p4"]
@@ -225,6 +227,9 @@ jobs:
           - idf_target: "esp32p4"
             eco_ver: "eco4"
             idf_ver: "release-v6.0"
+          - idf_target: "esp32p4"
+            eco_ver: "eco4"
+            idf_ver: "release-v6.1"
           - idf_target: "esp32p4"
             eco_ver: "eco4"
             idf_ver: "latest"

--- a/.github/workflows/build_and_run_main_ci.yml
+++ b/.github/workflows/build_and_run_main_ci.yml
@@ -66,6 +66,7 @@ jobs:
                       "release-v5.4",
                       "release-v5.5",
                       "release-v6.0",
+                      "release-v6.1",
                       "latest"]'
       idf_targets: '["esp32s2", "esp32p4"]'
       changed_files: ${{ needs.get-changed-files.outputs.all_changed_files }}

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -53,6 +53,8 @@ jobs:
           - test_app: host_native
             idf_ver: "release-v6.0"
           - test_app: host_native
+            idf_ver: "release-v6.1"
+          - test_app: host_native
             idf_ver: "latest"
 
     runs-on: ubuntu-latest
@@ -142,6 +144,8 @@ jobs:
           # Exclude native usb component for IDF >= 6 (usb component has been removed from esp-idf)
           - test_app: host_native
             idf_ver: "release-v6.0"
+          - test_app: host_native
+            idf_ver: "release-v6.1"
           - test_app: host_native
             idf_ver: "latest"
           # Exclude eco4 version for esp32s2


### PR DESCRIPTION
Add IDF 6.1 to CI

- [x] First need public release/v6.1 tag in https://hub.docker.com/r/espressif/idf/tags