### PR TITLE
fix(esp_tinyusb): Add explicit tinyusb dependency when component manager is off (IEC-554)

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+- esp_tinyusb: Add an explicit `tinyusb` dependency when the IDF component manager is disabled
+
 ## 2.2.0
 
 - esp_tinyusb: Added ESP32-S31 support

--- a/device/esp_tinyusb/CMakeLists.txt
+++ b/device/esp_tinyusb/CMakeLists.txt
@@ -9,6 +9,7 @@ set(srcs
     )
 
 set(priv_req "")
+set(req fatfs vfs)
 
 # USB-PHY driver
 # For IDF 6.x and later, usb_phy driver is moved from usb to esp_hw_support
@@ -62,11 +63,19 @@ if(${target} STREQUAL "esp32p4" OR ${target} STREQUAL "esp32s31")
     endif()
 endif() # esp32p4/esp32s31
 
+# idf_component.yml is ignored when the component manager is disabled, so the
+# dependency on tinyusb must be declared here instead. It belongs in REQUIRES
+# (not PRIV_REQUIRES) because the public header tinyusb.h includes tusb.h.
+idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
+if(NOT idf_component_manager)
+    list(APPEND req tinyusb)
+endif()
+
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"
                        PRIV_INCLUDE_DIRS "include_private"
                        PRIV_REQUIRES ${priv_req}
-                       REQUIRES fatfs vfs
+                       REQUIRES ${req}
                        )
 
 # Determine whether tinyusb is fetched from component registry or from local path

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-usb/en/latest/esp32p4/usb_device.html"
-version: "2.2.0"
+version: "2.2.1"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 repository: "https://github.com/espressif/esp-usb.git"
 repository_info:


### PR DESCRIPTION
# Checklist

- [x] Version in idf_component.yml file bumped
- [x] CHANGELOG.md entry added
- [ ] _Optional:_ README.md updated
- [ ] CI passing

# Change description

## What's broken

`esp_tinyusb` declares its dependency on `espressif/tinyusb` only in `idf_component.yml`. When a downstream project disables the component manager (`idf_build_set_property(IDF_COMPONENT_MANAGER 0)`) and adds TinyUSB directly as a local component, that manifest is ignored, and the dependency never makes it into the IDF build graph.

Two things break as a result:

1. **Build order.** The bottom of `device/esp_tinyusb/CMakeLists.txt` does:

   ```cmake
   idf_component_get_property(tusb_lib ${tinyusb_name} COMPONENT_LIB)
   target_include_directories(${tusb_lib} PRIVATE "include")
   ```

   Without a requirement edge between the two components, ESP-IDF is free to process `esp_tinyusb` before TinyUSB. When it does, `__idf_tinyusb` doesn't exist yet and configuration fails:

   ```
   CMake Error at .../esp_tinyusb/CMakeLists.txt:82 (target_include_directories):
     Cannot specify include directories for target "__idf_tinyusb" which is not
     built by this project.
   ```

2. **Public interface.** `esp_tinyusb`'s public header `include/tinyusb.h` includes `tusb.h`, which is owned by the TinyUSB component. Without a *public* requirement edge, any consumer of `esp_tinyusb` fails to compile with `fatal error: tusb.h: No such file or directory`.

The existing `BUILD_COMPONENTS` lookup further down resolves the right component name (`tinyusb` for the local case, `espressif__tinyusb` for the managed case) — but it runs too late to influence build order.

## The fix

When `IDF_COMPONENT_MANAGER` is off, append `tinyusb` to `REQUIRES`:

```cmake
idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
if(NOT idf_component_manager)
    list(APPEND req tinyusb)
endif()
```

This adds the missing edge so `esp_tinyusb` is processed after TinyUSB (fixing the `target_include_directories` race), and it's a **public** requirement, matching `public: true` in the manifest, so consumers can resolve `tusb.h` through `tinyusb.h`. A `PRIV_REQUIRES` edge would fix the build-order race but still leave consumers unable to find `tusb.h`.

The literal name `tinyusb` matches the assumption already encoded in the post-register `BUILD_COMPONENTS` check, so there's no new convention introduced.

## Why guard on `IDF_COMPONENT_MANAGER` rather than always requiring `tinyusb`

The two paths register TinyUSB under different names: the local component is `tinyusb`, while the managed dependency from `idf_component.yml` is registered as `espressif__tinyusb` (this is exactly the split the post-register `BUILD_COMPONENTS` check already handles). An unconditional `REQUIRES tinyusb` would reference a nonexistent component in the managed path and leave the requirement unresolved.

`IDF_COMPONENT_MANAGER` is set in `tools/cmake/project.cmake` before component discovery, so it's a stable signal at expand-requirements time. Guarding on whether TinyUSB is already in `BUILD_COMPONENTS` would not work: `expand_requirements.cmake` does a partial-evaluation pass to extract `REQUIRES`/`PRIV_REQUIRES` before any component is fully processed, and during that pass `BUILD_COMPONENTS` is still empty.

## Compatibility

- **Projects with the component manager enabled** (the documented default path): no change. The new branch isn't taken, TinyUSB continues to come in via `idf_component.yml` as `espressif__tinyusb`, and the existing post-register name lookup resolves correctly.
- **Projects with the component manager disabled**: gain a working, public build-order edge.
- Assumes a local TinyUSB component directory named `tinyusb` — the same assumption the existing code already makes.

## Reproduction

Any project that:
1. Calls `idf_build_set_property(IDF_COMPONENT_MANAGER 0)` (or `export IDF_COMPONENT_MANAGER=0`),
2. Adds both `espressif/tinyusb` and `espressif/esp-usb/device/esp_tinyusb` as local components,
3. Has neither component declare a requirement on the other,

will fail to configure (and, with only a private edge, fail to compile consumers) on ESP-IDF v5.x/v6.x with the errors above. Verified the fix on ESP-IDF v6.0.1, target `xtensa-esp32s3` — configuration and full build succeed.
