### PR TITLE
fix(build): Fixing build for gcc 16.1.0 

### DIFF
--- a/device/esp_tinyusb/test_apps/cdc/main/test_cdc.c
+++ b/device/esp_tinyusb/test_apps/cdc/main/test_cdc.c
@@ -193,6 +193,7 @@ TEST_CASE("tinyusb_cdc_throughput", "[esp_tinyusb][cdc_throughput]")
         bytes_written += tud_cdc_n_write(0, tx_buf, CDC_THROUGHPUT_TEST_BUFFER_SIZE);
     }
 
+    TEST_ASSERT_MESSAGE(bytes_written, "No bytes written");
     free(tx_buf);
 
     // Cleanup


### PR DESCRIPTION
## Description

Fixing gcc 16.1.0 build error related to `-Werror=unused-but-set-variable`. Seems like the newer gcc version is treating the unused but set more aggressively.

```sh
/__w/esp-usb/esp-usb/device/esp_tinyusb/test_apps/cdc/main/test_cdc.c: In function 'test_func_148':
/__w/esp-usb/esp-usb/device/esp_tinyusb/test_apps/cdc/main/test_cdc.c:184:12: error: variable 'bytes_written' set but not used [-Werror=unused-but-set-variable=]
  184 |     size_t bytes_written = 0;
      |            ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change in a test app only; no production or driver behavior changes.
> 
> **Overview**
> Adds **`TEST_ASSERT_MESSAGE(bytes_written, "No bytes written")`** after the CDC throughput write loop in `tinyusb_cdc_throughput`, so the accumulated `bytes_written` is read and the test fails if nothing was sent.
> 
> This clears **GCC 16.1.0** builds that treat **`-Wunused-but-set-variable`** as an error when `bytes_written` was only updated in the loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a36d8458487649121e782606614e08134372504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->