### PR TITLE
fix(CH34x): Invert DTR/RTS for CH34x converters

### DIFF
--- a/host/class/cdc/usb_host_ch34x_vcp/CHANGELOG.md
+++ b/host/class/cdc/usb_host_ch34x_vcp/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.1
+- Fix DTR/RTS polarity for CH34x
+
 ## 2.2.0
 - Added PID autodetection
 

--- a/host/class/cdc/usb_host_ch34x_vcp/idf_component.yml
+++ b/host/class/cdc/usb_host_ch34x_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.2.0"
+version: "2.2.1"
 description: USB Host driver for CH34x series of chips
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_ch34x_vcp
 issues: "https://github.com/espressif/esp-usb/issues"

--- a/host/class/cdc/usb_host_ch34x_vcp/usb_host_ch34x_vcp.c
+++ b/host/class/cdc/usb_host_ch34x_vcp/usb_host_ch34x_vcp.c
@@ -114,12 +114,12 @@ static int calculate_baud_divisor(unsigned int baud_rate, unsigned char *factor,
 // It strictly follows interface defined in interface/usb/cdc_acm_host_inteface.h
 static esp_err_t ch34x_set_control_line_state(cdc_acm_dev_hdl_t cdc_hdl, bool dtr, bool rts)
 {
-    uint16_t wValue = 0;
+    uint16_t wValue = CH34X_CONTROL_DTR | CH34X_CONTROL_RTS;
     if (dtr) {
-        wValue |= CH34X_CONTROL_DTR;
+        wValue &= ~CH34X_CONTROL_DTR;
     }
     if (rts) {
-        wValue |= CH34X_CONTROL_RTS;
+        wValue &= ~CH34X_CONTROL_RTS;
     }
     return cdc_acm_host_send_custom_request(cdc_hdl, CH34X_WRITE_REQ, CH34X_CMD_MODEM_OUT, wValue, cdc_hdl->notif.intf_desc->bInterfaceNumber, 0, NULL);
 }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
The CH34x VCP driver was sending the modem control bits (DTR/RTS) with inverted polarity. The CH34X_CONTROL_DTR/CH34X_CONTROL_RTS bits in the MODEM_OUT command are active-low, so the line was asserted when it should have been de-asserted and vice versa. The bits are now set by default and cleared when the corresponding signal is requested, matching the hardware's active-low behavior.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

- Closes https://github.com/espressif/esp-serial-flasher/issues/154

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
Tested on ESP32C3 board with CH340. 
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
