### PR TITLE
fix(ci): Fix gcc 16.1.0 compiler flags in esp-usb test apps

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -71,7 +71,18 @@ jobs:
           . ${IDF_PATH}/export.sh
           git config --global safe.directory $(pwd)
           pip install idf-build-apps==3.0.1 --upgrade
-          export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
+
+          PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-function"
+          # IDF latest (6.2) and newer use -Werror=unused-but-set-variable=1 (esp-idf@71618c8).
+          # Older IDF releases use -Werror=unused-but-set-variable without =1.
+          case "${{ matrix.idf_ver }}" in
+            release-v5.*|release-v6.0|release-v6.1)
+              PEDANTIC_FLAGS="${PEDANTIC_FLAGS} -Werror=unused-but-set-variable"
+              ;;
+            *)
+              PEDANTIC_FLAGS="${PEDANTIC_FLAGS} -Werror=unused-but-set-variable=1"
+              ;;
+          esac
           export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
           export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
           export ENV_VAR_USB_COMP_MANAGED=${{ matrix.usb_comp_managed }}


### PR DESCRIPTION
## Description

Fixing `Werror=unused-but-set-variable` compiler flag similar as in #512 for esp-idf examples build.

## Related

- Related to fix in #512 
- Fixing CI in #515 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application or runtime impact.
> 
> **Overview**
> Aligns **USB test app** CI pedantic compiler flags with the IDF examples workflow fix (#512).
> 
> Instead of always appending `-Werror=unused-but-set-variable`, `build_and_run_test_app_usb.yml` now builds `PEDANTIC_FLAGS` in steps and uses a **`case` on `matrix.idf_ver`**: **release-v5.\*, release-v6.0, and release-v6.1** keep the legacy flag form; **IDF latest (6.2+) and other newer matrix entries** use `-Werror=unused-but-set-variable=1` for GCC 16.1.0 compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a5e3056c833388a46b13c5cf93d3a375038b556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->