### PR TITLE
fix(cdc_acm_host): Fix submitting POLL transfers race

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed submitting transfer poll race condition https://github.com/espressif/esp-usb/pull/518
+
 ## [2.4.0] - 2026-04-14
 
 ### Added

--- a/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
+++ b/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c
@@ -171,6 +171,43 @@ static esp_err_t cdc_acm_reset_transfer_endpoint(usb_device_handle_t dev_hdl, us
 }
 
 /**
+ * @brief Submit a continuous IN poll transfer if polling is not already active
+ *
+ * Both cdc_acm_resume() and IN transfer callbacks resubmit poll transfers. This helper
+ * ensures only one submit is in-flight and tolerates a stale in-flight URB flag when halt
+ * flush completion has not been processed yet.
+ *
+ * @param[in] xfer IN poll transfer
+ * @param[in,out] polling_active Driver flag tracking whether the poll transfer was submitted
+ * @param[in] xfer_name Short name used for debug logs
+ * @return
+ *    - ESP_OK: Already polling or IN transfer successfully submitted for polling
+ *    - Other errors passed from caller functions
+ */
+static esp_err_t cdc_acm_submit_poll(usb_transfer_t *xfer, bool *polling_active, const char *xfer_name)
+{
+    if (*polling_active) {
+        ESP_LOGD(TAG, "%s poll already active, skip submit", xfer_name);
+        return ESP_OK;
+    }
+
+    esp_err_t err = usb_host_transfer_submit(xfer);
+    if (err == ESP_OK) {
+        *polling_active = true;
+        return ESP_OK;
+    }
+
+    if (err == ESP_ERR_NOT_FINISHED) {
+        *polling_active = true;
+        ESP_LOGD(TAG, "%s poll already in-flight, treat as active", xfer_name);
+        return ESP_OK;
+    }
+
+    ESP_LOGE(TAG, "%s poll submit failed: %s", xfer_name, esp_err_to_name(err));
+    return err;
+}
+
+/**
  * @brief Start CDC device
  *
  * After this call, USB host peripheral will continuously poll IN endpoints.
@@ -202,7 +239,7 @@ static esp_err_t cdc_acm_start(cdc_dev_t *cdc_dev, cdc_acm_host_dev_callback_t e
         err, TAG, "Could not claim interface");
     if (cdc_dev->data.in_xfer) {
         ESP_LOGD(TAG, "Submitting poll for BULK IN transfer");
-        ESP_ERROR_CHECK(usb_host_transfer_submit(cdc_dev->data.in_xfer));
+        ESP_ERROR_CHECK(cdc_acm_submit_poll(cdc_dev->data.in_xfer, &cdc_dev->data.in_polling, "BULK IN"));
     }
 
     // If notification are supported, claim its interface and start polling its IN endpoint
@@ -217,7 +254,7 @@ static esp_err_t cdc_acm_start(cdc_dev_t *cdc_dev, cdc_acm_host_dev_callback_t e
                 err, TAG, "Could not claim interface");
         }
         ESP_LOGD(TAG, "Submitting poll for INTR IN transfer");
-        ESP_ERROR_CHECK(usb_host_transfer_submit(cdc_dev->notif.xfer));
+        ESP_ERROR_CHECK(cdc_acm_submit_poll(cdc_dev->notif.xfer, &cdc_dev->notif.xfer_polling, "INTR IN"));
     }
 
     // Everything OK, add the device into list and return
@@ -706,6 +743,8 @@ esp_err_t cdc_acm_host_close(cdc_acm_dev_hdl_t cdc_hdl)
     CDC_ACM_EXIT_CRITICAL();
 
     // Cancel polling of BULK IN and INTERRUPT IN
+    cdc_dev->data.in_polling = false;
+    cdc_dev->notif.xfer_polling = false;
     if (cdc_dev->data.in_xfer) {
         ESP_ERROR_CHECK(cdc_acm_reset_transfer_endpoint(cdc_dev->dev_hdl, cdc_dev->data.in_xfer));
     }
@@ -785,6 +824,7 @@ static void in_xfer_cb(usb_transfer_t *transfer)
 {
     ESP_LOGD(TAG, "in xfer cb");
     cdc_dev_t *cdc_dev = (cdc_dev_t *)transfer->context;
+    cdc_dev->data.in_polling = false;
 
     if (!cdc_acm_is_transfer_completed(transfer)) {
         return;
@@ -834,13 +874,14 @@ static void in_xfer_cb(usb_transfer_t *transfer)
     }
 
     ESP_LOGD(TAG, "Submitting poll for BULK IN transfer");
-    usb_host_transfer_submit(cdc_dev->data.in_xfer);
+    cdc_acm_submit_poll(cdc_dev->data.in_xfer, &cdc_dev->data.in_polling, "BULK IN");
 }
 
 static void notif_xfer_cb(usb_transfer_t *transfer)
 {
     ESP_LOGD(TAG, "notif xfer cb");
     cdc_dev_t *cdc_dev = (cdc_dev_t *)transfer->context;
+    cdc_dev->notif.xfer_polling = false;
 
     if (cdc_acm_is_transfer_completed(transfer)) {
         cdc_notification_t *notif = (cdc_notification_t *)transfer->data_buffer;
@@ -875,7 +916,7 @@ static void notif_xfer_cb(usb_transfer_t *transfer)
 
         // Start polling for new data again
         ESP_LOGD(TAG, "Submitting poll for INTR IN transfer");
-        usb_host_transfer_submit(cdc_dev->notif.xfer);
+        cdc_acm_submit_poll(cdc_dev->notif.xfer, &cdc_dev->notif.xfer_polling, "INTR IN");
     }
 }
 
@@ -901,12 +942,33 @@ static void cdc_acm_resume(cdc_dev_t *cdc_dev)
 
     if (cdc_dev->data.in_xfer) {
         ESP_LOGD(TAG, "Submitting poll for BULK IN transfer");
-        ESP_ERROR_CHECK(usb_host_transfer_submit(cdc_dev->data.in_xfer));
+        ESP_ERROR_CHECK(cdc_acm_submit_poll(cdc_dev->data.in_xfer, &cdc_dev->data.in_polling, "BULK IN"));
     }
 
     if (cdc_dev->notif.xfer) {
         ESP_LOGD(TAG, "Submitting poll for INTR IN transfer");
-        ESP_ERROR_CHECK(usb_host_transfer_submit(cdc_dev->notif.xfer));
+        ESP_ERROR_CHECK(cdc_acm_submit_poll(cdc_dev->notif.xfer, &cdc_dev->notif.xfer_polling, "INTR IN"));
+    }
+}
+
+/**
+ * @brief Mark IN poll transfers as stopped on device suspend
+ *
+ * The USB host library halts and flushes endpoints before delivering the suspend event.
+ * Clear driver polling state so cdc_acm_resume() will resubmit after resume.
+ *
+ * @param[in] cdc_dev CDC device handle
+ */
+static void cdc_acm_suspend_polling(cdc_dev_t *cdc_dev)
+{
+    assert(cdc_dev);
+
+    if (cdc_dev->data.in_xfer) {
+        cdc_dev->data.in_polling = false;
+    }
+
+    if (cdc_dev->notif.xfer) {
+        cdc_dev->notif.xfer_polling = false;
     }
 }
 #endif // CDC_HOST_SUSPEND_RESUME_API_SUPPORTED
@@ -957,17 +1019,20 @@ static void usb_event_cb(const usb_host_client_event_msg_t *event_msg, void *arg
         cdc_dev_t *cdc_dev;
         cdc_dev_t *tcdc_dev;
         SLIST_FOREACH_SAFE(cdc_dev, &p_cdc_acm_obj->cdc_devices_list, list_entry, tcdc_dev) {
-            if (cdc_dev->dev_hdl == event_msg->dev_suspend_resume.dev_hdl && cdc_dev->notif.cb) {
+            if (cdc_dev->dev_hdl == event_msg->dev_suspend_resume.dev_hdl) {
 
-                // The driver does not have to do anything to suspend the device,
-                // the usb host lib already halted and flushed all EPs
+                // The USB host library halts and flushes all EPs before this event.
+                // Mark polling as stopped so cdc_acm_resume() will resubmit after resume.
+                cdc_acm_suspend_polling(cdc_dev);
 
-                // The suspended device was opened by this driver: inform user about this
-                const cdc_acm_host_dev_event_data_t suspend_event = {
-                    .type = CDC_ACM_HOST_DEVICE_SUSPENDED,
-                    .data.cdc_hdl = (cdc_acm_dev_hdl_t) cdc_dev,
-                };
-                cdc_dev->notif.cb(&suspend_event, cdc_dev->cb_arg);
+                if (cdc_dev->notif.cb) {
+                    // The suspended device was opened by this driver: inform user about this
+                    const cdc_acm_host_dev_event_data_t suspend_event = {
+                        .type = CDC_ACM_HOST_DEVICE_SUSPENDED,
+                        .data.cdc_hdl = (cdc_acm_dev_hdl_t) cdc_dev,
+                    };
+                    cdc_dev->notif.cb(&suspend_event, cdc_dev->cb_arg);
+                }
             }
         }
         break;

--- a/host/class/cdc/usb_host_cdc_acm/include/esp_private/cdc_host_common.h
+++ b/host/class/cdc/usb_host_cdc_acm/include/esp_private/cdc_host_common.h
@@ -44,12 +44,14 @@ struct cdc_dev_s {
         uint8_t *in_data_buffer_base;     // Pointer to IN data buffer in usb_transfer_t
         const usb_intf_desc_t *intf_desc; // Pointer to data interface descriptor
         SemaphoreHandle_t out_mux;        // OUT mutex
+        bool in_polling;                  // BULK IN poll transfer is submitted
     } data;
 
     struct {
         usb_transfer_t *xfer;             // IN notification transfer
         const usb_intf_desc_t *intf_desc; // Pointer to notification interface descriptor, can be NULL if there is no notification channel in the device
         cdc_acm_host_dev_callback_t cb;   // User's callback for device events
+        bool xfer_polling;                // INTR IN poll transfer is submitted
     } notif;                              // Structure with Notif pipe data
 
     usb_transfer_t *ctrl_transfer;        // CTRL (endpoint 0) transfer

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
@@ -15,6 +15,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
+#include "freertos/event_groups.h"
 #include "esp_idf_version.h"
 #include "esp_log.h"
 #include "esp_err.h"
@@ -100,7 +101,10 @@ static const cdc_acm_host_device_config_t default_dev_config = {
                 .dev_event_data = *event,
             },
         };
-        xQueueSend(app_queue, &test_event, 0);
+        if (app_queue)
+        {
+            xQueueSend(app_queue, &test_event, 0);
+        }
     },
     .data_cb = [](const uint8_t *data, size_t data_len, void *arg) -> bool {
         printf("Data received\n");
@@ -125,7 +129,10 @@ static const cdc_acm_host_driver_config_t driver_config_new_dev_cb = {
                 .usb_dev_hdl = usb_dev,
             },
         };
-        xQueueSend(app_queue, &test_event, 0);
+        if (app_queue)
+        {
+            xQueueSend(app_queue, &test_event, 0);
+        }
     }
 };
 
@@ -1545,6 +1552,29 @@ TEST_CASE("large_tx", "[cdc_acm]")
 #define TIMER_LIGHT_SLEEP_WAKEUP_TIME_US (5 * 1000 * 1000) // 5 seconds
 #define LIGHT_SLEEP_NUM_CYCLES           (5)
 
+static void light_sleep_enter_catch_impl(const char *file, int line)
+{
+    const esp_err_t light_sleep_err = esp_light_sleep_start();
+    if (light_sleep_err == ESP_ERR_SLEEP_REJECT) {
+        // Enter light sleep might be rejected, due to the other esp core being in a critical section
+        // Let the usb host lib handle current events and try to enter the light sleep again
+        printf("Light sleep rejected, re-entering light sleep");
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Second light sleep entry error at %s:%d\n", file, line);
+        taskYIELD();
+        TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, esp_light_sleep_start(), err_msg_buf);
+    } else if (light_sleep_err != ESP_OK) {
+        // Other error occurred
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Light sleep entry error at %s:%d\n", file, line);
+        TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, light_sleep_err, err_msg_buf);
+    } else {
+        // pass
+    }
+}
+/**
+ * @brief Enter light sleep and catch sleep rejected error
+ */
+#define light_sleep_enter_catch() light_sleep_enter_catch_impl(__FILE__, __LINE__)
+
 /**
  * @brief Test: Class driver usage with light sleep
  * #. open the device and setup light sleep timer wakeup source
@@ -1581,7 +1611,7 @@ TEST_CASE("light_sleep", "[cdc_acm][light_sleep]")
         nb_of_responses = 0;
 
         const int64_t t_before_us = esp_timer_get_time();               // Get timestamp before entering sleep
-        TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());             // Enter light sleep mode
+        light_sleep_enter_catch();                                      // Enter light sleep
         const int64_t t_after_us = esp_timer_get_time();                // Get timestamp after waking up from sleep
         const uint32_t wakeup_cause = esp_sleep_get_wakeup_causes();    // Determine wake up reason
         TEST_ASSERT(wakeup_cause & BIT(ESP_SLEEP_WAKEUP_TIMER));        // Wake up reason must be timer
@@ -1599,6 +1629,124 @@ TEST_CASE("light_sleep", "[cdc_acm][light_sleep]")
         wait_for_app_event(&resume_event, pdMS_TO_TICKS(5000));
         printf("Returned from light sleep, reason: timer, t=%lld ms, slept for %lld ms\n", t_after_us / 1000, (t_after_us - t_before_us) / 1000);
     }
+
+    TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_close(cdc_dev));
+    TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_uninstall());
+    vTaskDelay(20); // Short delay to allow task to be cleaned up
+}
+
+#define STRESS_TX_BUF_SIZE              (8 * 1024)
+#define STRESS_IO_ITERATIONS            (16)
+#define STRESS_LIGHT_SLEEP_WAKEUP_US    (500 * 1000)        // 500 mS
+#define EVT_STRESS_IO_DONE              BIT0
+
+static EventGroupHandle_t s_stress_io_event_group = NULL;
+
+/**
+ * @brief Enter light sleep repeatedly while CDC stress I/O is running in another task.
+ */
+static void light_sleep_during_io_task(void *arg)
+{
+    TaskHandle_t main_task_hdl = (TaskHandle_t)arg;
+    TEST_ASSERT_EQUAL(pdTRUE, ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000)));
+    printf("Light sleep stress task started during CDC I/O\n");
+
+    while (!(xEventGroupGetBits(s_stress_io_event_group) & EVT_STRESS_IO_DONE)) {
+        const int64_t t_before_us = esp_timer_get_time();
+
+        light_sleep_enter_catch();
+
+        const int64_t t_after_us = esp_timer_get_time();
+        const uint32_t wakeup_cause = esp_sleep_get_wakeup_causes();
+        TEST_ASSERT(wakeup_cause & BIT(ESP_SLEEP_WAKEUP_TIMER));
+        printf("Returned from light sleep, slept %lld ms\n", (t_after_us - t_before_us) / 1000);
+
+        // Suspend event: Light sleep auto suspend
+        wait_for_app_event(&suspend_event, pdMS_TO_TICKS(5000));
+        // Resume event: Submit transfer auto resume
+        wait_for_app_event(&resume_event, pdMS_TO_TICKS(5000));
+    }
+
+    if (main_task_hdl != NULL) {
+        xTaskNotifyGive(main_task_hdl);
+    }
+    vTaskDelete(NULL);
+}
+
+/**
+ * @brief Test: Long CDC-ACM I/O with light sleep from another task
+ *
+ * #. open the device and start a light sleep task
+ * #. run many large blocking TX transfers while the other task enters light sleep
+ * #. expect auto-suspend/resume around light sleep and that the device still works afterward
+ * #. cleanup
+ */
+TEST_CASE("light_sleep_during_io", "[cdc_acm][light_sleep]")
+{
+    test_install_cdc_driver(&driver_config_new_dev_cb);
+
+    s_stress_io_event_group = xEventGroupCreate();
+    TEST_ASSERT_NOT_NULL(s_stress_io_event_group);
+
+    TaskHandle_t light_sleep_task_hdl = NULL;
+    TEST_ASSERT_EQUAL(pdTRUE, xTaskCreate(light_sleep_during_io_task, "ls_stress", 4096, (void *)xTaskGetCurrentTaskHandle(), 8, &light_sleep_task_hdl));
+    TEST_ASSERT_NOT_NULL(light_sleep_task_hdl);
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_enable_timer_wakeup(STRESS_LIGHT_SLEEP_WAKEUP_US));
+    printf("Light sleep timer wakeup source is ready\n");
+
+    uint8_t *stress_tx_buf = (uint8_t *)malloc(STRESS_TX_BUF_SIZE);
+    TEST_ASSERT_NOT_NULL(stress_tx_buf);
+    for (size_t i = 0; i < STRESS_TX_BUF_SIZE; i++) {
+        stress_tx_buf[i] = (uint8_t)(i & 0xFF);
+    }
+
+    bytes_received = 0;
+    cdc_acm_dev_hdl_t cdc_dev = NULL;
+    cdc_acm_host_device_config_t dev_config = default_dev_config;
+    dev_config.out_buffer_size = STRESS_TX_BUF_SIZE;
+    dev_config.in_buffer_size = STRESS_TX_BUF_SIZE;
+    dev_config.user_arg = stress_tx_buf;
+    dev_config.data_cb = [](const uint8_t *data, size_t data_len, void *arg) -> bool {
+        (void)arg;
+        (void)data;
+        if (data_len > 0)
+        {
+            bytes_received += data_len;
+        }
+        return true;
+    };
+
+    printf("Opening CDC-ACM device\n");
+    wait_for_app_event(&new_dev_event, 100);
+    TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_open(0x303A, 0x4002, 0, &dev_config, &cdc_dev)); // 0x303A:0x4002 (TinyUSB Dual CDC device)
+    TEST_ASSERT_NOT_NULL(cdc_dev);
+
+    uint32_t tx_ok = 0, tx_err = 0;
+    xTaskNotifyGive(light_sleep_task_hdl);
+    printf("Starting %d x %d byte blocking TX iter with concurrent light sleep\n", STRESS_IO_ITERATIONS, STRESS_TX_BUF_SIZE);
+
+    for (int i = 0; i < STRESS_IO_ITERATIONS; i++) {
+        esp_err_t err = cdc_acm_host_data_tx_blocking(cdc_dev, stress_tx_buf, STRESS_TX_BUF_SIZE, 500);
+        if (err == ESP_OK) {
+            tx_ok++;
+        } else {
+            tx_err++;
+        }
+    }
+
+    // Resume the port if not already auto-resumed
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_root_port_resume());
+    // Wait for the light sleep task to finish
+    xEventGroupSetBits(s_stress_io_event_group, EVT_STRESS_IO_DONE);
+    TEST_ASSERT_EQUAL(pdTRUE, ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(5000)));
+
+    printf("Stress I/O finished: tx_ok=%lu tx_err=%lu rx_bytes=%lu\n",
+           (unsigned long)tx_ok, (unsigned long)tx_err, (unsigned long)bytes_received);
+
+    free(stress_tx_buf);
+    vEventGroupDelete(s_stress_io_event_group);
+    s_stress_io_event_group = NULL;
 
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_close(cdc_dev));
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_uninstall());
@@ -1640,7 +1788,7 @@ TEST_CASE("light_sleep_dconn_no_dev", "[light_sleep][host_suspend_dconn_no_dev]"
     vTaskDelay(10); // Wait until responses are processed
     TEST_ASSERT_EQUAL(NUM_ITERATIONS, nb_of_responses);
 
-    TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());             // Enter light sleep
+    light_sleep_enter_catch();                                 // Enter light sleep
 
     // Port was disconnected during light sleep (by USB Device): Disconnect interrupt was not delivered during light sleep,
     // but after exiting light sleep


### PR DESCRIPTION
Fixed race condition when submitting BULK IN transfer as part of resuming rotine.

## The problem

- The transfer could have been submitted from 3 places in code:
  - when claiming iface
  - as a part of `in_xfer_cb`
  - when resuming the root port

A race condition occurred when submitting BULK IN transfers from `in_xfer_cb` and root port resume routine with a following assert:
 
```sh
2026-06-29 11:07:53 [dut-1] ESP_ERROR_CHECK failed: esp_err_t 0x10c (ESP_ERR_NOT_FINISHED) at 0x420158fe
2026-06-29 11:07:53 [dut-1] file: "/home/peter/esp/esp-usb/host/class/cdc/usb_host_cdc_acm/cdc_acm_host.c" line 904
2026-06-29 11:07:53 [dut-1] func: cdc_acm_resume
2026-06-29 11:07:53 [dut-1] expression: usb_host_transfer_submit(cdc_dev->data.in_xfer)
```

The race condition happened, when the light sleep entry->exit occurred during the `in_xfer_cb`. 
- After light sleep entry the code execution in the `in_xfer_cb` continued -> submitted the BULK IN
- cdc_acm resume routine tried to submit the BULK IN as well

## The fix

- Added `cdc_acm_submit_poll` to unify submitting POLL transfers (BULK IN and INTR) from one place instead of using raw `usb_host_transfer_submit()`
- tracking `polling_active` flag for each EP which requires polling 
- added `cdc_acm` suspend routine (no routine before), to unset polling flags, as the `in-flight URB flag` from the USB Host lib could become stale when using light sleep automatic suspend

## Testing

Added load test for cdc_acm driver, which continuously submits data out transfers, whereas from another task light sleep is being called asynchronously.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core USB host CDC polling and suspend/resume timing; behavior change is intentional but affects all continuous IN polling paths.
> 
> **Overview**
> Fixes a race where **BULK IN** and **INTR IN** poll transfers could be submitted twice (e.g. from `in_xfer_cb` and `cdc_acm_resume()` during light sleep), triggering `ESP_ERR_NOT_FINISHED` asserts.
> 
> Introduces **`cdc_acm_submit_poll`** as the single path for resubmitting continuous IN polls, with per-endpoint **`in_polling`** / **`xfer_polling`** flags cleared in transfer callbacks, on close, and via new **`cdc_acm_suspend_polling`** when the USB host delivers suspend (so resume can safely resubmit after halt/flush). Suspend handling now resets polling for all matching CDC devices, not only those with a notification callback.
> 
> Tests add **`light_sleep_enter_catch`** for rejected light sleep, guard queue sends when `app_queue` is null, and a **`light_sleep_during_io`** stress case with large TX and concurrent light sleep. Changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40972907a03b234c5f2ce90f1df8be7316160e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->