### PR TITLE
feat(usb_host): add existing device enumeration

### DIFF
--- a/host/usb/src/usb_host.c
+++ b/host/usb/src/usb_host.c
@@ -62,8 +62,12 @@ DEFINE_CRIT_SECTION_LOCK_STATIC(host_lock);
 #define PROCESS_REQUEST_PENDING_FLAG_HUB        (1 << 1)
 #define PROCESS_REQUEST_PENDING_FLAG_ENUM       (1 << 2)
 
+#define DEV_ADDR_MAP_LEN                        4
+
 #define SHORT_DESC_REQ_LEN                      8
 #define CTRL_TRANSFER_MAX_DATA_LEN              CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE
+
+typedef uint32_t dev_addr_map_t[DEV_ADDR_MAP_LEN];
 
 typedef struct ep_wrapper_s ep_wrapper_t;
 typedef struct interface_s interface_t;
@@ -114,18 +118,20 @@ struct client_s {
             struct {
                 uint32_t handling_events: 1;
                 uint32_t taking_mux: 1;
-                uint32_t reserved6: 6;
+                uint32_t has_pending_new_dev: 1;
+                uint32_t reserved5: 5;
                 uint32_t num_intf_claimed: 8;
                 uint32_t reserved16: 16;
             };
             uint32_t val;
         } flags;
         uint32_t num_done_ctrl_xfer;
-        uint32_t opened_dev_addr_map[4];
+        dev_addr_map_t opened_dev_addr_map;
     } dynamic;
     // Mux protected members must be protected by host library the mux_lock when accessed
     struct {
         TAILQ_HEAD(tailhead_interfaces, interface_s) interface_tailq;
+        dev_addr_map_t pending_new_dev_addr_map;
     } mux_protected;
     // Constant members do no change after registration thus do not require a critical section
     struct {
@@ -156,6 +162,8 @@ typedef struct {
     // Mux protected members must be protected by host library the mux_lock when accessed
     struct {
         TAILQ_HEAD(tailhead_clients, client_s) client_tailq;  // List of all clients registered
+        // Devices whose NEW_DEV event has already been processed by the host lib
+        dev_addr_map_t client_visible_dev_addr_map;
     } mux_protected;
     // Constant members do no change after installation thus do not require a critical section
     struct {
@@ -174,28 +182,46 @@ const char *USB_HOST_TAG = "USB HOST";
 
 // ----------------------------------------------------- Helpers -------------------------------------------------------
 
-static inline void _record_client_opened_device(client_t *client_obj, uint8_t dev_addr)
+static inline void dev_addr_map_set(dev_addr_map_t dev_addr_map, uint8_t dev_addr)
 {
     assert(dev_addr != 0 && dev_addr <= 127);
-    client_obj->dynamic.opened_dev_addr_map[dev_addr / 32] |= (uint32_t)(1 << (dev_addr % 32));
+    dev_addr_map[dev_addr / 32] |= (1U << (dev_addr % 32));
 }
 
-static inline void _clear_client_opened_device(client_t *client_obj, uint8_t dev_addr)
+static inline void dev_addr_map_clear(dev_addr_map_t dev_addr_map, uint8_t dev_addr)
 {
     assert(dev_addr != 0 && dev_addr <= 127);
-    client_obj->dynamic.opened_dev_addr_map[dev_addr / 32] &= ~(uint32_t)(1 << (dev_addr % 32));
+    dev_addr_map[dev_addr / 32] &= ~(1U << (dev_addr % 32));
 }
 
-static inline bool _check_client_opened_device(client_t *client_obj, uint8_t dev_addr)
+static inline bool dev_addr_map_check(dev_addr_map_t dev_addr_map, uint8_t dev_addr)
 {
-    bool ret;
     assert(dev_addr <= 127);
-    if (dev_addr != 0) {
-        ret = client_obj->dynamic.opened_dev_addr_map[dev_addr / 32] & (uint32_t)(1 << (dev_addr % 32));
-    } else {
-        ret = false;
+    return (dev_addr != 0) ? ((dev_addr_map[dev_addr / 32] & (1U << (dev_addr % 32))) != 0) : false;
+}
+
+static inline void dev_addr_map_copy(dev_addr_map_t dst, const dev_addr_map_t src)
+{
+    for (size_t i = 0; i < DEV_ADDR_MAP_LEN; i++) {
+        dst[i] = src[i];
     }
-    return ret;
+}
+
+static inline void dev_addr_map_clear_all(dev_addr_map_t dev_addr_map)
+{
+    for (size_t i = 0; i < DEV_ADDR_MAP_LEN; i++) {
+        dev_addr_map[i] = 0;
+    }
+}
+
+static inline bool dev_addr_map_any(const dev_addr_map_t dev_addr_map)
+{
+    for (size_t i = 0; i < DEV_ADDR_MAP_LEN; i++) {
+        if (dev_addr_map[i] != 0) {
+            return true;
+        }
+    }
+    return false;
 }
 
 static bool _unblock_client(client_t *client_obj, bool in_isr)
@@ -269,6 +295,21 @@ static void stop_auto_suspend_timer(void)
     xTimerStop(p_host_lib_obj->constant.auto_suspend_timer, portMAX_DELAY);
 }
 
+static bool send_event_msg_to_client(client_t *client_obj, const usb_host_client_event_msg_t *event_msg, const char *error_msg)
+{
+    // The caller must hold mux_lock when calling this helper.
+    if (xQueueSend(client_obj->constant.event_msg_queue, event_msg, 0) == pdTRUE) {
+        HOST_ENTER_CRITICAL();
+        _unblock_client(client_obj, false);
+        HOST_EXIT_CRITICAL();
+        return true;
+    }
+    if (error_msg) {
+        ESP_LOGE(USB_HOST_TAG, "%s", error_msg);
+    }
+    return false;
+}
+
 static void send_event_msg_to_clients(const usb_host_client_event_msg_t *event_msg, bool send_to_all, uint8_t opened_dev_addr)
 {
     // Lock client list
@@ -279,22 +320,76 @@ static void send_event_msg_to_clients(const usb_host_client_event_msg_t *event_m
         if (!send_to_all) {
             // Check if client opened the device
             HOST_ENTER_CRITICAL();
-            bool send = _check_client_opened_device(client_obj, opened_dev_addr);
+            bool send = dev_addr_map_check(client_obj->dynamic.opened_dev_addr_map, opened_dev_addr);
             HOST_EXIT_CRITICAL();
             if (!send) {
                 continue;
             }
         }
-        // Send the event message
-        if (xQueueSend(client_obj->constant.event_msg_queue, event_msg, 0) == pdTRUE) {
-            HOST_ENTER_CRITICAL();
-            _unblock_client(client_obj, false);
-            HOST_EXIT_CRITICAL();
-        } else {
-            ESP_LOGE(USB_HOST_TAG, "Client event message queue full");
-        }
+        send_event_msg_to_client(client_obj, event_msg, "Client event message queue full");
     }
     // Unlock client list
+    xSemaphoreGive(p_host_lib_obj->constant.mux_lock);
+}
+
+static void send_pending_new_dev_events_to_client(client_t *client_obj)
+{
+    // The caller must hold mux_lock. Queue full is normal backpressure; pending bits are kept for a later retry.
+    for (uint8_t dev_addr = 1; dev_addr <= 127; dev_addr++) {
+        if (!dev_addr_map_check(client_obj->mux_protected.pending_new_dev_addr_map, dev_addr)) {
+            continue;
+        }
+        const usb_host_client_event_msg_t event_msg = {
+            .event = USB_HOST_CLIENT_EVENT_NEW_DEV,
+            .new_dev.address = dev_addr,
+        };
+        if (!send_event_msg_to_client(client_obj, &event_msg, NULL)) {
+            break;
+        }
+        dev_addr_map_clear(client_obj->mux_protected.pending_new_dev_addr_map, dev_addr);
+    }
+    const bool has_pending_new_dev = dev_addr_map_any(client_obj->mux_protected.pending_new_dev_addr_map);
+    HOST_ENTER_CRITICAL();
+    client_obj->dynamic.flags.has_pending_new_dev = has_pending_new_dev;
+    HOST_EXIT_CRITICAL();
+}
+
+static void send_new_dev_event_msg_to_clients(uint8_t dev_addr)
+{
+    xSemaphoreTake(p_host_lib_obj->constant.mux_lock, portMAX_DELAY);
+    // Mark visible first, then queue it as pending for every client so queue backpressure cannot drop discovery.
+    dev_addr_map_set(p_host_lib_obj->mux_protected.client_visible_dev_addr_map, dev_addr);
+    client_t *client_obj;
+    TAILQ_FOREACH(client_obj, &p_host_lib_obj->mux_protected.client_tailq, dynamic.tailq_entry) {
+        dev_addr_map_set(client_obj->mux_protected.pending_new_dev_addr_map, dev_addr);
+        send_pending_new_dev_events_to_client(client_obj);
+    }
+    xSemaphoreGive(p_host_lib_obj->constant.mux_lock);
+}
+
+static void clear_client_visible_device(uint8_t dev_addr)
+{
+    // Address 0 is the default control address and is never visible to host clients.
+    if (dev_addr == 0) {
+        return;
+    }
+    xSemaphoreTake(p_host_lib_obj->constant.mux_lock, portMAX_DELAY);
+    dev_addr_map_clear(p_host_lib_obj->mux_protected.client_visible_dev_addr_map, dev_addr);
+    client_t *client_obj;
+    TAILQ_FOREACH(client_obj, &p_host_lib_obj->mux_protected.client_tailq, dynamic.tailq_entry) {
+        dev_addr_map_clear(client_obj->mux_protected.pending_new_dev_addr_map, dev_addr);
+    }
+    xSemaphoreGive(p_host_lib_obj->constant.mux_lock);
+}
+
+static void clear_all_client_visible_devices(void)
+{
+    xSemaphoreTake(p_host_lib_obj->constant.mux_lock, portMAX_DELAY);
+    dev_addr_map_clear_all(p_host_lib_obj->mux_protected.client_visible_dev_addr_map);
+    client_t *client_obj;
+    TAILQ_FOREACH(client_obj, &p_host_lib_obj->mux_protected.client_tailq, dynamic.tailq_entry) {
+        dev_addr_map_clear_all(client_obj->mux_protected.pending_new_dev_addr_map);
+    }
     xSemaphoreGive(p_host_lib_obj->constant.mux_lock);
 }
 
@@ -315,7 +410,7 @@ static void send_removed_event_msg_to_clients(uint8_t dev_addr)
             continue;
         }
         HOST_ENTER_CRITICAL();
-        bool opened = _check_client_opened_device(client_obj, dev_addr);
+        bool opened = dev_addr_map_check(client_obj->dynamic.opened_dev_addr_map, dev_addr);
         HOST_EXIT_CRITICAL();
         if (opened) {
             continue;
@@ -381,19 +476,19 @@ static void usbh_event_callback(usbh_event_data_t *event_data, void *arg)
             // Device is a hub, we do not need to propagate the event to the clients
             break;
         }
-        // Prepare a NEW_DEV client event message, and send it to all clients
-        usb_host_client_event_msg_t event_msg = {
-            .event = USB_HOST_CLIENT_EVENT_NEW_DEV,
-            .new_dev.address = event_data->new_dev_data.dev_addr,
-        };
-        send_event_msg_to_clients(&event_msg, true, 0);
+        send_new_dev_event_msg_to_clients(event_data->new_dev_data.dev_addr);
         break;
     }
     case USBH_EVENT_DEV_GONE: {
+        if (event_data->dev_gone_data.dev_addr == 0) {
+            // Address 0 is used only during early enumeration and is never visible to host clients.
+            break;
+        }
         if (hub_dev_gone(event_data->dev_gone_data.dev_addr) == ESP_OK) {
             // Device is a hub, we do not need to propagate the event to the clients
             break;
         }
+        clear_client_visible_device(event_data->dev_gone_data.dev_addr);
         send_removed_event_msg_to_clients(event_data->dev_gone_data.dev_addr);
         // Prepare a DEV GONE event, send only to clients that have opened the device
         usb_host_client_event_msg_t event_msg = {
@@ -404,6 +499,11 @@ static void usbh_event_callback(usbh_event_data_t *event_data, void *arg)
         break;
     }
     case USBH_EVENT_DEV_REMOVED:
+        if (event_data->dev_removed_data.dev_addr == 0) {
+            // Address 0 is used only during early enumeration and is never visible to host clients.
+            break;
+        }
+        clear_client_visible_device(event_data->dev_removed_data.dev_addr);
         send_removed_event_msg_to_clients(event_data->dev_removed_data.dev_addr);
         break;
     case USBH_EVENT_DEV_FREE: {
@@ -1196,6 +1296,8 @@ esp_err_t usb_host_client_register(const usb_host_client_config_t *client_config
     p_host_lib_obj->dynamic.flags.num_clients++;
     HOST_EXIT_CRITICAL();
     TAILQ_INSERT_TAIL(&p_host_lib_obj->mux_protected.client_tailq, client_obj, dynamic.tailq_entry);
+    dev_addr_map_copy(client_obj->mux_protected.pending_new_dev_addr_map, p_host_lib_obj->mux_protected.client_visible_dev_addr_map);
+    send_pending_new_dev_events_to_client(client_obj);
     xSemaphoreGive(p_host_lib_obj->constant.mux_lock);
 
     // Write back client handle
@@ -1232,10 +1334,7 @@ esp_err_t usb_host_client_deregister(usb_host_client_handle_t client_hdl)
             client_obj->dynamic.flags.taking_mux ||
             client_obj->dynamic.flags.num_intf_claimed != 0 ||
             client_obj->dynamic.num_done_ctrl_xfer != 0 ||
-            client_obj->dynamic.opened_dev_addr_map[0] != 0 ||
-            client_obj->dynamic.opened_dev_addr_map[1] != 0 ||
-            client_obj->dynamic.opened_dev_addr_map[2] != 0 ||
-            client_obj->dynamic.opened_dev_addr_map[3] != 0) {
+            dev_addr_map_any(client_obj->dynamic.opened_dev_addr_map)) {
         can_deregister = false;
     } else {
         can_deregister = true;
@@ -1307,6 +1406,7 @@ esp_err_t usb_host_client_handle_events(usb_host_client_handle_t client_hdl, Tic
             urb->transfer.callback(&urb->transfer);
             HOST_ENTER_CRITICAL();
         }
+        const bool has_pending_new_dev = client_obj->dynamic.flags.has_pending_new_dev;
         HOST_EXIT_CRITICAL();
 
         // Handle event messages
@@ -1317,6 +1417,12 @@ esp_err_t usb_host_client_handle_events(usb_host_client_handle_t client_hdl, Tic
             assert(queue_ret == pdTRUE);
             (void)queue_ret;
             client_obj->constant.event_callback(&event_msg, client_obj->constant.callback_arg);
+        }
+
+        if (has_pending_new_dev) {
+            xSemaphoreTake(p_host_lib_obj->constant.mux_lock, portMAX_DELAY);
+            send_pending_new_dev_events_to_client(client_obj);
+            xSemaphoreGive(p_host_lib_obj->constant.mux_lock);
         }
 
         ret = ESP_OK;
@@ -1359,14 +1465,14 @@ esp_err_t usb_host_device_open(usb_host_client_handle_t client_hdl, uint8_t dev_
     }
 
     HOST_ENTER_CRITICAL();
-    if (_check_client_opened_device(client_obj, dev_addr)) {
+    if (dev_addr_map_check(client_obj->dynamic.opened_dev_addr_map, dev_addr)) {
         // Client has already opened the device. Close it and return an error
         ret = ESP_ERR_INVALID_STATE;
         HOST_EXIT_CRITICAL();
         goto already_opened;
     }
     // Record in client object that we have opened the device of this address
-    _record_client_opened_device(client_obj, dev_addr);
+    dev_addr_map_set(client_obj->dynamic.opened_dev_addr_map, dev_addr);
     HOST_EXIT_CRITICAL();
 
     *dev_hdl_ret = dev_hdl;
@@ -1405,14 +1511,14 @@ esp_err_t usb_host_device_close(usb_host_client_handle_t client_hdl, usb_device_
     HOST_ENTER_CRITICAL();
     uint8_t dev_addr;
     ESP_ERROR_CHECK(usbh_dev_get_addr(dev_hdl, &dev_addr));
-    if (!_check_client_opened_device(client_obj, dev_addr)) {
+    if (!dev_addr_map_check(client_obj->dynamic.opened_dev_addr_map, dev_addr)) {
         // Client never opened this device
         ret = ESP_ERR_NOT_FOUND;
         HOST_EXIT_CRITICAL();
         goto exit;
     }
     // Proceed to clear the record of the device form the client
-    _clear_client_opened_device(client_obj, dev_addr);
+    dev_addr_map_clear(client_obj->dynamic.opened_dev_addr_map, dev_addr);
     HOST_EXIT_CRITICAL();
 
     ESP_ERROR_CHECK(usbh_dev_close(dev_hdl));
@@ -1431,6 +1537,8 @@ esp_err_t usb_host_device_free_all(void)
 #if ENABLE_USB_HUBS
     hub_notify_all_free();
 #endif // ENABLE_USB_HUBS
+    // Existing-device enumeration must not report devices after the host has started freeing all device objects.
+    clear_all_client_visible_devices();
     ret = usbh_devs_mark_all_free();
     // If ESP_ERR_NOT_FINISHED is returned, caller must wait for USB_HOST_LIB_EVENT_FLAGS_ALL_FREE to confirm all devices are free
     return ret;
@@ -1796,7 +1904,7 @@ esp_err_t usb_host_interface_claim(usb_host_client_handle_t client_hdl, usb_devi
     uint8_t dev_addr;
     ESP_ERROR_CHECK(usbh_dev_get_addr(dev_hdl, &dev_addr));
     // Check if client actually opened device
-    HOST_CHECK_FROM_CRIT(_check_client_opened_device(client_obj, dev_addr), ESP_ERR_INVALID_STATE);
+    HOST_CHECK_FROM_CRIT(dev_addr_map_check(client_obj->dynamic.opened_dev_addr_map, dev_addr), ESP_ERR_INVALID_STATE);
     client_obj->dynamic.flags.taking_mux = 1;
     HOST_EXIT_CRITICAL();
 
@@ -1834,7 +1942,7 @@ esp_err_t usb_host_interface_release(usb_host_client_handle_t client_hdl, usb_de
     uint8_t dev_addr;
     ESP_ERROR_CHECK(usbh_dev_get_addr(dev_hdl, &dev_addr));
     // Check if client actually opened device
-    HOST_CHECK_FROM_CRIT(_check_client_opened_device(client_obj, dev_addr), ESP_ERR_INVALID_STATE);
+    HOST_CHECK_FROM_CRIT(dev_addr_map_check(client_obj->dynamic.opened_dev_addr_map, dev_addr), ESP_ERR_INVALID_STATE);
     client_obj->dynamic.flags.taking_mux = 1;
     HOST_EXIT_CRITICAL();
 

--- a/host/usb/test/target_test/usb_host/main/test_usb_host_client_timing.c
+++ b/host/usb/test/target_test/usb_host/main/test_usb_host_client_timing.c
@@ -1,0 +1,556 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "usb/usb_host.h"
+#include "unity.h"
+
+static const char *TAG = "USB Host timing";
+
+#define TEST_CLIENT_TIMING_TIMEOUT_MS       2000
+#define TEST_CLIENT_TIMING_NO_EVENT_MS      250
+#define TEST_CLIENT_TIMING_POLL_MS          10
+#define TEST_CLIENT_TIMING_MAX_CLIENTS      3
+
+typedef struct {
+    uint8_t last_new_dev_addr;
+    int new_dev_count;
+    int dev_gone_count;
+    int dev_removed_count;
+} client_timing_ctx_t;
+
+static void client_timing_cb(const usb_host_client_event_msg_t *event_msg, void *arg)
+{
+    client_timing_ctx_t *ctx = (client_timing_ctx_t *)arg;
+
+    switch (event_msg->event) {
+    case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        ESP_LOGI(TAG, "Client event -> New device, address: %d", event_msg->new_dev.address);
+        ctx->last_new_dev_addr = event_msg->new_dev.address;
+        ctx->new_dev_count++;
+        break;
+    case USB_HOST_CLIENT_EVENT_DEV_GONE:
+        ESP_LOGI(TAG, "Client event -> Device gone");
+        ctx->dev_gone_count++;
+        break;
+    case USB_HOST_CLIENT_EVENT_DEV_REMOVED:
+        ESP_LOGI(TAG, "Client event -> Device removed, address: %d", event_msg->dev_removed.address);
+        ctx->dev_removed_count++;
+        break;
+    default:
+        break;
+    }
+}
+
+static void handle_client_events(usb_host_client_handle_t *client_hdl, int client_count)
+{
+    for (int i = 0; i < client_count; i++) {
+        if (client_hdl[i]) {
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_client_handle_events(client_hdl[i], 0));
+        }
+    }
+}
+
+static void wait_for_device_count(int expected_count)
+{
+    TickType_t timeout_ticks = pdMS_TO_TICKS(10000);
+    TimeOut_t timeout;
+    vTaskSetTimeOutState(&timeout);
+
+    while (1) {
+        uint32_t event_flags = 0;
+        usb_host_lib_handle_events(pdMS_TO_TICKS(TEST_CLIENT_TIMING_POLL_MS), &event_flags);
+
+        usb_host_lib_info_t lib_info;
+        TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_info(&lib_info));
+        if (lib_info.num_devices == expected_count) {
+            return;
+        }
+
+        if (xTaskCheckForTimeOut(&timeout, &timeout_ticks) == pdTRUE) {
+            TEST_FAIL_MESSAGE("Timed out waiting for expected USB device count");
+        }
+    }
+}
+
+static void wait_for_all_devices_free(void)
+{
+    TickType_t timeout_ticks = pdMS_TO_TICKS(TEST_CLIENT_TIMING_TIMEOUT_MS);
+    TimeOut_t timeout;
+    vTaskSetTimeOutState(&timeout);
+
+    while (1) {
+        uint32_t event_flags = 0;
+        usb_host_lib_handle_events(pdMS_TO_TICKS(TEST_CLIENT_TIMING_POLL_MS), &event_flags);
+        if (event_flags & USB_HOST_LIB_EVENT_FLAGS_ALL_FREE) {
+            return;
+        }
+
+        if (xTaskCheckForTimeOut(&timeout, &timeout_ticks) == pdTRUE) {
+            TEST_FAIL_MESSAGE("Timed out waiting for all USB devices to be freed");
+        }
+    }
+}
+
+static void wait_for_new_dev_events(usb_host_client_handle_t *client_hdl, client_timing_ctx_t *ctx, int client_count, int expected_count)
+{
+    TickType_t timeout_ticks = pdMS_TO_TICKS(TEST_CLIENT_TIMING_TIMEOUT_MS);
+    TimeOut_t timeout;
+    vTaskSetTimeOutState(&timeout);
+
+    while (1) {
+        bool all_seen = true;
+        usb_host_lib_handle_events(pdMS_TO_TICKS(TEST_CLIENT_TIMING_POLL_MS), NULL);
+        handle_client_events(client_hdl, client_count);
+
+        for (int i = 0; i < client_count; i++) {
+            if (ctx[i].new_dev_count != expected_count) {
+                all_seen = false;
+                break;
+            }
+        }
+
+        if (all_seen) {
+            return;
+        }
+
+        if (xTaskCheckForTimeOut(&timeout, &timeout_ticks) == pdTRUE) {
+            TEST_FAIL_MESSAGE("Timed out waiting for NEW_DEV events");
+        }
+    }
+}
+
+static void assert_new_dev_count(const client_timing_ctx_t *ctx, int client_count, int expected_count)
+{
+    for (int i = 0; i < client_count; i++) {
+        TEST_ASSERT_EQUAL(expected_count, ctx[i].new_dev_count);
+    }
+}
+
+static void assert_disconnect_count(const client_timing_ctx_t *ctx, int client_count, const int *expected_dev_gone, const int *expected_dev_removed)
+{
+    for (int i = 0; i < client_count; i++) {
+        TEST_ASSERT_EQUAL(expected_dev_gone[i], ctx[i].dev_gone_count);
+        TEST_ASSERT_EQUAL(expected_dev_removed[i], ctx[i].dev_removed_count);
+    }
+}
+
+static void drain_events_for(usb_host_client_handle_t *client_hdl, int client_count, int duration_ms)
+{
+    TickType_t timeout_ticks = pdMS_TO_TICKS(duration_ms);
+    TimeOut_t timeout;
+    vTaskSetTimeOutState(&timeout);
+
+    do {
+        usb_host_lib_handle_events(pdMS_TO_TICKS(TEST_CLIENT_TIMING_POLL_MS), NULL);
+        handle_client_events(client_hdl, client_count);
+        vTaskDelay(pdMS_TO_TICKS(TEST_CLIENT_TIMING_POLL_MS));
+    } while (xTaskCheckForTimeOut(&timeout, &timeout_ticks) == pdFALSE);
+}
+
+static void wait_for_existing_device_ready(void)
+{
+    /*
+     * num_devices == 1 can become true before the pending USBH_EVENT_NEW_DEV is dispatched by the host lib.
+     * Keep running the host lib with no clients so late-client tests do not accidentally catch that real event.
+     */
+    wait_for_device_count(1);
+    drain_events_for(NULL, 0, TEST_CLIENT_TIMING_NO_EVENT_MS);
+}
+
+static void register_timing_client(client_timing_ctx_t *ctx, usb_host_client_handle_t *client_hdl)
+{
+    const usb_host_client_config_t client_config = {
+        .is_synchronous = false,
+        .max_num_event_msg = 5,
+        .async = {
+            .client_event_callback = client_timing_cb,
+            .callback_arg = ctx,
+        },
+    };
+
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_client_register(&client_config, client_hdl));
+}
+
+static void register_timing_removed_notify_client(client_timing_ctx_t *ctx, usb_host_client_handle_t *client_hdl)
+{
+    const usb_host_client_config_t client_config = {
+        .is_synchronous = false,
+        .max_num_event_msg = 5,
+        .flags = {
+            .notify_dev_removed = 1,
+        },
+        .async = {
+            .client_event_callback = client_timing_cb,
+            .callback_arg = ctx,
+        },
+    };
+
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_client_register(&client_config, client_hdl));
+}
+
+static void power_off_root_and_wait_empty(void)
+{
+    /*
+     * The test setup powers the root port immediately. Wait for the already attached test device first,
+     * then power the root port off and wait for the host stack to recycle the device object.
+     */
+    wait_for_device_count(1);
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(false));
+    wait_for_all_devices_free();
+}
+
+static void power_on_root_and_wait_one_device(void)
+{
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(true));
+    wait_for_device_count(1);
+}
+
+static void power_off_root_only(void)
+{
+    wait_for_device_count(1);
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(false));
+}
+
+static void cleanup_timing_test(usb_host_client_handle_t *client_hdl, int client_count)
+{
+    for (int i = 0; i < client_count; i++) {
+        if (client_hdl[i]) {
+            TEST_ASSERT_EQUAL(ESP_OK, usb_host_client_deregister(client_hdl[i]));
+            client_hdl[i] = NULL;
+        }
+    }
+
+    drain_events_for(NULL, 0, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    esp_err_t ret = usb_host_device_free_all();
+    TEST_ASSERT_TRUE(ret == ESP_OK || ret == ESP_ERR_NOT_FINISHED);
+    if (ret == ESP_ERR_NOT_FINISHED) {
+        wait_for_all_devices_free();
+    }
+}
+
+static void wait_for_client_disconnect_events(usb_host_client_handle_t *client_hdl, client_timing_ctx_t *ctx, int client_count,
+                                              const int *expected_dev_gone, const int *expected_dev_removed)
+{
+    TickType_t timeout_ticks = pdMS_TO_TICKS(TEST_CLIENT_TIMING_TIMEOUT_MS);
+    TimeOut_t timeout;
+    vTaskSetTimeOutState(&timeout);
+
+    while (1) {
+        bool all_seen = true;
+        usb_host_lib_handle_events(pdMS_TO_TICKS(TEST_CLIENT_TIMING_POLL_MS), NULL);
+        handle_client_events(client_hdl, client_count);
+
+        for (int i = 0; i < client_count; i++) {
+            if (ctx[i].dev_gone_count != expected_dev_gone[i] || ctx[i].dev_removed_count != expected_dev_removed[i]) {
+                all_seen = false;
+                break;
+            }
+        }
+
+        if (all_seen) {
+            return;
+        }
+
+        if (xTaskCheckForTimeOut(&timeout, &timeout_ticks) == pdTRUE) {
+            TEST_FAIL_MESSAGE("Timed out waiting for disconnect events");
+        }
+    }
+}
+
+TEST_CASE("USB Host clients registered before insertion receive NEW_DEV", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx[2] = {};
+    usb_host_client_handle_t client_hdl[2] = {};
+
+    power_off_root_and_wait_empty();
+    register_timing_client(&ctx[0], &client_hdl[0]);
+    register_timing_client(&ctx[1], &client_hdl[1]);
+
+    power_on_root_and_wait_one_device();
+    wait_for_new_dev_events(client_hdl, ctx, 2, 1);
+    drain_events_for(client_hdl, 2, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    assert_new_dev_count(ctx, 2, 1);
+    TEST_ASSERT_NOT_EQUAL(0, ctx[0].last_new_dev_addr);
+    TEST_ASSERT_EQUAL(ctx[0].last_new_dev_addr, ctx[1].last_new_dev_addr);
+
+    cleanup_timing_test(client_hdl, 2);
+}
+
+TEST_CASE("USB Host clients registered after enumeration receive existing NEW_DEV by default", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx[2] = {};
+    usb_host_client_handle_t client_hdl[2] = {};
+
+    wait_for_existing_device_ready();
+    register_timing_client(&ctx[0], &client_hdl[0]);
+    register_timing_client(&ctx[1], &client_hdl[1]);
+    wait_for_new_dev_events(client_hdl, ctx, 2, 1);
+    drain_events_for(client_hdl, 2, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    const int client0_new_dev_count = ctx[0].new_dev_count;
+    const int client1_new_dev_count = ctx[1].new_dev_count;
+
+    cleanup_timing_test(client_hdl, 2);
+
+    TEST_ASSERT_EQUAL(1, client0_new_dev_count);
+    TEST_ASSERT_EQUAL(1, client1_new_dev_count);
+}
+
+TEST_CASE("USB Host mixed early and late clients preserve per-client NEW_DEV timing", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx[2] = {};
+    usb_host_client_handle_t client_hdl[2] = {};
+
+    power_off_root_and_wait_empty();
+    register_timing_client(&ctx[0], &client_hdl[0]);
+    power_on_root_and_wait_one_device();
+    wait_for_new_dev_events(client_hdl, ctx, 1, 1);
+
+    register_timing_client(&ctx[1], &client_hdl[1]);
+    wait_for_new_dev_events(&client_hdl[1], &ctx[1], 1, 1);
+    drain_events_for(client_hdl, 2, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    const int early_client_new_dev_count = ctx[0].new_dev_count;
+    const int late_client_new_dev_count = ctx[1].new_dev_count;
+
+    cleanup_timing_test(client_hdl, 2);
+
+    TEST_ASSERT_EQUAL(1, early_client_new_dev_count);
+    TEST_ASSERT_EQUAL(1, late_client_new_dev_count);
+}
+
+TEST_CASE("USB Host late clients receive NEW_DEV for later reconnect", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx[2] = {};
+    usb_host_client_handle_t client_hdl[2] = {};
+
+    wait_for_existing_device_ready();
+    register_timing_client(&ctx[0], &client_hdl[0]);
+    register_timing_client(&ctx[1], &client_hdl[1]);
+    wait_for_new_dev_events(client_hdl, ctx, 2, 1);
+    drain_events_for(client_hdl, 2, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    const int client0_historical_count = ctx[0].new_dev_count;
+    const int client1_historical_count = ctx[1].new_dev_count;
+
+    power_off_root_and_wait_empty();
+    power_on_root_and_wait_one_device();
+    wait_for_new_dev_events(client_hdl, ctx, 2, 2);
+    drain_events_for(client_hdl, 2, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    TEST_ASSERT_NOT_EQUAL(0, ctx[0].last_new_dev_addr);
+    TEST_ASSERT_EQUAL(ctx[0].last_new_dev_addr, ctx[1].last_new_dev_addr);
+
+    cleanup_timing_test(client_hdl, 2);
+
+    TEST_ASSERT_EQUAL(1, client0_historical_count);
+    TEST_ASSERT_EQUAL(1, client1_historical_count);
+}
+
+TEST_CASE("USB Host multiple late clients receive one existing NEW_DEV by default", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx[TEST_CLIENT_TIMING_MAX_CLIENTS] = {};
+    usb_host_client_handle_t client_hdl[TEST_CLIENT_TIMING_MAX_CLIENTS] = {};
+    int new_dev_count[TEST_CLIENT_TIMING_MAX_CLIENTS] = {};
+
+    wait_for_existing_device_ready();
+    for (int i = 0; i < TEST_CLIENT_TIMING_MAX_CLIENTS; i++) {
+        register_timing_client(&ctx[i], &client_hdl[i]);
+        wait_for_new_dev_events(&client_hdl[i], &ctx[i], 1, 1);
+        drain_events_for(&client_hdl[i], 1, TEST_CLIENT_TIMING_NO_EVENT_MS);
+        new_dev_count[i] = ctx[i].new_dev_count;
+    }
+
+    cleanup_timing_test(client_hdl, TEST_CLIENT_TIMING_MAX_CLIENTS);
+
+    for (int i = 0; i < TEST_CLIENT_TIMING_MAX_CLIENTS; i++) {
+        TEST_ASSERT_EQUAL(1, new_dev_count[i]);
+    }
+}
+
+TEST_CASE("USB Host DEV_GONE is delivered only to clients that opened the device", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx[3] = {};
+    usb_host_client_handle_t client_hdl[3] = {};
+    usb_device_handle_t opened_dev[2] = {};
+
+    power_off_root_and_wait_empty();
+    register_timing_client(&ctx[0], &client_hdl[0]);
+    register_timing_client(&ctx[1], &client_hdl[1]);
+    register_timing_client(&ctx[2], &client_hdl[2]);
+
+    power_on_root_and_wait_one_device();
+    wait_for_new_dev_events(client_hdl, ctx, 3, 1);
+    drain_events_for(client_hdl, 3, TEST_CLIENT_TIMING_NO_EVENT_MS);
+    assert_new_dev_count(ctx, 3, 1);
+
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_device_open(client_hdl[0], ctx[0].last_new_dev_addr, &opened_dev[0]));
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_device_open(client_hdl[1], ctx[1].last_new_dev_addr, &opened_dev[1]));
+
+    power_off_root_only();
+
+    const int expected_dev_gone[3] = {1, 1, 0};
+    const int expected_dev_removed[3] = {0, 0, 0};
+    wait_for_client_disconnect_events(client_hdl, ctx, 3, expected_dev_gone, expected_dev_removed);
+    drain_events_for(client_hdl, 3, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    const int final_dev_gone_count[3] = {ctx[0].dev_gone_count, ctx[1].dev_gone_count, ctx[2].dev_gone_count};
+    const int final_dev_removed_count[3] = {ctx[0].dev_removed_count, ctx[1].dev_removed_count, ctx[2].dev_removed_count};
+
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_device_close(client_hdl[0], opened_dev[0]));
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_device_close(client_hdl[1], opened_dev[1]));
+    cleanup_timing_test(client_hdl, 3);
+
+    assert_disconnect_count((const client_timing_ctx_t[]) {
+        {.dev_gone_count = final_dev_gone_count[0], .dev_removed_count = final_dev_removed_count[0]},
+        {.dev_gone_count = final_dev_gone_count[1], .dev_removed_count = final_dev_removed_count[1]},
+        {.dev_gone_count = final_dev_gone_count[2], .dev_removed_count = final_dev_removed_count[2]},
+    }, 3, expected_dev_gone, expected_dev_removed);
+}
+
+TEST_CASE("USB Host DEV_REMOVED is delivered to unopened clients that subscribe", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx[2] = {};
+    usb_host_client_handle_t client_hdl[2] = {};
+    usb_device_handle_t opened_dev = NULL;
+
+    power_off_root_and_wait_empty();
+    register_timing_client(&ctx[0], &client_hdl[0]);
+    register_timing_removed_notify_client(&ctx[1], &client_hdl[1]);
+
+    power_on_root_and_wait_one_device();
+    wait_for_new_dev_events(client_hdl, ctx, 2, 1);
+    drain_events_for(client_hdl, 2, TEST_CLIENT_TIMING_NO_EVENT_MS);
+    assert_new_dev_count(ctx, 2, 1);
+
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_device_open(client_hdl[0], ctx[0].last_new_dev_addr, &opened_dev));
+
+    power_off_root_only();
+
+    const int expected_dev_gone[2] = {1, 0};
+    const int expected_dev_removed[2] = {0, 1};
+    wait_for_client_disconnect_events(client_hdl, ctx, 2, expected_dev_gone, expected_dev_removed);
+    drain_events_for(client_hdl, 2, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    const int final_dev_gone_count[2] = {ctx[0].dev_gone_count, ctx[1].dev_gone_count};
+    const int final_dev_removed_count[2] = {ctx[0].dev_removed_count, ctx[1].dev_removed_count};
+
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_device_close(client_hdl[0], opened_dev));
+    cleanup_timing_test(client_hdl, 2);
+
+    assert_disconnect_count((const client_timing_ctx_t[]) {
+        {.dev_gone_count = final_dev_gone_count[0], .dev_removed_count = final_dev_removed_count[0]},
+        {.dev_gone_count = final_dev_gone_count[1], .dev_removed_count = final_dev_removed_count[1]},
+    }, 2, expected_dev_gone, expected_dev_removed);
+}
+
+TEST_CASE("USB Host late client receives existing device as NEW_DEV", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx = {};
+    usb_host_client_handle_t client_hdl = NULL;
+
+    wait_for_existing_device_ready();
+    register_timing_client(&ctx, &client_hdl);
+    wait_for_new_dev_events(&client_hdl, &ctx, 1, 1);
+    drain_events_for(&client_hdl, 1, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    TEST_ASSERT_EQUAL(1, ctx.new_dev_count);
+    TEST_ASSERT_NOT_EQUAL(0, ctx.last_new_dev_addr);
+
+    cleanup_timing_test(&client_hdl, 1);
+}
+
+TEST_CASE("USB Host late client receives one NEW_DEV across pending enumeration boundary", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx = {};
+    usb_host_client_handle_t client_hdl = NULL;
+
+    power_off_root_and_wait_empty();
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_set_root_port_power(true));
+    wait_for_device_count(1);
+
+    register_timing_client(&ctx, &client_hdl);
+    wait_for_new_dev_events(&client_hdl, &ctx, 1, 1);
+    drain_events_for(&client_hdl, 1, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    const int new_dev_count = ctx.new_dev_count;
+
+    cleanup_timing_test(&client_hdl, 1);
+
+    TEST_ASSERT_EQUAL(1, new_dev_count);
+}
+
+TEST_CASE("USB Host client does not receive NEW_DEV after all devices are freed", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx = {};
+    usb_host_client_handle_t client_hdl = NULL;
+
+    wait_for_existing_device_ready();
+    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FINISHED, usb_host_device_free_all());
+    wait_for_all_devices_free();
+
+    register_timing_client(&ctx, &client_hdl);
+    drain_events_for(&client_hdl, 1, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    const int new_dev_count = ctx.new_dev_count;
+
+    cleanup_timing_test(&client_hdl, 1);
+
+    TEST_ASSERT_EQUAL(0, new_dev_count);
+}
+
+TEST_CASE("USB Host client registration tolerates device removal in flight", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx = {};
+    usb_host_client_handle_t client_hdl = NULL;
+
+    wait_for_existing_device_ready();
+    power_off_root_only();
+
+    register_timing_client(&ctx, &client_hdl);
+    drain_events_for(&client_hdl, 1, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    TEST_ASSERT_TRUE(ctx.new_dev_count <= 1);
+    if (ctx.new_dev_count == 1) {
+        TEST_ASSERT_NOT_EQUAL(0, ctx.last_new_dev_addr);
+    }
+
+    cleanup_timing_test(&client_hdl, 1);
+}
+
+TEST_CASE("USB Host late clients and early clients share consistent NEW_DEV visibility", "[usb_host][timing][low_speed][full_speed][high_speed]")
+{
+    client_timing_ctx_t ctx[3] = {};
+    usb_host_client_handle_t client_hdl[3] = {};
+
+    power_off_root_and_wait_empty();
+    register_timing_client(&ctx[0], &client_hdl[0]);
+    power_on_root_and_wait_one_device();
+    wait_for_new_dev_events(client_hdl, ctx, 1, 1);
+    drain_events_for(client_hdl, 1, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    register_timing_client(&ctx[1], &client_hdl[1]);
+    register_timing_client(&ctx[2], &client_hdl[2]);
+    wait_for_new_dev_events(&client_hdl[1], &ctx[1], 2, 1);
+    drain_events_for(&client_hdl[1], 2, TEST_CLIENT_TIMING_NO_EVENT_MS);
+
+    TEST_ASSERT_EQUAL(1, ctx[0].new_dev_count);
+    TEST_ASSERT_EQUAL(1, ctx[1].new_dev_count);
+    TEST_ASSERT_EQUAL(1, ctx[2].new_dev_count);
+    TEST_ASSERT_EQUAL(ctx[0].last_new_dev_addr, ctx[1].last_new_dev_addr);
+    TEST_ASSERT_EQUAL(ctx[0].last_new_dev_addr, ctx[2].last_new_dev_addr);
+
+    cleanup_timing_test(client_hdl, 3);
+}


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

## Problem Solved

  - When registering multiple classes using a composite device, the registration of different classes may occur at different times. If the enumeration of the USB device takes place prior to class registration, the subsequently registered classes will never receive the device connection event until re-enumeration is performed.

## Changes

  - Add `enumerate_existing_devices` to USB Host client config so late-registered clients can opt in to receiving `NEW_DEV`
  events for already visible devices.
  - Track client-visible device addresses in the USB Host layer and keep real `NEW_DEV` delivery ordered with historical event
  replay.
  - Skip client-facing remove/gone events for default address 0 devices that disappear during early enumeration.


<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

  - Add USB Host timing target tests for early/late clients, reconnects, opened/unopened clients, opt-in replay, and stale-
  device cleanup.

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core client event ordering and default behavior for late registration (more NEW_DEV delivery), with new locking paths around pending replay; mistakes could cause duplicate/missed discovery or races under queue backpressure.
> 
> **Overview**
> **Late-registered USB host clients now get `NEW_DEV` for devices the stack already enumerated**, fixing composite setups where class drivers register after connect. The host layer tracks **client-visible** device addresses and, on each new device, marks them visible and queues delivery per client instead of a single broadcast that could be lost when an event queue is full.
> 
> Delivery uses **pending bitmasks** per client plus a **`has_pending_new_dev`** flag; `usb_host_client_handle_events` retries after the queue drains. **Registration** seeds pending from the global visible map and flushes immediately. **Removal** clears visible/pending state (including on `usb_host_device_free_all`), and **address 0** no longer generates client remove/gone traffic during early enumeration.
> 
> Opened-device tracking is refactored to shared **`dev_addr_map_*`** helpers. **Target timing tests** cover early/late/mixed clients, reconnects, `DEV_GONE`/`DEV_REMOVED` routing, free-all, and in-flight disconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4d7f1a557947a4db4d2c568bcbf0e0f026a1ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->