### PR TITLE
release(host/ftdi): Release FTDI driver v2.1.1

### DIFF
--- a/host/class/cdc/usb_host_ftdi_vcp/CHANGELOG.md
+++ b/host/class/cdc/usb_host_ftdi_vcp/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-05-27
+
+### Fixed
+- Correct divisor selection in 1 MBaud to 2 MBaud range (https://github.com/espressif/esp-usb/pull/488)
+
 ## [2.1.0] - 2026-01-26
 
 ### Added

--- a/host/class/cdc/usb_host_ftdi_vcp/idf_component.yml
+++ b/host/class/cdc/usb_host_ftdi_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.1.0"
+version: "2.1.1"
 description: USB Host driver for FTDI USB<->UART converters series of chips
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_ftdi_vcp
 issues: "https://github.com/espressif/esp-usb/issues"


### PR DESCRIPTION
## Related

- Contains https://github.com/espressif/esp-usb/pull/488
- Closes https://github.com/espressif/esp-usb/milestone/37