### PR TITLE
change: Do not wrap main in linux tests

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/CMakeLists.txt
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/CMakeLists.txt
@@ -3,7 +3,3 @@ idf_component_register(SRC_DIRS .
                         INCLUDE_DIRS "../../" .
                         PRIV_INCLUDE_DIRS "../../../private_include"
                         WHOLE_ARCHIVE)
-
-# We do not use main() from esp-idf as it discards argc and argv arguments
-# We wrap main so argc and argv are correctly passed to Catch2
-target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_main.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <catch2/catch_session.hpp>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -25,7 +26,11 @@ static void main_task(void *args)
     vTaskDelete(NULL);
 }
 
-extern "C" int __wrap_main(int argc, const char **argv)
+extern "C" void app_main(void)
+{
+}
+
+int main(int argc, const char **argv)
 {
     // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
     // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.

--- a/host/class/msc/usb_host_msc/host_test/main/CMakeLists.txt
+++ b/host/class/msc/usb_host_msc/host_test/main/CMakeLists.txt
@@ -2,7 +2,3 @@ idf_component_register(SRC_DIRS .
                         REQUIRES cmock
                         INCLUDE_DIRS .
                         WHOLE_ARCHIVE)
-
-# We do not use main() from esp-idf as it discards argc and argv arguments
-# We wrap main so argc and argv are correctly passed to Catch2
-target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/class/msc/usb_host_msc/host_test/main/test_main.cpp
+++ b/host/class/msc/usb_host_msc/host_test/main/test_main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <catch2/catch_session.hpp>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -25,7 +26,11 @@ static void main_task(void *args)
     vTaskDelete(NULL);
 }
 
-extern "C" int __wrap_main(int argc, const char **argv)
+extern "C" void app_main(void)
+{
+}
+
+int main(int argc, const char **argv)
 {
     // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
     // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.

--- a/host/class/uac/usb_host_uac/host_test/main/CMakeLists.txt
+++ b/host/class/uac/usb_host_uac/host_test/main/CMakeLists.txt
@@ -2,7 +2,3 @@ idf_component_register(SRC_DIRS .
                         REQUIRES cmock
                         INCLUDE_DIRS .
                         WHOLE_ARCHIVE)
-
-# We do not use main() from esp-idf as it discards argc and argv arguments
-# We wrap main so argc and argv are correctly passed to Catch2
-target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/class/uac/usb_host_uac/host_test/main/test_main.cpp
+++ b/host/class/uac/usb_host_uac/host_test/main/test_main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <catch2/catch_session.hpp>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -25,7 +26,11 @@ static void main_task(void *args)
     vTaskDelete(NULL);
 }
 
-extern "C" int __wrap_main(int argc, const char **argv)
+extern "C" void app_main(void)
+{
+}
+
+int main(int argc, const char **argv)
 {
     // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
     // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.

--- a/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
+++ b/host/class/uvc/usb_host_uvc/host_test/main/CMakeLists.txt
@@ -3,7 +3,3 @@ idf_component_register(SRC_DIRS . parsing streaming opening
                         INCLUDE_DIRS . parsing streaming opening
                         PRIV_INCLUDE_DIRS "../../private_include"
                         WHOLE_ARCHIVE)
-
-# We do not use main() from esp-idf as it discards argc and argv arguments
-# We wrap main so argc and argv are correctly passed to Catch2
-target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/class/uvc/usb_host_uvc/host_test/main/test_main.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/test_main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <catch2/catch_session.hpp>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -25,7 +26,11 @@ static void main_task(void *args)
     vTaskDelete(NULL);
 }
 
-extern "C" int __wrap_main(int argc, const char **argv)
+extern "C" void app_main(void)
+{
+}
+
+int main(int argc, const char **argv)
 {
     // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
     // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.

--- a/host/usb/test/host_test/usb_host_layer_test/main/CMakeLists.txt
+++ b/host/usb/test/host_test/usb_host_layer_test/main/CMakeLists.txt
@@ -7,7 +7,3 @@ list(APPEND srcs "test_main.cpp"
 idf_component_register(SRCS  ${srcs}
                         REQUIRES cmock usb
                         WHOLE_ARCHIVE)
-
-# We do not use main() from esp-idf as it discards argc and argv arguments
-# We wrap main so argc and argv are correctly passed to Catch2
-target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/usb/test/host_test/usb_host_layer_test/main/test_main.cpp
+++ b/host/usb/test/host_test/usb_host_layer_test/main/test_main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <catch2/catch_session.hpp>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -25,7 +26,11 @@ static void main_task(void *args)
     vTaskDelete(NULL);
 }
 
-extern "C" int __wrap_main(int argc, const char **argv)
+extern "C" void app_main(void)
+{
+}
+
+int main(int argc, const char **argv)
 {
     // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
     // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.

--- a/host/usb/test/host_test/usbh_layer_test/main/CMakeLists.txt
+++ b/host/usb/test/host_test/usbh_layer_test/main/CMakeLists.txt
@@ -6,7 +6,3 @@ list(APPEND srcs "test_main.cpp"
 idf_component_register(SRCS  ${srcs}
                         REQUIRES cmock usb
                         WHOLE_ARCHIVE)
-
-# We do not use main() from esp-idf as it discards argc and argv arguments
-# We wrap main so argc and argv are correctly passed to Catch2
-target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/host/usb/test/host_test/usbh_layer_test/main/test_main.cpp
+++ b/host/usb/test/host_test/usbh_layer_test/main/test_main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <catch2/catch_session.hpp>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -25,7 +26,11 @@ static void main_task(void *args)
     vTaskDelete(NULL);
 }
 
-extern "C" int __wrap_main(int argc, const char **argv)
+extern "C" void app_main(void)
+{
+}
+
+int main(int argc, const char **argv)
 {
     // Following section is copied from components\freertos\FreeRTOS-Kernel\portable\linux\port_idf.c
     // It starts the FreeRTOS scheduler and creates the main task to run Catch2 tests.


### PR DESCRIPTION
Latest IDF provides weak main, so we do not need to wrap

Partly reverts https://github.com/espressif/esp-usb/pull/375 because esp-idf now supports main overriding without linker wrapping.

Also fixes build on MacOS