### PR TITLE
feat(usb_device): esp_tinyusb API calls with a device in suspended state

### DIFF
--- a/device/esp_tinyusb/test_apps/power_management/README.md
+++ b/device/esp_tinyusb/test_apps/power_management/README.md
@@ -7,7 +7,24 @@ The tests focus on:
 - Power management of the USB Device
 - Testing tinyusb suspend/resume callbacks delivery
 - Testing remote wakeup signalizing by the device
+- Calling esp_tinyusb public API when the USB Device is in suspended state
+- Init/Deinit of esp_tinyusb driver with device in suspended state
 
-## Running the test locally on Linux host PC:
+## Running the tests on a host PC
 
-- User needs to [set permissions](../README.md#set-root-permissions-for-low-level-access-to-usb-devices) to the USB device, to successfully run test app on Linux host PC
+These pytest cases rely on the Linux kernel **USB automatic suspend** feature. After a short period of USB inactivity (about 2–3 seconds), the host suspends the device. That suspend/resume cycle is what triggers the TinyUSB power-management events validated by the tests.
+
+### Linux (Ubuntu)
+
+The tests are verified on **Ubuntu** (CI runners are using Ubuntu). The USB `power/control` could be `auto` or `on`, depending on the linux distribution build.
+
+If automatic suspend is disabled on your Linux host (for example on Raspberry Pi CI runners, where `power/control` defaults to `on`), enable it with a UDEV rule as described in [Set power management of the USB device](../README.md#set-power-management-of-the-usb-device) in the parent README.
+
+Additional Linux setup:
+
+- User needs to [set permissions](../README.md#set-root-permissions-for-low-level-access-to-usb-devices) to the USB device to successfully run the test app on a Linux host PC
+- The `pyusb` Python package must be installed manually before running pytest (`pip install pyusb`)
+
+### Windows, macOS, and other non-Linux hosts
+
+These pytest tests were **not tested** with Windows, macOS, or other non-Linux host PCs. They depend on Linux kernel USB power management (automatic suspend/resume) and on Linux CDC-ACM driver behavior used by the test scripts.

--- a/device/esp_tinyusb/test_apps/power_management/main/test_device_pm.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_device_pm.c
@@ -12,8 +12,11 @@
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "freertos/event_groups.h"
+#include "freertos/semphr.h"
 #include "esp_log.h"
 #include "esp_err.h"
+#include "esp_bit_defs.h"
 
 #include "unity.h"
 #include "tinyusb.h"
@@ -26,14 +29,22 @@
 #define SUSPEND_RESUME_TEST_ITERATIONS          5
 #define DEVICE_EVENT_WAIT_MS                    5000
 
-#define EVENT_BITS_ATTACHED                     (1U << 0)   /**< Device attached event */
-#define EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN     (1U << 1)   /**< Device suspended with remote wakeup enabled event */
-#define EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS    (1U << 2)   /**< Device suspended with remote wakeup disabled event */
-#define EVENT_BITS_RESUMED                      (1U << 3)   /**< Device resumed event */
+#define EVENT_BITS_ATTACHED                     BIT0   /**< Device attached event */
+#define EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN     BIT1   /**< Device suspended with remote wakeup enabled event */
+#define EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS    BIT2   /**< Device suspended with remote wakeup disabled event */
+#define EVENT_BITS_RESUMED                      BIT3   /**< Device resumed event */
+#define DEVICE_EVENT_BITS_ALL   (EVENT_BITS_ATTACHED | EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN | \
+                                 EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS | EVENT_BITS_RESUMED)
 
 static char err_msg_buf[128];
 const static char *TAG = "PM_Device";
-static TaskHandle_t main_task_hdl = NULL;
+
+// Static event group for device event delivery
+static EventGroupHandle_t device_event_group = NULL;
+static StaticEventGroup_t device_event_group_buffer;
+// Static binary semaphore for RX data callback
+static SemaphoreHandle_t rx_data_sem = NULL;
+static StaticSemaphore_t rx_data_sem_buffer;
 
 static const tusb_desc_device_t cdc_device_descriptor = {
     .bLength = sizeof(cdc_device_descriptor),
@@ -81,110 +92,40 @@ static const uint8_t cdc_desc_configuration_remote_wakeup[] = {
 };
 
 /**
+ * @brief Initialize freertos primitives for the test
+ *
+ * Event group bits for device events delivery (suspend, resume, attach, detach)
+ * Semaphore for RX callback notifications
+ */
+static void test_pm_sync_init(void)
+{
+    if (device_event_group == NULL) {
+        device_event_group = xEventGroupCreateStatic(&device_event_group_buffer);
+    }
+    xEventGroupClearBits(device_event_group, DEVICE_EVENT_BITS_ALL);
+
+    if (rx_data_sem == NULL) {
+        rx_data_sem = xSemaphoreCreateBinaryStatic(&rx_data_sem_buffer);
+    }
+    while (xSemaphoreTake(rx_data_sem, 0) == pdTRUE) {
+    }
+}
+
+/**
  * @brief CDC Device RX callback for tinyusb_suspend_resume_events test case
  */
 static void tinyusb_cdc_rx_callback(int itf, cdcacm_event_t *event)
 {
-    if (main_task_hdl != NULL) {
+    if (rx_data_sem != NULL) {
         ESP_LOGI(TAG, "RX data cb");
-        xTaskNotifyGive(main_task_hdl);
+        xSemaphoreGive(rx_data_sem);
     }
 }
 
 /**
- * @brief Device event handler for tinyusb_suspend_resume_events test case
+ * @brief Device event handler providing event group bits
  */
-static void test_suspend_resume_event_handler(tinyusb_event_t *event, void *arg)
-{
-    switch (event->id) {
-    case TINYUSB_EVENT_ATTACHED:
-        printf("TINYUSB_EVENT_ATTACHED\n");
-        break;
-    case TINYUSB_EVENT_DETACHED:
-        printf("TINYUSB_EVENT_DETACHED\n");
-        break;
-    case TINYUSB_EVENT_SUSPENDED:
-        printf("TINYUSB_EVENT_SUSPENDED\n");
-        break;
-    case TINYUSB_EVENT_RESUMED:
-        printf("TINYUSB_EVENT_RESUMED\n");
-        break;
-    default:
-        break;
-    }
-}
-
-/**
- * @brief Tinyusb power management suspend/resume events
- *
- * Tests TINYUSB_EVENT_SUSPENDED and TINYUSB_EVENT_RESUMED esp_tinyusb events
- *
- * Pytest expects TINYUSB_EVENT_SUSPENDED event - because of auto suspend
- * Pytest sends data to device to resume it
- * Device resumes, receives and validates the data, sends a response and goes to suspended state (auto suspend)
- * Pytest expect TINYUSB_EVENT_SUSPENDED ...
- */
-TEST_CASE("tinyusb_suspend_resume_events", "[esp_tinyusb][device_pm_suspend_resume]")
-{
-    // Get current task handle for task notification from the RX callback
-    main_task_hdl = xTaskGetCurrentTaskHandle();
-
-    // Install TinyUSB driver
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_suspend_resume_event_handler);
-    tusb_cfg.descriptor.device = &cdc_device_descriptor;
-    tusb_cfg.descriptor.full_speed_config = cdc_desc_configuration_remote_wakeup;
-#if (TUD_OPT_HIGH_SPEED)
-    tusb_cfg.descriptor.qualifier = &device_qualifier;
-    tusb_cfg.descriptor.high_speed_config = cdc_desc_configuration_remote_wakeup;
-#endif // TUD_OPT_HIGH_SPEED
-
-    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
-    acm_cfg.callback_rx = &tinyusb_cdc_rx_callback;
-
-    // Init CDC device
-    TEST_ASSERT_FALSE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
-    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_init(&acm_cfg));
-    TEST_ASSERT_TRUE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
-
-    uint8_t buf[TINYUSB_CDC_RX_BUFSIZE + 1];
-    const char expect_reply[] = "Time to resume\r\n";
-    const char send_message[] = "Time to suspend\r\n";
-
-    int test_iterations = 0;
-    do {
-        // Wait for new data from the host (Sent by pytest)
-        if (pdTRUE == ulTaskNotifyTake(true, pdMS_TO_TICKS(10000))) {
-
-            size_t rx_size = 0;
-            ESP_ERROR_CHECK(tinyusb_cdcacm_read(TINYUSB_CDC_ACM_0, buf, TINYUSB_CDC_RX_BUFSIZE, &rx_size));
-            if (rx_size > 0) {
-                ESP_LOGI(TAG, "Intf %d, RX %d bytes", TINYUSB_CDC_ACM_0, rx_size);
-                // Check if received string is equal to expect_reply string
-                TEST_ASSERT_EQUAL_UINT8_ARRAY(expect_reply, buf, sizeof(expect_reply) - 1);
-
-                // Reply to the host with send_message string
-                strncpy((char *)buf, send_message, sizeof(send_message) - 1);
-                tinyusb_cdcacm_write_queue(TINYUSB_CDC_ACM_0, buf, sizeof(send_message) - 1);
-                tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, 0);
-                test_iterations++;
-            }
-        } else {
-            TEST_FAIL_MESSAGE("RX Data CB not received on time");
-        }
-    } while (test_iterations <= SUSPEND_RESUME_TEST_ITERATIONS);
-}
-
-/**
- * @brief Dummy CDC Device RX callback for tinyusb_remote_wakeup_reporting test case
- */
-static void tinyusb_cdc_rx_callback_dmy(int itf, cdcacm_event_t *event)
-{
-}
-
-/**
- * @brief Device event handler for tinyusb_remote_wakeup_reporting test case
- */
-static void test_remote_wake_event_handler(tinyusb_event_t *event, void *arg)
+static void device_event_handler(tinyusb_event_t *event, void *arg)
 {
     uint32_t event_bits = UINT32_MAX;
 
@@ -195,6 +136,7 @@ static void test_remote_wake_event_handler(tinyusb_event_t *event, void *arg)
         break;
     case TINYUSB_EVENT_DETACHED:
         printf("TINYUSB_EVENT_DETACHED\n");
+        // No event bits for detached event
         return;
     case TINYUSB_EVENT_SUSPENDED:
         if (event->suspended.remote_wakeup) {
@@ -213,8 +155,8 @@ static void test_remote_wake_event_handler(tinyusb_event_t *event, void *arg)
         return;
     }
 
-    if (main_task_hdl) {
-        xTaskNotify(main_task_hdl, event_bits, eSetBits);
+    if (device_event_group != NULL) {
+        xEventGroupSetBits(device_event_group, event_bits);
     }
 }
 
@@ -228,22 +170,104 @@ static void test_remote_wake_event_handler(tinyusb_event_t *event, void *arg)
  */
 static void expect_device_event_impl(const uint32_t expected_event, TickType_t ticks, const char *file, int line)
 {
-    uint32_t notify_bits = 0;
-    if (pdTRUE == xTaskNotifyWait(0, UINT32_MAX, &notify_bits, ticks)) {
-        if (expected_event != notify_bits) {
-            snprintf(err_msg_buf, sizeof(err_msg_buf),
-                     "Unexpected event at %s:%d\n %ld expected, %ld delivered\n",
-                     file, line, expected_event, notify_bits);
-            TEST_FAIL_MESSAGE(err_msg_buf);
-        }
-    } else {
+    const EventBits_t bits = xEventGroupWaitBits(device_event_group, expected_event, pdTRUE, pdTRUE, ticks);
+    if ((bits & expected_event) == expected_event) {
+        return;
+    }
+
+    if (bits != 0) {
         snprintf(err_msg_buf, sizeof(err_msg_buf),
-                 "Event %ld at %s:%d\n was not delivered on time",
-                 expected_event, file, line);
+                 "Unexpected event at %s:%d\n %ld expected, %ld delivered\n",
+                 file, line, expected_event, (uint32_t)bits);
         TEST_FAIL_MESSAGE(err_msg_buf);
     }
+
+    snprintf(err_msg_buf, sizeof(err_msg_buf),
+             "Event %ld at %s:%d\n was not delivered on time",
+             expected_event, file, line);
+    TEST_FAIL_MESSAGE(err_msg_buf);
 }
 #define expect_device_event(expected_event, ticks) expect_device_event_impl((expected_event), (ticks), __FILE__, __LINE__)
+
+/**
+ * @brief Install TinyUSB driver and initialize CDC ACM for PM tests
+ *
+ * @param[in] rx_cb     Optional CDC RX callback (may be NULL)
+ *
+ * @return tinyusb_config_t used for driver install (for reuse on reinstall)
+ */
+static tinyusb_config_t test_pm_init_tinyusb_cdc(tusb_cdcacm_callback_t rx_cb)
+{
+    // Initialize freertos primitives
+    test_pm_sync_init();
+
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(device_event_handler);
+    tusb_cfg.descriptor.device = &cdc_device_descriptor;
+    tusb_cfg.descriptor.full_speed_config = cdc_desc_configuration_remote_wakeup;
+#if (TUD_OPT_HIGH_SPEED)
+    tusb_cfg.descriptor.qualifier = &device_qualifier;
+    tusb_cfg.descriptor.high_speed_config = cdc_desc_configuration_remote_wakeup;
+#endif // TUD_OPT_HIGH_SPEED
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+    acm_cfg.callback_rx = rx_cb;
+    TEST_ASSERT_FALSE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_init(&acm_cfg));
+    TEST_ASSERT_TRUE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
+
+    return tusb_cfg;
+}
+
+/**
+ * @brief Tinyusb power management suspend/resume events
+ *
+ * Tests TINYUSB_EVENT_SUSPENDED and TINYUSB_EVENT_RESUMED esp_tinyusb events
+ *
+ * Pytest expects TINYUSB_EVENT_SUSPENDED event - because of auto suspend
+ * Pytest sends data to device to resume it
+ * Device resumes, receives and validates the data, sends a response and goes to suspended state (auto suspend)
+ * Pytest expect TINYUSB_EVENT_SUSPENDED ...
+ */
+TEST_CASE("tinyusb_suspend_resume_events", "[esp_tinyusb][device_pm_suspend_resume]")
+{
+    // Install and initialize cdc
+    test_pm_init_tinyusb_cdc(tinyusb_cdc_rx_callback);
+
+    uint8_t buf[TINYUSB_CDC_RX_BUFSIZE + 1];
+    const char expect_reply[] = "Time to resume\r\n";
+    const char send_message[] = "Time to suspend\r\n";
+
+    // Expect attach event
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    int test_iterations = 0;
+    do {
+        expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+        // Wait for new data from the host (Sent by pytest)
+        if (pdTRUE == xSemaphoreTake(rx_data_sem, pdMS_TO_TICKS(10000))) {
+
+            expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+            size_t rx_size = 0;
+            TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_read(TINYUSB_CDC_ACM_0, buf, TINYUSB_CDC_RX_BUFSIZE, &rx_size));
+            if (rx_size > 0) {
+                ESP_LOGI(TAG, "Intf %d, RX %d bytes", TINYUSB_CDC_ACM_0, rx_size);
+                // Check if received string is equal to expect_reply string
+                TEST_ASSERT_EQUAL_UINT8_ARRAY(expect_reply, buf, sizeof(expect_reply) - 1);
+
+                // Reply to the host with send_message string
+                strncpy((char *)buf, send_message, sizeof(send_message) - 1);
+                tinyusb_cdcacm_write_queue(TINYUSB_CDC_ACM_0, buf, sizeof(send_message) - 1);
+                tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, 0);
+                test_iterations++;
+            }
+        } else {
+            TEST_FAIL_MESSAGE("RX Data CB not received on time");
+        }
+    } while (test_iterations < SUSPEND_RESUME_TEST_ITERATIONS);
+
+    // Wait for the last auto suspend to finish the pytest
+    expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+}
 
 
 /**
@@ -260,28 +284,13 @@ static void expect_device_event_impl(const uint32_t expected_event, TickType_t t
  */
 TEST_CASE("tinyusb_remote_wakeup_reporting", "[esp_tinyusb][device_pm_remote_wake]")
 {
-    // Get current tak handle for the device event handler
-    main_task_hdl = xTaskGetCurrentTaskHandle();
+    // Install and initialize cdc
+    test_pm_init_tinyusb_cdc(NULL);
 
-    // Install TinyUSB driver, device with remote wakeup enabled
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_remote_wake_event_handler);
-    tusb_cfg.descriptor.device = &cdc_device_descriptor;
-    tusb_cfg.descriptor.full_speed_config = cdc_desc_configuration_remote_wakeup;
-#if (TUD_OPT_HIGH_SPEED)
-    tusb_cfg.descriptor.qualifier = &device_qualifier;
-    tusb_cfg.descriptor.high_speed_config = cdc_desc_configuration_remote_wakeup;
-#endif // TUD_OPT_HIGH_SPEED
-
-    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
-    acm_cfg.callback_rx = &tinyusb_cdc_rx_callback_dmy;
-
-    // Init CDC device
-    TEST_ASSERT_FALSE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
-    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_init(&acm_cfg));
-    TEST_ASSERT_TRUE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
-
-    // Expect attach event and auto suspend event with remote wakeup disabled by default
+    // Expect attach event
     expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    // Expect auto suspend event with remote wakeup disabled by default
+    // pytest never opend tty device, just uses pyusb to interact with the device thus Linux host cdc-acm driver does not automatically enable remote wakeup
     expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
 
     // Try to signalize remote wakeup, when the host did not enable it
@@ -298,6 +307,106 @@ TEST_CASE("tinyusb_remote_wakeup_reporting", "[esp_tinyusb][device_pm_remote_wak
     // Signalize remote wakeup and expect resume event
     TEST_ASSERT_EQUAL(ESP_OK, tinyusb_remote_wakeup());
     expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+}
+
+/**
+ * @brief TinyUSB public API behavior in suspended state
+ *
+ * Tests CDC ACM read/write/flush API error handling while the device is suspended
+ *
+ * - Install device and wait for attach followed by auto suspend
+ * - Verify read returns no data while suspended
+ * - Verify write queue accepts data while suspended
+ * - Verify write flush returns ESP_OK and queues data while suspended
+ * - Pytest resumes the device by accessing it
+ * - Verify received data and flush queued data after resume
+ * - Wait for auto suspend
+ */
+TEST_CASE("tinyusb_cdc_public_api_error_handling", "[esp_tinyusb][cdc_device_pm_public_api]")
+{
+    // Install and initialize cdc
+    test_pm_init_tinyusb_cdc(tinyusb_cdc_rx_callback);
+
+    // Wait for attach event
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    // Expect auto suspend event with remote wakeup enabled by default
+    // pytest opens a tty device (not just pyusb) to interact with the device thus Linux host cdc-acm driver automatically enables remote wakeup
+    expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    size_t rx_size = 0;
+    uint8_t buf[TINYUSB_CDC_RX_BUFSIZE + 1];
+    const char send_message[] = "llo from suspended state\r\n";
+    const char expect_reply[] = "Time to resume\r\n";
+
+    // Device must be read from from suspended state
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_read(TINYUSB_CDC_ACM_0, buf, TINYUSB_CDC_RX_BUFSIZE, &rx_size));
+    TEST_ASSERT(!rx_size);
+
+    // Buffer must be queued even if in suspended state
+    TEST_ASSERT_EQUAL_INT16(1, tinyusb_cdcacm_write_queue_char(TINYUSB_CDC_ACM_0, 'H'));
+    TEST_ASSERT_EQUAL_INT16(1, tinyusb_cdcacm_write_queue_char(TINYUSB_CDC_ACM_0, 'e'));
+    TEST_ASSERT_EQUAL_INT16(sizeof(send_message) - 1, tinyusb_cdcacm_write_queue(TINYUSB_CDC_ACM_0, ((uint8_t *)send_message), sizeof(send_message) - 1));
+    // Buffer shall be be flushed in suspended state (in tinyusb v 0.20, ESP_ERR_NOT_FINISHED was expected)
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, 0));
+
+    // Pytest resumes the device by accessing it
+    expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    // Expect data from the host
+    if (pdTRUE == xSemaphoreTake(rx_data_sem, pdMS_TO_TICKS(10000))) {
+
+        TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_read(TINYUSB_CDC_ACM_0, buf, TINYUSB_CDC_RX_BUFSIZE, &rx_size));
+        TEST_ASSERT_MESSAGE(rx_size, "No data received from host");
+        ESP_LOGI(TAG, "Intf %d, RX %d bytes", TINYUSB_CDC_ACM_0, rx_size);
+        // Check if received string is equal to expect_reply string
+        TEST_ASSERT_EQUAL_UINT8_ARRAY(expect_reply, buf, sizeof(expect_reply) - 1);
+    } else {
+        TEST_FAIL_MESSAGE("RX Data CB not received on time");
+    }
+
+    // Write queued data
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, 0));
+
+    // Wait for auto suspend
+    expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    vTaskDelay(10);
+}
+
+/**
+ * @brief TinyUSB driver init/deinit while device is suspended
+ *
+ * Tests that the TinyUSB driver can be safely deinitialized and reinitialized
+ * while the USB device remains in suspended state
+ *
+ * - Install device and wait for attach followed by auto suspend
+ * - Deinit CDC and uninstall TinyUSB driver while suspended
+ * - Reinstall TinyUSB driver and reinit CDC while still suspended
+ */
+TEST_CASE("tinyusb_init_deinit_from_suspended", "[esp_tinyusb][device_pm]")
+{
+    // Install and initialize cdc
+    const tinyusb_config_t tusb_cfg = test_pm_init_tinyusb_cdc(NULL);
+
+    // Wait for attach event
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    // Expect auto suspend event with remote wakeup disabled by default
+    // pytest never opend tty device, just uses pyusb to interact with the device thus Linux host cdc-acm driver does not automatically enable remote wakeup
+    expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    // Deinit and uninstall the driver while the device is in suspended state
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_deinit(TINYUSB_CDC_ACM_0));
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+
+    // Let the driver to be uninstalled
+    vTaskDelay(10);
+
+    // Install the driver and init the device while in suspended state
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+
+    // Init CDC device
+    TEST_ASSERT_FALSE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_init(&acm_cfg));
+    TEST_ASSERT_TRUE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
 }
 
 #endif

--- a/device/esp_tinyusb/test_apps/power_management/pytest_usb_pm.py
+++ b/device/esp_tinyusb/test_apps/power_management/pytest_usb_pm.py
@@ -30,7 +30,6 @@ DUT_PID = 0x4002
 # Tinyusb device events from device event handler
 TINYUSB_EVENTS = {
     "attached":                     "TINYUSB_EVENT_ATTACHED",
-    "suspended":                    "TINYUSB_EVENT_SUSPENDED",
     "resumed":                      "TINYUSB_EVENT_RESUMED",
     "suspended_remote_wake_dis":    "TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_DIS",
     "suspended_remote_wake_en":     "TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_EN",
@@ -87,9 +86,9 @@ def test_usb_device_suspend_resume(dut: IdfDut) -> None:
             # This expect_exact is ignored by pytest when running second rerun of flaky test (unknown reason),
             # making the test fail in further steps, adding explicit sleep(3) to wait for the suspend events
             sleep(3)
-            dut.expect_exact(TINYUSB_EVENTS['suspended'])
+            dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
 
-            for i in range(0, 5):
+            for i in range(5):
                 print(f"Power cycle iteration {i}.")
 
                 # Resume the device by accessing it
@@ -100,13 +99,16 @@ def test_usb_device_suspend_resume(dut: IdfDut) -> None:
                 dut.expect_exact(TINYUSB_EVENTS['resumed'])
 
                 # Wait for auto suspend (set to 3 seconds)
-                dut.expect_exact(TINYUSB_EVENTS['suspended'])
+                dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
 
                 # Stay suspended for a while
                 sleep(2)
 
     except SerialException as e:
         raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
+
+    # Wait for the test app to finish
+    dut.expect_exact('PM_Device_main_app: Cleanup')
 
 def set_remote_wake_on_device(VID: int, PID: int) -> None:
     '''
@@ -232,3 +234,97 @@ def test_usb_device_remote_wakeup_en(dut: IdfDut) -> None:
 
     # Expect device to resume (remote wakeup)
     dut.expect_exact(TINYUSB_EVENTS['resumed'])
+
+    # Wait for the test app to finish
+    dut.expect_exact('PM_Device_main_app: Cleanup')
+    sleep(1)
+
+@pytest.mark.usb_device
+@pytest.mark.parametrize(
+    'config, target',
+    [
+        pytest.param('default', 'esp32s2'),
+        pytest.param('default', 'esp32s3'),
+        pytest.param('default', 'esp32h4'),
+        pytest.param('default', 'esp32p4', marks=[pytest.mark.eco_default]),
+        pytest.param('esp32p4_eco4', 'esp32p4', marks=[pytest.mark.esp32p4_eco4]),
+        pytest.param('default', 'esp32s31'),
+    ],
+    indirect=['target'],
+)
+def test_usb_cdc_device_pm_public_api(dut: IdfDut) -> None:
+    '''
+    Running the test locally:
+    1. Build the test app for your USB-OTG capable DUT
+    2. Connect you DUT to your test runner (local machine) with USB port and flashing port
+    3. Run `pytest --target <target>`
+
+    Test procedure:
+    1. Run the test on the DUT
+    2. Expect one COM Port in the system
+    3. Open it and wait for the device to enter suspended state
+    4. Wait for the DUT to complete public API error handling checks while suspended
+    5. Resume the device by sending data to it
+    6. Verify the device sends data that was queued during suspended state
+    7. Wait for the device to enter suspended state again
+    '''
+    sleep(5) # When rerunning flaky test, to re-initialize the device
+    dut.expect_exact('Press ENTER to see the list of tests.')
+    dut.write('[cdc_device_pm_public_api]')
+    dut.expect_exact('TinyUSB: TinyUSB Driver installed')
+    sleep(2)  # Some time for the OS to enumerate our USB device
+
+    # Find device with Espressif TinyUSB VID/PID
+    ports = []
+    for p in comports():
+        if (p.vid == DUT_VID and p.pid == DUT_PID):
+            ports.append(p.device)
+
+    if len(ports) == 0:
+        raise Exception('TinyUSB COM port not found')
+
+    try:
+        with Serial(ports[0], timeout=2) as cdc:
+            dut.expect_exact(TINYUSB_EVENTS['attached'])
+
+            # Wait for auto suspend (set to 3 seconds)
+            # This expect_exact is ignored by pytest when running second rerun of flaky test (unknown reason),
+            # making the test fail in further steps, adding explicit sleep(3) to wait for the suspend events
+            sleep(3)
+            dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
+
+            # Some time for the DUT to finish error handling test
+            sleep(1)
+            # Resume the device by accessing it and expect resume event
+            cdc.write(b'Time to resume\r\n')
+            dut.expect_exact(TINYUSB_EVENTS['resumed'])
+
+            # Expect response from the device, which was queued during suspended state and sent after resuming
+            res = cdc.readline()
+            assert b'Hello from suspended state\r\n' in res
+
+            # Wait for auto suspend (set to 3 seconds)
+            dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
+
+    except SerialException as e:
+        raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
+
+    # Wait for the test app to finish
+    dut.expect_exact('PM_Device_main_app: Cleanup')
+    sleep(1)
+
+@pytest.mark.usb_device
+@pytest.mark.parametrize(
+    'config, target',
+    [
+        pytest.param('default', 'esp32s2'),
+        pytest.param('default', 'esp32s3'),
+        pytest.param('default', 'esp32h4'),
+        pytest.param('default', 'esp32p4', marks=[pytest.mark.eco_default]),
+        pytest.param('esp32p4_eco4', 'esp32p4', marks=[pytest.mark.esp32p4_eco4]),
+        pytest.param('default', 'esp32s31'),
+    ],
+    indirect=['target'],
+)
+def test_usb_device_pm(dut: IdfDut) -> None:
+    dut.run_all_single_board_cases(group='device_pm')


### PR DESCRIPTION
Only tests, no functional changes.

## Tests added

- `esp_tinyusb` public API calls when device in suspended state
  - read/write/queue data during device suspend
- install/uninstall init/deinit tinyusb during device suspend 

## Modifcations
- Unified device event handler function (there were 2 before)
- Differentiated freerots synchronization primitives for RX Callback event delivery and Device event delivery
  - Before: Plain task notifications
  - Now: Static semaphore for RX callback, Static event group bits for device events
- Fixed some synchronization issues in test cases between device and host

## Related

- tests https://github.com/espressif/tinyusb/pull/80

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes only; no production esp_tinyusb driver behavior is modified in this diff.
> 
> **Overview**
> Expands the **power-management test app** with coverage for calling **esp_tinyusb** CDC APIs and **driver install/uninstall** while the USB device is host-suspended, plus documentation for running those pytest flows on Linux.
> 
> On-device Unity tests gain **`tinyusb_cdc_public_api_error_handling`** (read/write/queue/flush while suspended, then verify data after host resume) and **`tinyusb_init_deinit_from_suspended`** (CDC deinit + driver uninstall/reinstall during suspend). Existing suspend/resume and remote-wakeup cases are refactored to share **`test_pm_init_tinyusb_cdc`** and a single **`device_event_handler`** that sets **remote-wakeup-aware suspend** event bits.
> 
> Synchronization moves from **task notifications** to a **static event group** for PM events and a **binary semaphore** for RX callbacks, with stricter **`expect_device_event`** sequencing in the suspend/resume loop.
> 
> Pytest now expects **`TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_EN`** (or `_DIS` where appropriate) instead of a generic suspended string, adds **`test_usb_cdc_device_pm_public_api`**, **`test_usb_device_pm`** (`run_all_single_board_cases` for group `device_pm`), and waits for app cleanup on more flows. The README documents Linux **USB auto-suspend**, **pyusb**, and that non-Linux hosts are unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657c54acac81982391aa29a35ec35b8cf2f29369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->