### PR TITLE
fix(usb_device): fix CPU load test case

### DIFF
--- a/device/esp_tinyusb/test_apps/runtime_config/main/device_handling.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/device_handling.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,7 +24,7 @@
 
 static SemaphoreHandle_t wait_mount = NULL;
 
-#define TUSB_DEVICE_DELAY_MS        1000
+#define TUSB_DEVICE_DELAY_MS        2000
 
 void test_device_setup(void)
 {
@@ -36,12 +36,15 @@ void test_device_release(void)
 {
     TEST_ASSERT_NOT_NULL(wait_mount);
     vSemaphoreDelete(wait_mount);
+    wait_mount = NULL;
 }
 
 void test_device_wait(void)
 {
     // Wait for tud_mount_cb() to be called
-    TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(wait_mount, pdMS_TO_TICKS(TUSB_DEVICE_DELAY_MS)), "No tusb_mount_cb() in time");
+    if (wait_mount) {
+        TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(wait_mount, pdMS_TO_TICKS(TUSB_DEVICE_DELAY_MS)), "No tusb_mount_cb() in time");
+    }
     // Delay to allow finish the enumeration
     // Disable this delay could lead to potential race conditions when the tud_task() is pinned to another CPU
     vTaskDelay(pdMS_TO_TICKS(250));
@@ -51,7 +54,9 @@ void test_device_event_handler(tinyusb_event_t *event, void *arg)
 {
     switch (event->id) {
     case TINYUSB_EVENT_ATTACHED:
-        xSemaphoreGive(wait_mount);
+        if (wait_mount) {
+            xSemaphoreGive(wait_mount);
+        }
         break;
     case TINYUSB_EVENT_DETACHED:
         break;


### PR DESCRIPTION
Fixing the  `TEST_CASE("[CPU load] Install & Uninstall, default configuration", "[cpu_load]")` test case currently failing on `esp32p4 ECO4 IDF 6.0`



## Related

<details>
<summary> Error log </summary>

```sh
2026-06-19 13:14:33                 | | (_)                     | |    
2026-06-19 13:14:33   ___  ___ _ __ | |_ _ _ __  _   _ _   _ ___| |__  
2026-06-19 13:14:33  / _ \/ __| '_ \| __| | '_ \| | | | | | / __| '_ \ 
2026-06-19 13:14:33 |  __/\__ \ |_) | |_| | | | | |_| | |_| \__ \ |_) |
2026-06-19 13:14:33  \___||___/ .__/ \__|_|_| |_|\__, |\__,_|___/_.__/ 
2026-06-19 13:14:33           | |______           __/ |               
2026-06-19 13:14:33           |_|______|         |___/                
2026-06-19 13:14:33  _____ _____ _____ _____                           
2026-06-19 13:14:33 |_   _|  ___/  ___|_   _|                          
2026-06-19 13:14:33   | | | |__ \ `--.  | |                            
2026-06-19 13:14:33   | | |  __| `--. \ | |                            
2026-06-19 13:14:33   | | | |___/\__/ / | |                            
2026-06-19 13:14:33   \_/ \____/\____/  \_/                            
2026-06-19 13:14:33 
2026-06-19 13:14:33 
2026-06-19 13:14:33 Press ENTER to see the list of tests.
2026-06-19 13:14:33 [cpu_load]
2026-06-19 13:14:33 Running tests matching '[cpu_load]'...
2026-06-19 13:14:33 Running [CPU load] Install & Uninstall, default configuration...
2026-06-19 13:14:33 W (503) tusb_desc: No Device descriptor provided, using default.
2026-06-19 13:14:33 W (503) tusb_desc: No Full-speed configuration descriptor provided, using default.
2026-06-19 13:14:33 W (503) tusb_desc: No High-speed configuration descriptor provided, using default.
2026-06-19 13:14:33 W (503) tusb_desc: No Qualifier descriptor provided, using default.
2026-06-19 13:14:33 W (513) tusb_desc: No String descriptors provided, using default.
2026-06-19 13:14:33 I (523) tusb_desc: 
2026-06-19 13:14:33 ┌─────────────────────────────────┐
2026-06-19 13:14:33 │  USB Device Descriptor Summary  │
2026-06-19 13:14:33 ├───────────────────┬─────────────┤
2026-06-19 13:14:33 │bDeviceClass       │ 239         │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │bDeviceSubClass    │ 2           │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │bDeviceProtocol    │ 1           │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │bMaxPacketSize0    │ 64          │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │idVendor           │ 0x303a      │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │idProduct          │ 0x4002      │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │bcdDevice          │ 0x100       │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │iManufacturer      │ 0x1         │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │iProduct           │ 0x2         │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │iSerialNumber      │ 0x3         │
2026-06-19 13:14:33 ├───────────────────┼─────────────┤
2026-06-19 13:14:33 │bNumConfigurations │ 0x1         │
2026-06-19 13:14:33 └───────────────────┴─────────────┘
2026-06-19 13:14:33 I (683) TinyUSB: TinyUSB Driver installed on port 1
2026-06-19 13:14:33 Starting TinyUSB load measurement test...
2026-06-19 13:14:34 ./main/test_cpu_load.c:44:[CPU load] Install & Uninstall, default configuration:FAIL: Expected 1 Was 0. Function [cpu_load]. No tusb_mount_cb() in timeMALLOC_CAP_8BIT usage: Free memory delta: -5236 Leak threshold: -128 
2026-06-19 13:14:34 MALLOC_CAP_8BIT critical leak: Before 596812 bytes free, After 591576 bytes free (delta 5236)
2026-06-19 13:14:34 
2026-06-19 13:14:34 
2026-06-19 13:14:34 -----------------------
2026-06-19 13:14:34 1 Tests 1 Failures 0 Ignored 
2026-06-19 13:14:34 FAIL
2026-06-19 13:14:34 Enter next test, or 'enter' to see menu
2026-06-19 13:14:35 
2026-06-19 13:14:35 assert failed: xQueueGenericSend queue.c:937 (!( ( pvItemToQueue == ((void *)0) ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ))
2026-06-19 13:14:35 Core  1 register dump:
2026-06-19 13:14:35 MEPC    : 0x4ff06e22  RA      : 0x4ff06dd4  SP      : 0x4ff3c110  GP      : 0x4ff0e080  
2026-06-19 13:14:35 TP      : 0x4ff3c350  T0      : 0x73614255  T1      : 0x3e2d6575  T2      : 0x70795465  
2026-06-19 13:14:35 S0/FP   : 0x00000042  S1      : 0x00000001  A0      : 0x4ff3c164  A1      : 0x4ff0fec9  
2026-06-19 13:14:35 A2      : 0x00000001  A3      : 0x4ff3c1e9  A4      : 0x00000001  A5      : 0x4ff13000  
2026-06-19 13:14:35 A6      : 0x0000000c  A7      : 0x65755178  S2      : 0x00000009  S3      : 0x4ff3c2b5  
2026-06-19 13:14:35 S4      : 0x4ff0fec8  S5      : 0x00000001  S6      : 0x00000000  S7      : 0x00000000  
2026-06-19 13:14:35 S8      : 0x00000000  S9      : 0x00000000  S10     : 0x00000000  S11     : 0x00000000  
2026-06-19 13:14:35 T3      : 0x74497875  T4      : 0x69536d65  T5      : 0x2120657a  T6      : 0x2028203d  
2026-06-19 13:14:35 MSTATUS : 0x00011880  MTVEC   : 0x4ff00003  MCAUSE  : 0x00000002  MTVAL   : 0x00000000  
2026-06-19 13:14:35 MHARTID : 0x00000001  
2026-06-19 13:14:35 
2026-06-19 13:14:35 Stack memory:
2026-06-19 13:14:35 4ff3c110: 0x000006f5 0x00000004 0x40038be0 0x4ff0637e 0x00000000 0x00000002 0x00000003 0x4ff1092c
2026-06-19 13:14:35 4ff3c130: 0x40038be0 0x4ff1093c 0x4003275e 0x4ff10940 0x4ff3c150 0x4ff10944 0x40032828 0x4ff0fec8
2026-06-19 13:14:35 4ff3c150: 0x00373339 0x00000000 0x00000000 0x00000000 0x00000000 0x65737361 0x66207472 0x656c6961
2026-06-19 13:14:35 4ff3c170: 0x78203a64 0x75657551 0x6e654765 0x63697265 0x646e6553 0x65757120 0x632e6575 0x3733393a
2026-06-19 13:14:35 4ff3c190: 0x28212820 0x70202820 0x65744976 0x516f546d 0x65756575 0x203d3d20 0x6f762828 0x2a206469
2026-06-19 13:14:35 4ff3c1b0: 0x20293029 0x26262029 0x70202820 0x65755178 0x3e2d6575 0x74497875 0x69536d65 0x2120657a
2026-06-19 13:14:35 4ff3c1d0: 0x2028203d 0x73614255 0x70795465 0x20745f65 0x55302029 0x29202920 0x4ff10029 0x4ff07e7a
2026-06-19 13:14:35 4ff3c1f0: 0x00000000 0x4ff12180 0x4ff1212c 0x4001fe6e 0x00000002 0x4003961d 0x00000001 0x4ff0f280
2026-06-19 13:14:35 4ff3c210: 0x00000200 0x00000004 0x00000001 0x4000fbd0 0x00000200 0x00000004 0x00000000 0x605900ac
2026-06-19 13:14:35 4ff3c230: 0x00000001 0x4ff1212c 0x00000000 0x00000000 0x00000000 0x00000001 0x4ff3b2ac 0x4001fde8
2026-06-19 13:14:35 4ff3c250: 0x00000002 0x4ff1279c 0x00000001 0x00000000 0x00000001 0x0000003a 0x40039606 0x605900ac
2026-06-19 13:14:35 4ff3c270: 0x0000000c 0x00ff0409 0x00000001 0x00000000 0x00000000 0x00000001 0x4ff3c2f4 0x4000bafa
2026-06-19 13:14:35 4ff3c290: 0x00000000 0x00000000 0x00000000 0x4000e0e2 0x00000000 0x00000000 0x00000001 0x605900ac
2026-06-19 13:14:35 4ff3c2b0: 0x00000000 0x00000000 0x4ff3c2f4 0x400100ca 0x00000000 0x00000000 0x000000ce 0x605900ac
2026-06-19 13:14:35 4ff3c2d0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0xffffffff 0x400104d0
2026-06-19 13:14:35 4ff3c2f0: 0x00000601 0x00010900 0x00000000 0x605900ac 0x00000000 0x00000000 0x4ff3b360 0x4000e48c
2026-06-19 13:14:35 4ff3c310: 0x00000000 0x00000000 0x00000000 0x4001f318 0x00000000 0x00000000 0x00000000 0x00000000
2026-06-19 13:14:35 4ff3c330: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5
2026-06-19 13:14:35 4ff3c350: 0x00000000 0x4ff0db78 0x4ff0db28 0x4ff0db28 0x00000000 0x4ff3b388 0x4ff3b388 0x00000000
2026-06-19 13:14:35 4ff3c370: 0x00000000 0x00000000 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xbaad5678 0xfefefefe
2026-06-19 13:14:35 4ff3c390: 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe
2026-06-19 13:14:35 4ff3c3b0: 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe
2026-06-19 13:14:35 4ff3c3d0: 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe
2026-06-19 13:14:35 4ff3c3f0: 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe
2026-06-19 13:14:35 4ff3c410: 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe
2026-06-19 13:14:35 4ff3c430: 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe
2026-06-19 13:14:35 4ff3c450: 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe 0xfefefefe
2026-06-19 13:14:35 4ff3c470: 0xfefefefe 0xfefefefe 0xfefefefe 0x4ff3b378 0x0000007c 0xabba1234 0x00000070 0x4ff3c230
2026-06-19 13:14:35 4ff3c490: 0x00000000 0x4ff10ee0 0x4ff10ee0 0x4ff3c48c 0x4ff10ed8 0x00000014 0x4ff0e290 0x4ff0e290
2026-06-19 13:14:35 4ff3c4b0: 0x4ff3c48c 0x00000000 0x00000005 0x4ff3b388 0x796e6954 0x00425355 0x00000000 0x00000000
2026-06-19 13:14:35 4ff3c4d0: 0x00000001 0x4ff3c380 0x00000006 0x00000000 0x00000005 0x00000000 0x00000000 0x00000000
2026-06-19 13:14:35 4ff3c4f0: 0x0002e589 0x00000000 0x00000000 0xbaad5678 0x000000a0 0xabba1234 0x0000008d 0x00000000
2026-06-19 13:14:35 
2026-06-19 13:14:35 
2026-06-19 13:14:35 
2026-06-19 13:14:35 ELF file SHA256: 1df102c3a
2026-06-19 13:14:35 
2026-06-19 13:14:35 Rebooting...
2026-06-19 13:14:35 ESP-ROM:esp32p4-eco2-20240710
2026-06-19 13:14:35 Build:Jul 10 2024
2026-06-19 13:14:35 rst:0xc (SW_CPU_RESET),boot:0x30f (SPI_FAST_FLASH_BOOT)
2026-06-19 13:14:35 Core0 Saved PC:0x4fc18dce
2026-06-19 13:14:35 Core1 Saved PC:0x4ff03fd8
2026-06-19 13:14:35 SPI mode:DIO, clock div:2
2026-06-19 13:14:35 load:0x4ff33ce0,len:0x15e0
2026-06-19 13:14:35 load:0x4ff29ed0,len:0xe48
2026-06-19 13:14:35 load:0x4ff2cbd0,len:0x35bc
2026-06-19 13:14:35 entry 0x4ff29eda
```

</details>


The error log shows that the test fails while waiting for device mount semaphore. The blocking time was set to 1 second. But the event got delivered shortly after the test failed (the Queue generic assert, due to the queue was unistalled).

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in `device_handling.c` with no production USB driver behavior changes.
> 
> **Overview**
> Hardens the **runtime_config** TinyUSB test helpers so the **CPU load** install/uninstall case passes on slower targets (e.g. esp32p4 ECO4 on IDF 6.0).
> 
> **`TUSB_DEVICE_DELAY_MS`** is raised from **1000 ms to 2000 ms** so `test_device_wait()` does not fail when `TINYUSB_EVENT_ATTACHED` arrives just after the old timeout.
> 
> **`test_device_release()`** now clears **`wait_mount`** after `vSemaphoreDelete`, and **`test_device_wait()`** / **`test_device_event_handler()`** only take or give the semaphore when **`wait_mount`** is non-null. That avoids signaling or waiting on a deleted semaphore when attach events are still delivered after teardown (the post-failure `xQueueGenericSend` assert in the reported log).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f29a17c432ec4146134f40f4fbb8170df47045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->