### PR TITLE
fix(usb_host): Light sleep auto suspend hardening

### DIFF
--- a/docs/en/usb_host.rst
+++ b/docs/en/usb_host.rst
@@ -54,6 +54,7 @@ Currently, the Host Library and the underlying Host Stack has the following limi
     - The External Hub Driver: Remote Wakeup feature is not supported (External Hubs are active, even if there are no devices inserted).
     - The External Hub Driver: Doesn't handle error cases (overcurrent handling, errors during initialization etc. are not implemented yet).
     - The External Hub Driver: No Interface selection. The Driver uses the first available Interface with Hub Class code (09h).
+    - Light sleep: USB Host with a USB Device connected does not detect device reconnection during light sleep. Treats it as a suspend/resume cycle.
     :esp32s31 or esp32p4: - The External Hub Driver: No Transaction Translator layer (No FS/LS Devices support when a Hub is attached to HS Host).
 
 

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
@@ -1642,6 +1642,11 @@ TEST_CASE("light_sleep_dconn_no_dev", "[light_sleep][host_suspend_dconn_no_dev]"
 
     TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());             // Enter light sleep
 
+    // Make sure there is no stale device is present right after exiting light sleep
+    usb_host_lib_info_t info;
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_info(&info));
+    TEST_ASSERT_EQUAL(0, info.num_devices);
+
     // Port was disconnected during light sleep (by USB Device): Disconnect interrupt was not delivered during light sleep,
     // but after exiting light sleep
     // Expect just device disconnect, no suspend event

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -495,8 +495,15 @@ reset_err:
             break;
         case ROOT_PORT_STATE_NOT_POWERED: // The user turned off ports' power. Indicate to USBH that the device is gone
         case ROOT_PORT_STATE_ENABLED: // There is an enabled (active) device. Indicate to USBH that the device is gone
-        case ROOT_PORT_STATE_SUSPENDED: // The user called usb host suspend, Indicate to USBH that the device is suspended
             port_has_device = true;
+            break;
+        case ROOT_PORT_STATE_SUSPENDED: // Device disconnected while hub still marked suspended (e.g. during light sleep)
+            port_has_device = true;
+            // Clear stale suspended state so resume-by-transfer is not attempted on a recovery port
+            root_hub_port->dynamic.state = ROOT_PORT_STATE_ENABLED;
+#ifdef AUTO_PM_LIGHT_SLEEP
+            p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 0;
+#endif // AUTO_PM_LIGHT_SLEEP
             break;
         default:
             abort();    // Should never occur
@@ -617,7 +624,8 @@ static void root_port_req(root_hub_port_t *root_hub_port)
             // Root port resumed correctly
             break;
         case ESP_ERR_INVALID_RESPONSE:
-            // Root port's state machine changed it's state during suspend command execution (port disconnect)
+        case ESP_ERR_INVALID_STATE:
+            // Root port's state machine changed during resume (port disconnect or stale hub suspend state).
             // The root port is already in recovery state, which was set by dconn event interrupt, no further action needed
             return;
         default:
@@ -926,7 +934,14 @@ bool hub_root_is_suspended(void)
 #endif
     assert(root_hub_port->constant.hdl);
     HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED, false);
+    hcd_port_handle_t root_port_hdl = root_hub_port->constant.hdl;
     HUB_DRIVER_EXIT_CRITICAL();
+
+    // Hub suspend state can be stale if disconnect occurred before the hub event was processed
+    const hcd_port_state_t port_state = hcd_port_get_state(root_port_hdl);
+    if (port_state != HCD_PORT_STATE_SUSPENDED && port_state != HCD_PORT_STATE_SUSPENDING) {
+        return false;
+    }
 
     return true;
 }
@@ -978,18 +993,17 @@ esp_err_t hub_root_can_resume(void)
     const hcd_port_state_t port_state = hcd_port_get_state(root_hub_port->constant.hdl);
     esp_err_t ret;
     switch (port_state) {
+    case HCD_PORT_STATE_SUSPENDED:
+        ret = ESP_OK;
+        break;
     case HCD_PORT_STATE_RESUMING:
         // Root port is already issuing resume command and is within a RESUME_RECOVERY_MS or a RESUME_HOLD_MS timeout,
         // no need to issue the resume command again
         ret = ESP_ERR_TIMEOUT;
         break;
-    case HCD_PORT_STATE_SUSPENDING:
-        // Root port is within a SUSPEND_ENTRY_MS timeout
-        // We can't resume the port right now, as it would have caused an undefined state
-        ret = ESP_ERR_NOT_ALLOWED;
-        break;
     default:
-        ret = ESP_OK;
+        // Port disconnected, in recovery, or otherwise not resumable
+        ret = ESP_ERR_NOT_ALLOWED;
         break;
     }
 

--- a/host/usb/src/usb_host.c
+++ b/host/usb/src/usb_host.c
@@ -1987,10 +1987,11 @@ esp_err_t usb_host_transfer_submit(usb_transfer_t *transfer)
     // Check if the root port is suspended (global suspend)
     if (hub_root_is_suspended()) {
         // Root port is suspended at the time we are submitting a transfer
-        ESP_LOGD(USB_HOST_TAG, "Resuming the root port");
+        ESP_LOGD(USB_HOST_TAG, "Resuming the root port by transfer submit");
 
         ret = usb_host_lib_root_port_resume();
         if (ret != ESP_OK) {
+            ESP_LOGW(USB_HOST_TAG, "Root port resume before transfer submit failed: %s", esp_err_to_name(ret));
             goto submit_err;
         }
     }
@@ -2032,10 +2033,11 @@ esp_err_t usb_host_transfer_submit_control(usb_host_client_handle_t client_hdl, 
     // Check if the root port is suspended (global suspend)
     if (hub_root_is_suspended()) {
         // Root port is suspended at the time we are submitting a ctrl transfer
-        ESP_LOGD(USB_HOST_TAG, "Resuming the root port");
+        ESP_LOGD(USB_HOST_TAG, "Resuming the root port by CTRL transfer submit");
 
         ret = usb_host_lib_root_port_resume();
         if (ret != ESP_OK) {
+            ESP_LOGW(USB_HOST_TAG, "Root port resume before control transfer submit failed: %s", esp_err_to_name(ret));
             goto submit_err;
         }
     }


### PR DESCRIPTION
Fixing some smaller issues for the light sleep auto suspend feature:
 - fixing hub_root_can_resume allowed states
 - fixing stale hub state when device disconnects in light sleep
 - add limitations to the docs
 - add tests

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect root-port suspend/resume and auto-resume-on-transfer in light-sleep scenarios; scope is limited to hub PM logic with new tests, but incorrect handling could affect USB connectivity after sleep.
> 
> **Overview**
> Hardens **USB Host** behavior around **light-sleep auto suspend**, especially when the device disconnects while the hub still thinks the root port is suspended.
> 
> **Hub driver (`hub.c`)** clears stale suspend state on disconnect during light sleep (resets root port to enabled, clears `light_sleep_auto_pm`), cross-checks HCD port state in `hub_root_is_suspended()`, and tightens `hub_root_can_resume()` so only truly suspended/resuming ports are allowed (disconnect/recovery returns `ESP_ERR_NOT_ALLOWED`). Resume handling also treats `ESP_ERR_INVALID_STATE` like a benign port state change.
> 
> **USB Host library** logs a warning when auto-resume before transfer submit fails.
> 
> **Docs** document that device reconnection during light sleep is not detected and is handled like suspend/resume.
> 
> **CDC-ACM test** asserts no stale devices remain immediately after waking from light sleep before disconnect/reconnect events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7609b7edad62a3cffa79302ee10579c7e32e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->