### PR TITLE
Revert "feat(host/cdc): Open devices with USB address"

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-- Added the option to open a CDC device with specific address also to legacy `cdc_acm_host_device_config_t`
-
 ## [2.4.0] - 2026-04-14
 
 ### Added

--- a/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
@@ -597,7 +597,7 @@ esp_err_t cdc_acm_host_open_v1_dispatch(uint16_t vid, uint16_t pid, uint8_t inte
         .vid = vid,
         .pid = pid,
         .interface_idx = interface_idx,
-        .dev_addr = dev_config->dev_addr,
+        .dev_addr = CDC_HOST_ANY_DEV_ADDR,
         .connection_timeout_ms = dev_config->connection_timeout_ms,
         .out_buffer_size = dev_config->out_buffer_size,
         .in_buffer_size = dev_config->in_buffer_size,

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_device_interaction.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_device_interaction.cpp
@@ -198,7 +198,6 @@ SCENARIO("Invalid custom command")
             .event_cb = nullptr,
             .data_cb = nullptr,
             .user_arg = nullptr,
-            .dev_addr = CDC_HOST_ANY_DEV_ADDR,
         };
 
         // Use any device, does not matter for this test
@@ -249,7 +248,6 @@ SCENARIO("Interact with mocked USB devices")
             .event_cb = nullptr,
             .data_cb = nullptr,
             .user_arg = nullptr,
-            .dev_addr = CDC_HOST_ANY_DEV_ADDR,
         };
 
         SECTION("Interact with device: ASIX Electronics Corp. AX88772A Fast Ethernet") {
@@ -439,7 +437,6 @@ SCENARIO("TinyUSB serial")
                 .event_cb = nullptr,
                 .data_cb = nullptr,
                 .user_arg = nullptr,
-                .dev_addr = CDC_HOST_ANY_DEV_ADDR,
             };
 
             usb_host_device_open_Stub(usb_host_device_open_mock_callback);

--- a/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_opening_device.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/host_test/device_interaction/main/test_opening_device.cpp
@@ -52,7 +52,6 @@ SCENARIO("Test mocked device opening and closing")
             .event_cb = nullptr,
             .data_cb = nullptr,
             .user_arg = nullptr,
-            .dev_addr = CDC_HOST_ANY_DEV_ADDR,
         };
 
         SECTION("Fail to open CDC-ACM Device: dev_config is nullptr") {
@@ -273,7 +272,6 @@ SCENARIO("Test usb_host_transfer_alloc() failures")
             .event_cb = nullptr,
             .data_cb = nullptr,
             .user_arg = nullptr,
-            .dev_addr = CDC_HOST_ANY_DEV_ADDR,
         };
 
         REQUIRE(ESP_OK == usb_host_mock_add_device(5, (const usb_device_desc_t *)ch340_device_desc,

--- a/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_host_types.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/usb/cdc_host_types.h
@@ -92,7 +92,6 @@ typedef struct {
     cdc_acm_host_dev_callback_t event_cb; /*!< Device event callback. Can be NULL. */
     cdc_acm_data_callback_t data_cb;      /*!< Data RX callback. Can be NULL for write-only devices. */
     void *user_arg;                       /*!< User argument passed to both callbacks. */
-    uint8_t dev_addr;                     /*!< USB device address to select, or CDC_HOST_ANY_DEV_ADDR to match any. */
 } cdc_acm_host_device_config_t;
 
 /**


### PR DESCRIPTION
Reverts espressif/esp-usb#490

There is no clean way this can compile without any warning on C++

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> API surface change for anyone who set `dev_addr` on the legacy struct; behavior reverts to VID/PID/interface matching without per-address selection on Form 2. v2 open path is unchanged.
> 
> **Overview**
> Reverts exposing **USB device address** on the legacy `cdc_acm_host_device_config_t` API (from #490). The field is removed from the struct; **`cdc_acm_host_open` Form 2** again always matches **any** address via `CDC_HOST_ANY_DEV_ADDR` in `cdc_acm_host_open_v1_dispatch`, instead of forwarding `dev_config->dev_addr`.
> 
> **Address-specific open** remains on **`cdc_acm_host_open_config_t`** / `cdc_acm_host_open` Form 1 (`dev_addr` unchanged there). Host tests drop `.dev_addr` from legacy `dev_config` initializers. Changelog **Unreleased** note about legacy `dev_addr` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9eeb074b325da998b274c83b56db4cf546b6e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->