### PR TITLE
fix(uvc): handle payload errors (IEC-551)

### DIFF
--- a/host/class/uvc/usb_host_uvc/Kconfig
+++ b/host/class/uvc/usb_host_uvc/Kconfig
@@ -24,4 +24,10 @@ menu "USB HOST UVC"
         default y
         help
             "If ERR is set in the header, this is an error packet, and the frame will be discarded"
+
+    config UVC_CHECK_PAYLOAD_HEADER_SOI
+        bool "Check SOI bit in payload header"
+        default y
+        help
+            "If SOI is set in the header, this is an error packet, and the frame will be discarded"
 endmenu

--- a/host/class/uvc/usb_host_uvc/uvc_isoc.c
+++ b/host/class/uvc/usb_host_uvc/uvc_isoc.c
@@ -119,6 +119,7 @@ void isoc_transfer_callback(usb_transfer_t *transfer)
             uvc_stream->single_thread.skip_current_frame = false;
 #endif // CONFIG_UVC_CHECK_PAYLOAD_HEADER_ERR
 
+#ifdef CONFIG_UVC_CHECK_PAYLOAD_HEADER_SOI
             // Check mjpeg frame start
             if (uvc_stream->dynamic.vs_format.format == UVC_VS_FORMAT_MJPEG &&
                     (payload_data[0] != JPEG_MARKER || payload_data[1] != JPEG_SOI)) {
@@ -126,6 +127,7 @@ void isoc_transfer_callback(usb_transfer_t *transfer)
                 uvc_stream->single_thread.skip_current_frame = true;
                 ESP_LOGW(TAG, "invalid MJPEG SOI");
             }
+#endif // CONFIG_UVC_CHECK_PAYLOAD_HEADER_SOI
 
             // Get free frame buffer for this new frame
             UVC_ENTER_CRITICAL();

--- a/host/class/uvc/usb_host_uvc/uvc_isoc.c
+++ b/host/class/uvc/usb_host_uvc/uvc_isoc.c
@@ -153,7 +153,9 @@ void isoc_transfer_callback(usb_transfer_t *transfer)
                 // We received SoF but current_frame is not NULL: We missed EoF - reset the frame buffer
                 ESP_EARLY_LOGW(TAG, "missed EoF");
                 uvc_stream->single_thread.skip_current_frame = true;
-                uvc_frame_reset(uvc_stream->dynamic.current_frame);
+                if (uvc_stream->dynamic.current_frame) {
+                    uvc_frame_reset(uvc_stream->dynamic.current_frame);
+                }
                 UVC_EXIT_CRITICAL();
             }
         }


### PR DESCRIPTION
1. Some UVC cameras may fail this check. Add a configuration option that allows users to choose the check behavior.
2. In race conditions, current_frame can be NULL. Only perform the frame reset when current_frame is valid.