### PR TITLE
fix(usb_host): fix USB Host light sleep rejection

### DIFF
--- a/host/usb/test/target_test/usb_sleep_modes/main/test_usb_host_esp_sleep.c
+++ b/host/usb/test/target_test/usb_sleep_modes/main/test_usb_host_esp_sleep.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
@@ -25,9 +26,33 @@
 #define EVT_WAIT_TIME_MS                 (5 * 1000)        // 5 seconds
 #define LIGHT_SLEEP_NUM_CYCLES           (3)
 
+static char err_msg_buf[128];
 const char *USB_SLEEP_TAG = "USB sleep";
 
 extern void test_setup(void);
+
+static void light_sleep_enter_catch_impl(const char *file, int line)
+{
+    const esp_err_t light_sleep_err = esp_light_sleep_start();
+    if (light_sleep_err == ESP_ERR_SLEEP_REJECT) {
+        // Enter light sleep might be rejected, due to the other esp core being in a critical section
+        // Let the usb host lib handle current events and try to enter the light sleep again
+        ESP_LOGI(USB_SLEEP_TAG, "Light sleep rejected, re-entering light sleep");
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Second light sleep entry error at %s:%d\n", file, line);
+        taskYIELD();
+        TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, esp_light_sleep_start(), err_msg_buf);
+    } else if (light_sleep_err != ESP_OK) {
+        // Other error occurred
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Light sleep entry error at %s:%d\n", file, line);
+        TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, light_sleep_err, err_msg_buf);
+    } else {
+        // pass
+    }
+}
+/**
+ * @brief Enter light sleep and catch sleep rejected error
+ */
+#define light_sleep_enter_catch() light_sleep_enter_catch_impl(__FILE__, __LINE__)
 
 /*
     Light sleep task
@@ -55,7 +80,7 @@ static void light_sleep_task(void *args)
         const int64_t t_before_us = esp_timer_get_time();
 
         // Enter light sleep mode
-        TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());
+        light_sleep_enter_catch();
 
         // Get timestamp after waking up from sleep
         const int64_t t_after_us = esp_timer_get_time();
@@ -270,7 +295,7 @@ static void light_sleep_enter_task_error(void *args)
     const int64_t t_before_us = esp_timer_get_time();
 
     // Immediately enter light sleep mode
-    TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());
+    light_sleep_enter_catch();
 
     // Get timestamp after waking up from sleep
     const int64_t t_after_us = esp_timer_get_time();
@@ -469,7 +494,7 @@ static void light_sleep_enter_latency_task(void *args)
     vTaskDelay(20);
 
     // Init cache, call the DUT function for the first time separately outside of the measuring loop
-    TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());
+    light_sleep_enter_catch();
 
     // Resume the root port manually and wait for the resume sequence
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_root_port_resume());
@@ -477,7 +502,7 @@ static void light_sleep_enter_latency_task(void *args)
 
     // Measure enter and exit light sleep latency
     for (int i = 0; i < LIGHT_SLEEP_NUM_CYCLES; i++) {
-        TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());
+        light_sleep_enter_catch();
         const uint32_t wakeup_cause = esp_sleep_get_wakeup_causes();
         TEST_ASSERT(wakeup_cause & BIT(ESP_SLEEP_WAKEUP_TIMER));
 
@@ -686,14 +711,14 @@ TEST_CASE("Test USB Host light sleep events delivery", "[usb_sleep_modes][low_sp
 
     /* Test case 1: Light sleep callback suspend event delivery */
     // Enter light sleep with root port resumed and expect suspend event (auto suspend by light sleep)
-    TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());
+    light_sleep_enter_catch();
     TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xQueueReceive(notif_queue, &client_event, pdMS_TO_TICKS(1000)), "Suspend event not delivered");
     TEST_ASSERT_EQUAL_MESSAGE(client_event, USB_HOST_CLIENT_EVENT_DEV_SUSPENDED, "Unexpected event delivered");
 
     /* Test case 2: Light sleep callback with root port auto-suspended */
     // Enter light sleep with root port automatically suspended and expect no event
     // Light sleep shall not deliver suspend event if the root port was not suspended by the light sleep callback
-    TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());
+    light_sleep_enter_catch();
     TEST_ASSERT_EQUAL_MESSAGE(pdFALSE, xQueueReceive(notif_queue, &client_event, pdMS_TO_TICKS(1000)), "An event delivered, but none was expected");
 
     // Manually resume and suspend the root port (don't use light sleep callback to suspend the port)
@@ -706,7 +731,7 @@ TEST_CASE("Test USB Host light sleep events delivery", "[usb_sleep_modes][low_sp
 
     /* Test case 3: Light sleep callback with root port manually suspended */
     // Enter light sleep with root port manually suspended and expect no event
-    TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());
+    light_sleep_enter_catch();
     TEST_ASSERT_EQUAL_MESSAGE(pdFALSE, xQueueReceive(notif_queue, &client_event, pdMS_TO_TICKS(1000)), "An event delivered, but none was expected");
 
     // Stop the client task, deregister client and release devices


### PR DESCRIPTION
Fixing light sleep tests introduced by [0c7caf7](https://github.com/espressif/esp-idf/commit/0c7caf79b5948c56b9fd6852b3e47bd1ca443d89) commit in esp-idf

- light sleep entry could be rejected, due to other esp core currently being in a critical section
- fixing this special case by letting the usb host lib to handle ongoing usb events

<details>
<summary> CI Error log </summary>

```sh
2026-06-24 09:46:54  ____ ___  ___________________    __                   __   
2026-06-24 09:46:54 |    |   \/   _____/\______   \ _/  |_  ____   _______/  |_ 
2026-06-24 09:46:54 |    |   /\_____  \  |    |  _/ \   __\/ __ \ /  ___/\   __\
2026-06-24 09:46:54 |    |  / /        \ |    |   \  |  | \  ___/ \___ \  |  |  
2026-06-24 09:46:54 |______/ /_______  / |______  /  |__|  \___  >____  > |__|  
2026-06-24 09:46:54                  \/         \/             \/     \/        
2026-06-24 09:46:54 
2026-06-24 09:46:54 
2026-06-24 09:46:54 Press ENTER to see the list of tests.
2026-06-24 09:46:54 1
2026-06-24 09:46:54 Running Test USB Host light sleep...
2026-06-24 09:46:54 USB Host installed
2026-06-24 09:46:54 I (429) USB sleep: Light sleep timer wakeup source is ready
2026-06-24 09:46:54 I (429) Ctrl Client sleep: Starting
2026-06-24 09:46:55 I (839) Ctrl Client sleep: Client event -> New device
2026-06-24 09:46:58 I (839) Ctrl Client sleep: Open
2026-06-24 09:46:58 I (839) Ctrl Client sleep: Transfer
2026-06-24 09:46:58 Returned from light sleep, reason: timer, t=3556 ms, slept for 2998 ms
2026-06-24 09:46:58 I (839) Ctrl Client sleep: Client event -> Device suspended
2026-06-24 09:46:58 I (899) Ctrl Client sleep: Client event -> Device resumed
2026-06-24 09:46:58 I (899) Ctrl Client sleep: Transfer
2026-06-24 09:46:58 ./main/test_usb_host_esp_sleep.c:58:Test USB Host light sleep:FAIL: Expected 0 Was 259. Function [usb_sleep_modes][light_sleep]Guru Meditation Error: Core  1 panic'ed (Stack protection fault). 
2026-06-24 09:46:58 
2026-06-24 09:46:58 Detected in task "sleep_task" at 0x4fc1adec
2026-06-24 09:46:58 Stack pointer: 0x4ff17f40
2026-06-24 09:46:58 Stack bounds: 0x4ff3bc10 - 0x4ff3cc00
2026-06-24 09:46:58 
2026-06-24 09:46:58 
2026-06-24 09:46:58 Core  1 register dump:
2026-06-24 09:46:58 MEPC    : 0x4fc1adf4  RA      : 0x4001a01e  SP      : 0x4ff17f40  GP      : 0x4ff0fb00  
2026-06-24 09:46:58 TP      : 0x4ff3cbd0  T0      : 0x4fc09fd4  T1      : 0x7e800000  T2      : 0x00000000  
2026-06-24 09:46:58 S0/FP   : 0x4ff0f834  S1      : 0x00000000  A0      : 0x4ff136f0  A1      : 0x00000001  
2026-06-24 09:46:58 A2      : 0x00000000  A3      : 0x4ff3fea4  A4      : 0x00000001  A5      : 0x000500ca  
2026-06-24 09:46:58 A6      : 0xb4000000  A7      : 0x00000001  S2      : 0x00000000  S3      : 0x00000000  
2026-06-24 09:46:58 S4      : 0x00000000  S5      : 0x00000000  S6      : 0x00000000  S7      : 0x00000000  
2026-06-24 09:46:58 S8      : 0x00000000  S9      : 0x00000000  S10     : 0x00000000  S11     : 0x00000000  
2026-06-24 09:46:58 T3      : 0x00000000  T4      : 0x00000d90  T5      : 0x00000000  T6      : 0x00000000  
2026-06-24 09:46:58 MSTATUS : 0x00013880  MTVEC   : 0x4ff00003  MCAUSE  : 0x0000001b  MTVAL   : 0x00000000  
2026-06-24 09:46:58 MHARTID : 0x00000001  
2026-06-24 09:46:58 
2026-06-24 09:46:58 Stack memory:
2026-06-24 09:46:58 4ff17f40: 0x00000005 0x00000005 0x4ff0f834 0x4000be98 0x00000005 0x00000100 0x4ff0f834 0x4001a33e
```

</details>

## Related

- Fixes #516 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to USB host sleep mode unit tests; no host library or sleep driver production logic is modified.
> 
> **Overview**
> USB Host light sleep target tests were failing when `esp_light_sleep_start()` returned **`ESP_ERR_SLEEP_REJECT`** (e.g. another core in a critical section), which previously caused hard `TEST_ASSERT_EQUAL(ESP_OK, …)` failures and follow-on panics.
> 
> This PR adds **`light_sleep_enter_catch()`** / **`light_sleep_enter_catch_impl()`**: on reject it logs, **`taskYIELD()`** so the USB host stack can drain events, then retries entry once; other errors still fail with file/line messages via a shared **`err_msg_buf`**. All direct light-sleep assertions in the light-sleep task, error-handling, latency, and suspend-event delivery cases now go through this helper instead of assuming first-call success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359242d2ff50e6eb594ef8fe9b6cf3a5a2dc2c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->