### PR TITLE
Remove idf5.4 usb managed support

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -64,7 +64,7 @@ host/usb:
     - if: SOC_USB_OTG_SUPPORTED == 1 and ENV_VAR_USB_COMP_MANAGED == "yes"
       reason: USB Component tests with native USB component are already running in esp-idf CI
   disable:
-    - if: IDF_VERSION < "5.4.0"
+    - if: IDF_VERSION < "5.5.3"
       reason: We will support component overriding only in service releases
 
 host/usb/test/target_test/enum:
@@ -74,13 +74,13 @@ host/usb/test/target_test/enum:
     - if: SOC_USB_OTG_SUPPORTED == 1 and ENV_VAR_USB_COMP_MANAGED == "yes" and IDF_TARGET not in ["esp32s31"]
       reason: Test uses FSLS PHY interface to emulate device attach/detach which the esp32s31 lacks
   disable:
-    - if: IDF_VERSION < "5.4.0"
+    - if: IDF_VERSION < "5.5.3"
       reason: We will support component overriding only in service releases
 
 # Host tests
 .host_test_enable_rules: &host_test_enable_rules
   enable:
-    - if: IDF_TARGET in ["linux"] and (IDF_VERSION >= "6.1.0")
+    - if: IDF_TARGET in ["linux"] and (IDF_VERSION >= "6.2.0")
       reason: USB mocks are run only for the latest version of IDF
 
 host/class/cdc/usb_host_cdc_acm/host_test:

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Create component manifest file for usb_host_lib
         # Create manifest file for usb_host_lib example, because the examples do not have it for IDF < 6.0
         # and we need to override the usb component
-        if: contains('release-v5.4 release-v5.5', matrix.idf_ver)
+        if: contains('release-v5.5', matrix.idf_ver)
         working-directory: ${{ env.USB_EXAMPLES_PATH }}/host/usb_host_lib/main
         run: |
           python3 - << 'EOF'
@@ -146,7 +146,7 @@ jobs:
           fi
       - name: Override usb component
         # Override usb host component only for service releases
-        if: contains('release-v5.4 release-v5.5 release-v6.0 latest', matrix.idf_ver)
+        if: contains('release-v5.5 release-v6.0 latest', matrix.idf_ver)
         run: |
           . ${IDF_PATH}/export.sh
           python .github/ci/override_managed_component.py usb host/usb ${{ env.USB_EXAMPLES_PATH }}/host/*

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -49,6 +49,8 @@ jobs:
             idf_ver: "release-v5.2"
           - test_app: host_managed
             idf_ver: "release-v5.3"
+          - test_app: host_managed
+            idf_ver: "release-v5.4"
           # Exclude native usb component for IDF >= 6 (usb component has been removed from esp-idf)
           - test_app: host_native
             idf_ver: "release-v6.0"
@@ -139,6 +141,8 @@ jobs:
             idf_ver: "release-v5.2"
           - test_app: host_managed
             idf_ver: "release-v5.3"
+          - test_app: host_managed
+            idf_ver: "release-v5.4"
           # Exclude native usb component for IDF >= 6 (usb component has been removed from esp-idf)
           - test_app: host_native
             idf_ver: "release-v6.0"

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/idf_component.yml
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/idf_component.yml
@@ -15,7 +15,7 @@ dependencies:
     override_path: "../../../../../usb"
     rules:                                    # Both if clauses must be fulfilled to override the component
       - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above
 
   # Following components are not needed, but this way we at least built them in CI
   espressif/esp_modem_usb_dte:

--- a/host/class/hid/usb_host_hid/test_app/main/idf_component.yml
+++ b/host/class/hid/usb_host_hid/test_app/main/idf_component.yml
@@ -15,4 +15,4 @@ dependencies:
     override_path: "../../../../../usb"
     rules:                                      # Both if clauses must be fulfilled to override the component
       - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above

--- a/host/class/msc/usb_host_msc/test_app/main/idf_component.yml
+++ b/host/class/msc/usb_host_msc/test_app/main/idf_component.yml
@@ -15,4 +15,4 @@ dependencies:
     override_path: "../../../../../usb"
     rules:                                      # Both if clauses must be fulfilled to override the component
       - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above

--- a/host/class/uac/usb_host_uac/examples/audio_player/main/idf_component.yml
+++ b/host/class/uac/usb_host_uac/examples/audio_player/main/idf_component.yml
@@ -7,4 +7,4 @@ dependencies:
     version: "*"
     override_path: "../../../../../../usb"
     rules:
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above

--- a/host/class/uac/usb_host_uac/test_app/main/idf_component.yml
+++ b/host/class/uac/usb_host_uac/test_app/main/idf_component.yml
@@ -10,4 +10,4 @@ dependencies:
     override_path: "../../../../../usb"
     rules:                                      # Both if clauses must be fulfilled to override the component
       - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above

--- a/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/examples/basic_uvc_stream/main/idf_component.yml
@@ -8,4 +8,4 @@ dependencies:
     version: "*"
     override_path: "../../../../../../usb"
     rules:
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above

--- a/host/class/uvc/usb_host_uvc/examples/camera_display/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/examples/camera_display/main/idf_component.yml
@@ -10,4 +10,4 @@ dependencies:
     version: "*"
     override_path: "../../../../../../usb"
     rules:
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above

--- a/host/class/uvc/usb_host_uvc/test_app/main/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/test_app/main/idf_component.yml
@@ -10,4 +10,4 @@ dependencies:
     override_path: "../../../../../usb"
     rules:                                      # Both if clauses must be fulfilled to override the component
       - if: "$ENV_VAR_USB_COMP_MANAGED == yes"  # Environmental variable to select between managed (esp-usb) and native (esp-idf) USB Component
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above

--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- This component now requires ESP-IDF version >= 5.5.3
+
 ## [1.4.1] - 2026-05-29
 
 ### Fixed

--- a/host/usb/CMakeLists.txt
+++ b/host/usb/CMakeLists.txt
@@ -72,24 +72,3 @@ idf_component_register(SRCS ${srcs}
 if(CONFIG_COMPILER_STATIC_ANALYZER AND CMAKE_C_COMPILER_ID STREQUAL "GNU") # TODO GCC-366 (segfault)
     set_property(SOURCE usb_host.c PROPERTY COMPILE_FLAGS -fno-analyzer)
 endif()
-
-# Create public symbol representing remote wakeup changes availability based on IDF version
-# Remote wakeup HAL changes are present:
-# On IDF 5.4.x from IDF 5.4.4
-# On IDF 5.5.x from IDF 5.5.3
-# On IDF 6.0.x from IDF 6.0.0
-set(REMOTE_WAKE_HAL_SUPPORTED OFF)
-set(IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
-
-# IDF 5.4.x from 5.4.4
-if(IDF_VERSION VERSION_GREATER_EQUAL "5.4.4" AND IDF_VERSION VERSION_LESS "5.5.0")
-    set(REMOTE_WAKE_HAL_SUPPORTED ON)
-
-# IDF 5.5.x from 5.5.3 and all 6.x+
-elseif(IDF_VERSION VERSION_GREATER_EQUAL "5.5.3")
-    set(REMOTE_WAKE_HAL_SUPPORTED ON)
-endif()
-
-if(REMOTE_WAKE_HAL_SUPPORTED)
-    target_compile_definitions(${COMPONENT_LIB} PUBLIC REMOTE_WAKE_HAL_SUPPORTED)
-endif()

--- a/host/usb/idf_component.yml
+++ b/host/usb/idf_component.yml
@@ -8,7 +8,7 @@ repository: "https://github.com/espressif/esp-usb.git"
 repository_info:
   path: "host/usb"
 dependencies:
-  idf: ">=5.4"
+  idf: ">=5.5.3"
 targets:
   - esp32s2
   - esp32s3

--- a/host/usb/include/usb/usb_helpers.h
+++ b/host/usb/include/usb/usb_helpers.h
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
-Warning: The USB Host Library API is still a beta version and may be subject to change
-*/
-
 #pragma once
 
 #include <stdint.h>

--- a/host/usb/include/usb/usb_host.h
+++ b/host/usb/include/usb/usb_host.h
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
-Warning: The USB Host Library API is still a beta version and may be subject to change
-*/
-
 #pragma once
 
 #include <stdint.h>

--- a/host/usb/include/usb/usb_host.h
+++ b/host/usb/include/usb/usb_host.h
@@ -25,6 +25,8 @@ extern "C" {
 
 // ------------------------------------------------- Macros and Types --------------------------------------------------
 
+#define REMOTE_WAKE_HAL_SUPPORTED (1)  // Define for class drivers that this version of usb component supports the remote wakeup HAL API.
+
 // ----------------------- Handles -------------------------
 
 /**

--- a/host/usb/include/usb/usb_types_ch9.h
+++ b/host/usb/include/usb/usb_types_ch9.h
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
-Warning: The USB Host Library API is still a beta version and may be subject to change
-*/
-
 #pragma once
 
 #include <stdint.h>

--- a/host/usb/include/usb/usb_types_stack.h
+++ b/host/usb/include/usb/usb_types_stack.h
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
-Warning: The USB Host Library API is still a beta version and may be subject to change
-*/
-
 #pragma once
 
 #include <stdbool.h>

--- a/host/usb/private_include/hcd.h
+++ b/host/usb/private_include/hcd.h
@@ -75,9 +75,7 @@ typedef enum {
     HCD_PORT_EVENT_DISCONNECTION,   /**< A device disconnection has been detected */
     HCD_PORT_EVENT_ERROR,           /**< A port error has been detected. Port is now HCD_PORT_STATE_RECOVERY  */
     HCD_PORT_EVENT_OVERCURRENT,     /**< Overcurrent detected on the port. Port is now HCD_PORT_STATE_RECOVERY */
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
     HCD_PORT_EVENT_REMOTE_WAKEUP,   /**< A remote-wakeup event from device has been detected */
-#endif // REMOTE_WAKE_HAL_SUPPORTED
 } hcd_port_event_t;
 
 /**

--- a/host/usb/src/hcd_dwc.c
+++ b/host/usb/src/hcd_dwc.c
@@ -863,7 +863,6 @@ static hcd_port_event_t _intr_hdlr_hprt(port_t *port, usb_dwc_hal_port_event_t h
         port->flags.conn_dev_ena = 0;
         break;
     }
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
     case USB_DWC_HAL_PORT_EVENT_REMOTE_WAKEUP: {
         ESP_EARLY_LOGD(HCD_DWC_TAG, "Remote wakeup generated from device");
         // Port must have been previously suspended to start processing remote wakeup signaling
@@ -872,7 +871,6 @@ static hcd_port_event_t _intr_hdlr_hprt(port_t *port, usb_dwc_hal_port_event_t h
         }
         break;
     }
-#endif // REMOTE_WAKE_HAL_SUPPORTED
     default: {
         abort();
         break;
@@ -1180,7 +1178,6 @@ static inline bool _is_fifo_config_by_bias(const usb_dwc_hal_fifo_config_t *cfg)
  */
 static inline bool _internal_clk_gate(port_t *port, bool enable)
 {
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
     // Stop PHY Clock and gate HCLK
     usb_dwc_hal_pwr_clk_internal_clock_gate(port->hal, enable);
 
@@ -1197,9 +1194,6 @@ static inline bool _internal_clk_gate(port_t *port, bool enable)
         return true;
     }
     return false;
-#else
-    return true;
-#endif // REMOTE_WAKE_HAL_SUPPORTED
 }
 
 // ---------------------- Commands -------------------------

--- a/host/usb/src/hcd_dwc.c
+++ b/host/usb/src/hcd_dwc.c
@@ -1168,9 +1168,6 @@ static inline bool _is_fifo_config_by_bias(const usb_dwc_hal_fifo_config_t *cfg)
 /**
  * @brief Gate internal clock
  *
- * @note HAL functions used in this function were backported together with remote wakeup changes, we are guarding the
- *       presence of both using the same public define
- *
  * @param[in] port Pointer to the port object
  * @param[in] enable enable/disable internal clock gating
  * @return True internal clk successfully gated/un-gated

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -513,13 +513,11 @@ reset_err:
 
         break;
     }
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
     case HCD_PORT_EVENT_REMOTE_WAKEUP:
         // Mark root port as ready to be resumed
         // We allow this to fail in case a disconnect/port error happens while remote wakeup.
         hub_root_mark_resume();
         break;
-#endif // REMOTE_WAKE_HAL_SUPPORTED
     default:
         abort();    // Should never occur
         break;

--- a/host/usb/src/usb_host.c
+++ b/host/usb/src/usb_host.c
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
-Warning: The USB Host Library API is still a beta version and may be subject to change
-*/
-
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/host/usb/test/mocks/usb_host_full_mock/usb/CMakeLists.txt
+++ b/host/usb/test/mocks/usb_host_full_mock/usb/CMakeLists.txt
@@ -28,8 +28,3 @@ target_sources(${COMPONENT_LIB} PRIVATE "${original_usb_dir}/src/usb_private.c")
 
 # Add the extra src files for USB device mocking
 target_sources(${COMPONENT_LIB} PRIVATE "mock_add_usb_device.cpp")
-
-# Set public symbol REMOTE_WAKE_HAL_SUPPORTED, which is normally set in usb component cmake
-# and depends on remote wakeup feature presence in USB HAL/LL
-set(REMOTE_WAKE_HAL_SUPPORTED ON)
-target_compile_definitions(${COMPONENT_LIB} PUBLIC REMOTE_WAKE_HAL_SUPPORTED)

--- a/host/usb/test/target_test/common/hcd_common.c
+++ b/host/usb/test/target_test/common/hcd_common.c
@@ -432,7 +432,6 @@ void test_hcd_ping_device(hcd_pipe_handle_t default_pipe, urb_t *default_urb)
     TEST_ASSERT_EQUAL(USB_B_DESCRIPTOR_TYPE_CONFIGURATION, config_desc->bDescriptorType);
 }
 
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
 void test_hcd_remote_wake_enable(hcd_pipe_handle_t default_pipe, urb_t *feature_urb, bool enable)
 {
     feature_urb->transfer.num_bytes = sizeof(usb_setup_packet_t);
@@ -488,4 +487,3 @@ bool test_hcd_remote_wake_check(hcd_pipe_handle_t default_pipe, urb_t *get_statu
     printf("Remote wake-up is currently %s\n", ((remote_wake_enabled)) ? ("enabled") : ("disabled") );
     return remote_wake_enabled;
 }
-#endif // REMOTE_WAKE_HAL_SUPPORTED

--- a/host/usb/test/target_test/common/hcd_common.h
+++ b/host/usb/test/target_test/common/hcd_common.h
@@ -221,7 +221,6 @@ uint8_t test_hcd_enum_device(hcd_pipe_handle_t default_pipe);
  */
 void test_hcd_ping_device(hcd_pipe_handle_t default_pipe, urb_t *default_urb);
 
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
 /**
  * @brief Enable remote wakeup feature on device
  *
@@ -244,4 +243,3 @@ void test_hcd_remote_wake_enable(hcd_pipe_handle_t default_pipe, urb_t *feature_
  *         False if remote wake-up is currently disabled
  */
 bool test_hcd_remote_wake_check(hcd_pipe_handle_t default_pipe, urb_t *get_status_urb);
-#endif // REMOTE_WAKE_HAL_SUPPORTED

--- a/host/usb/test/target_test/common/idf_component.yml
+++ b/host/usb/test/target_test/common/idf_component.yml
@@ -4,4 +4,4 @@ dependencies:
     version: "*"
     override_path: "../../../../usb"
     matches:
-      - if: "idf_version >=5.4"                 # Use managed component only for 5.4 and above
+      - if: "idf_version >=5.5.3"                 # Use managed component only for 5.5.3 and above

--- a/host/usb/test/target_test/hcd/main/test_hcd_port.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_port.c
@@ -473,7 +473,6 @@ TEST_CASE("Test HCD port command bailout", "[port][low_speed][full_speed][high_s
     vSemaphoreDelete(sync_sem);
 }
 
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
 /*
 Test HCD port remote wakeup
 
@@ -542,5 +541,3 @@ TEST_CASE("Test HCD port remote wakeup", "[port][low_speed][full_speed][high_spe
     test_hcd_free_urb(set_feature_urb);
     test_hcd_wait_for_disconn(port_hdl, false);
 }
-
-#endif // REMOTE_WAKE_HAL_SUPPORTED

--- a/host/usb/test/target_test/usb_host/main/ctrl_client.h
+++ b/host/usb/test/target_test/usb_host/main/ctrl_client.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,4 @@ typedef struct {
 
 void ctrl_client_async_seq_task(void *arg);
 
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
 void ctrl_client_remote_wake_task(void *arg);
-#endif // REMOTE_WAKE_HAL_SUPPORTED

--- a/host/usb/test/target_test/usb_host/main/remote_wake_client.c
+++ b/host/usb/test/target_test/usb_host/main/remote_wake_client.c
@@ -14,7 +14,6 @@
 #include "usb/usb_host.h"
 #include "unity.h"
 
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
 /*
 Implementation of remote wakeup client used for USB Host tests
 
@@ -290,5 +289,3 @@ void ctrl_client_remote_wake_task(void *arg)
     ESP_LOGI(REMOTE_WAKE_CLIENT_TAG, "Done");
     vTaskDelete(NULL);
 }
-
-#endif // REMOTE_WAKE_HAL_SUPPORTED

--- a/host/usb/test/target_test/usb_host/main/test_usb_host_async.c
+++ b/host/usb/test/target_test/usb_host/main/test_usb_host_async.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -676,7 +676,6 @@ TEST_CASE("Test USB Host suspend/resume multiple tasks access (no client)", "[us
     TEST_ASSERT_MESSAGE(ulTaskNotifyTake(pdFALSE, pdMS_TO_TICKS(1000)), "usb host lib task did not finish");
 }
 
-#ifdef REMOTE_WAKE_HAL_SUPPORTED
 /*
 Note: This test is run in CI only in limited state (open MSC device -> Check remote wakeup from descriptor -> close device)
       It can be run manually with remote wakeup capable device
@@ -723,5 +722,3 @@ TEST_CASE("Test USB Host remote wakeup", "[usb_host][low_speed][full_speed][high
     }
     printf("Deleting host_lib_task\n");
 }
-
-#endif // REMOTE_WAKE_HAL_SUPPORTED


### PR DESCRIPTION
Overriding esp-idf native `usb` component with managed component from esp-usb was supported for all service period releases. At the time of first release, this was 5.4 and 5.5

IDF 5.4 entered maintenance period in January 2026. It is time to drop support for managed usb in5.4

The minimal required version is now 5.5.3 which already support remote wake-up HAL API