### PR TITLE
fix(usb_device_example): Fix build of tusb_cdc_acm_wakeup example

### DIFF
--- a/.github/ci/.idf-build-examples-rules.yml
+++ b/.github/ci/.idf-build-examples-rules.yml
@@ -8,6 +8,10 @@ examples/peripherals/usb/device/tusb_ncm:
   disable:
     - if: SOC_USB_OTG_SUPPORTED != 1 or SOC_WIFI_SUPPORTED != 1
 
+examples/peripherals/usb/device/tusb_cdc_acm_wakeup:
+  disable:
+    - if: SOC_USB_OTG_SUPPORTED != 1 or SOC_PM_SUPPORT_USB_WAKEUP != 1
+
 examples/peripherals/usb/host:
   disable:
     - if: SOC_USB_OTG_SUPPORTED != 1

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -159,7 +159,17 @@ jobs:
           cd ${IDF_PATH}
 
           # Export compiler flags
-          export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
+          PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-function"
+          # IDF latest (6.2) and newer use -Werror=unused-but-set-variable=1 (esp-idf@71618c8).
+          # Older IDF releases use -Werror=unused-but-set-variable without =1.
+          case "${{ matrix.idf_ver }}" in
+            release-v5.*|release-v6.0|release-v6.1)
+              PEDANTIC_FLAGS="${PEDANTIC_FLAGS} -Werror=unused-but-set-variable"
+              ;;
+            *)
+              PEDANTIC_FLAGS="${PEDANTIC_FLAGS} -Werror=unused-but-set-variable=1"
+              ;;
+          esac
           export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
           export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
 


### PR DESCRIPTION
## Changes

### CDC-ACM wakeup example build fix
Fixing build of newly added `tusb_cdc_acm_wakeup` example with CI build fail [here](https://github.com/espressif/esp-usb/actions/runs/27888350566/job/82527316665#step:10:4523).

<details>
<summary> Error log </summary>

Code

```sh
/opt/esp/idf/examples/peripherals/usb/device/tusb_cdc_acm_wakeup/main/tusb_cdc_acm_wakeup_main.c:24:2: error: #error This example requires a target with SOC_PM_SUPPORT_USB_WAKEUP.
   24 | #error This example requires a target with SOC_PM_SUPPORT_USB_WAKEUP.
      |  ^~~~~
```

</details>

### gcc 16.1.0 with extra compiler flags

Extra compiler flag  `-Werror=unused-but-set-variable` is causing some examples fail to build. Modifying the flag to `-Werror=unused-but-set-variable=1`, same as in esp-idf.

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI manifest rules and compiler-flag selection in the IDF examples workflow, with no runtime product code touched.
> 
> **Overview**
> Fixes IDF USB example CI failures for the new **`tusb_cdc_acm_wakeup`** example and for stricter **gcc 16.1** warning handling on newer IDF.
> 
> The build manifest now **disables** `examples/peripherals/usb/device/tusb_cdc_acm_wakeup` unless the target has **USB OTG** and **`SOC_PM_SUPPORT_USB_WAKEUP`**, so CI no longer compiles it on chips that would hit the example’s `#error`.
> 
> In **`build_and_run_idf_examples.yml`**, pedantic **`EXTRA_CFLAGS` / `EXTRA_CXXFLAGS`** append **`-Werror=unused-but-set-variable`** for **release-v5.\***, **v6.0**, and **v6.1**, and **`-Werror=unused-but-set-variable=1`** for **`latest`** and other newer matrix entries, matching esp-idf’s split and avoiding unrelated example build breaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31027d03d90bb02b7123272caed734c248f4238a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->