### PR TITLE
feat(esp_tinyusb): Integrate TinyUSB with esp_tinyusb

### DIFF
--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -43,7 +43,6 @@ jobs:
       matrix:
         idf_ver:
           [
-            "release-v5.2",
             "release-v5.3",
             "release-v5.4",
             "release-v5.5",

--- a/.github/workflows/build_and_run_main_ci.yml
+++ b/.github/workflows/build_and_run_main_ci.yml
@@ -61,8 +61,7 @@ jobs:
     needs: get-changed-files
     uses: ./.github/workflows/build_and_run_test_app_usb.yml
     with:
-      idf_releases: '["release-v5.2",
-                      "release-v5.3",
+      idf_releases: '["release-v5.3",
                       "release-v5.4",
                       "release-v5.5",
                       "release-v6.0",

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -46,8 +46,6 @@ jobs:
         exclude:
           # Exclude using managed usb component for older releases, only with service releases
           - test_app: host_managed
-            idf_ver: "release-v5.2"
-          - test_app: host_managed
             idf_ver: "release-v5.3"
           - test_app: host_managed
             idf_ver: "release-v5.4"
@@ -146,12 +144,7 @@ jobs:
             runner_tag: usb_host_flash_disk
           - test_app: host_managed
             runner_tag: usb_device
-          # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
-          - idf_ver: "release-v5.2"
-            idf_target: "esp32p4"
           # Exclude using managed usb component for older releases, only with service releases
-          - test_app: host_managed
-            idf_ver: "release-v5.2"
           - test_app: host_managed
             idf_ver: "release-v5.3"
           - test_app: host_managed

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "device/esp_tinyusb/tinyusb"]
+	path = device/esp_tinyusb/tinyusb
+	url = https://github.com/espressif/tinyusb.git

--- a/.idf_build_apps.toml
+++ b/.idf_build_apps.toml
@@ -1,6 +1,7 @@
 exclude = [
     "static_analysis",
     "device/esp_tinyusb/test_apps/usb_cv",
+    "device/esp_tinyusb/tinyusb",
 ]
 recursive = true
 manifest_file = ".build-test-rules.yml"

--- a/codespell-ignore-list
+++ b/codespell-ignore-list
@@ -1,2 +1,3 @@
 inout
 wheight
+synopsys

--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- TODO write this note
+
 ## 2.2.1
 
 - esp_tinyusb: Add an explicit `tinyusb` dependency when the IDF component manager is disabled
@@ -23,7 +27,7 @@
 
 ## 2.0.1
 
-- esp_tinyusb: Added ESP32H4 support
+- esp_tinyusb: Added ESP32-H4 support
 - esp_tinyusb: Fixed an assertion failure on the GetOtherSpeedDescriptor() request for ESP32-P4 when the OTG1.1 port is used
 - MSC: Added dynamic member and storage operation multitask protection
 - MSC: Used `esp_vfs_fat_register_cfg` function prototype for esp-idf v5.3 and higher

--- a/device/esp_tinyusb/CMakeLists.txt
+++ b/device/esp_tinyusb/CMakeLists.txt
@@ -1,15 +1,39 @@
+if(IDF_BUILD_V2)
+    include(CMakeLists_v2.txt)
+    return()
+endif()
+
 idf_build_get_property(target IDF_TARGET)
 set(IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
 
+# required by rndis_reports.c: #include "netif/ethernet.h"
+set(priv_req esp_netif)
+set(priv_includes
+    "include_private"
+    "tinyusb/src/device"
+)
+
 set(srcs
+    # esp_tinyusb core
     "descriptors_control.c"
     "tinyusb.c"
     "usb_descriptors.c"
     "tinyusb_task.c"
-    )
 
-set(priv_req "")
-set(req fatfs vfs)
+    # TinyUSB core
+    "tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c"
+    "tinyusb/src/portable/synopsys/dwc2/dwc2_common.c"
+    "tinyusb/src/common/tusb_fifo.c"
+    "tinyusb/src/device/usbd.c"
+    "tinyusb/src/tusb.c"
+
+    # TinyUSB classes
+    "tinyusb/src/class/mtp/mtp_device.c"
+    "tinyusb/src/class/printer/printer_device.c"
+    "tinyusb/src/class/audio/audio_device.c"
+    "tinyusb/src/class/video/video_device.c"
+    "tinyusb/src/class/usbtmc/usbtmc_device.c"
+    )
 
 # USB-PHY driver
 # For IDF 6.x and later, usb_phy driver is moved from usb to esp_hw_support
@@ -23,6 +47,7 @@ if(CONFIG_TINYUSB_CDC_ENABLED)
     list(APPEND srcs
         "cdc.c"
         "tinyusb_cdc_acm.c"
+        "tinyusb/src/class/cdc/cdc_device.c"
         )
     if(CONFIG_VFS_SUPPORT_IO)
         list(APPEND srcs
@@ -36,6 +61,7 @@ if(CONFIG_TINYUSB_MSC_ENABLED)
     list(APPEND srcs
         "tinyusb_msc.c"
         "storage_spiflash.c"
+        "tinyusb/src/class/msc/msc_device.c"
         )
     if(CONFIG_SOC_SDMMC_HOST_SUPPORTED)
         list(APPEND srcs
@@ -48,44 +74,77 @@ endif() # CONFIG_TINYUSB_MSC_ENABLED
 if(CONFIG_TINYUSB_NET_MODE_NCM)
     list(APPEND srcs
          "tinyusb_net.c"
+         "tinyusb/src/class/net/ncm_device.c"
          )
 endif() # CONFIG_TINYUSB_NET_MODE_NCM
 
+if(CONFIG_TINYUSB_NET_MODE_ECM_RNDIS)
+    list(APPEND srcs
+         "tinyusb/src/class/net/ecm_rndis_device.c"
+         "tinyusb/lib/networking/rndis_reports.c"
+         )
+    list(APPEND priv_includes "tinyusb/lib/networking")
+endif()
+
+if(CONFIG_TINYUSB_DFU_MODE_DFU)
+    list(APPEND srcs
+         "tinyusb/src/class/dfu/dfu_device.c"
+         )
+endif()
+
+if(CONFIG_TINYUSB_DFU_MODE_DFU_RUNTIME)
+    list(APPEND srcs
+         "tinyusb/src/class/dfu/dfu_rt_device.c"
+         )
+endif()
+
+if(CONFIG_TINYUSB_HID_COUNT GREATER 0)
+    list(APPEND srcs
+         "tinyusb/src/class/hid/hid_device.c"
+         )
+endif()
+
+if(CONFIG_TINYUSB_MIDI_COUNT GREATER 0)
+    list(APPEND srcs
+         "tinyusb/src/class/midi/midi_device.c"
+         "tinyusb/src/class/midi/midi2_device.c"
+         )
+endif()
+
+if(CONFIG_TINYUSB_BTH_ENABLED)
+    list(APPEND srcs
+         "tinyusb/src/class/bth/bth_device.c"
+         )
+endif()
+
+if(CONFIG_TINYUSB_VENDOR_COUNT GREATER 0)
+    list(APPEND srcs
+         "tinyusb/src/class/vendor/vendor_device.c"
+         )
+endif()
+
 # Software VBUS monitoring is needed for chips with HS USB-OTG peripheral
 if(${target} STREQUAL "esp32p4" OR ${target} STREQUAL "esp32s31")
-    list(APPEND srcs "tinyusb_vbus_monitor.c")
-
     # VBUS monitoring requires GPIO driver
-    if(IDF_VERSION VERSION_GREATER_EQUAL "5.3")
-        list(APPEND priv_req esp_driver_gpio)
-    else()
-        list(APPEND priv_req driver)
-    endif()
+    list(APPEND priv_req esp_driver_gpio)
+    list(APPEND srcs "tinyusb_vbus_monitor.c")
 endif() # esp32p4/esp32s31
 
-# idf_component.yml is ignored when the component manager is disabled, so the
-# dependency on tinyusb must be declared here instead. It belongs in REQUIRES
-# (not PRIV_REQUIRES) because the public header tinyusb.h includes tusb.h.
-idf_build_get_property(idf_component_manager IDF_COMPONENT_MANAGER)
-if(NOT idf_component_manager)
-    list(APPEND req tinyusb)
+if(${target} STREQUAL "esp32p4")
+    list(APPEND priv_req
+                esp_mm # required by dcd_dwc2.c: #include "esp_cache.h"
+        )
 endif()
 
 idf_component_register(SRCS ${srcs}
-                       INCLUDE_DIRS "include"
-                       PRIV_INCLUDE_DIRS "include_private"
+                       INCLUDE_DIRS "include" "tinyusb/src"
+                       PRIV_INCLUDE_DIRS ${priv_includes}
                        PRIV_REQUIRES ${priv_req}
-                       REQUIRES ${req}
+                       REQUIRES fatfs vfs freertos
                        )
 
-# Determine whether tinyusb is fetched from component registry or from local path
-idf_build_get_property(build_components BUILD_COMPONENTS)
-if(tinyusb IN_LIST build_components)
-    set(tinyusb_name tinyusb) # Local component
-else()
-    set(tinyusb_name espressif__tinyusb) # Managed component
-endif()
+string(TOUPPER "OPT_MCU_${target}" tusb_mcu)
+target_compile_options(${COMPONENT_LIB} PUBLIC "-DCFG_TUSB_MCU=${tusb_mcu}")
 
-# Pass tusb_config.h from this component to TinyUSB
-idf_component_get_property(tusb_lib ${tinyusb_name} COMPONENT_LIB)
-target_include_directories(${tusb_lib} PRIVATE "include")
+# when no builtin class driver is enabled, an uint8_t data compared with `BUILTIN_DRIVER_COUNT` will always be false
+set_source_files_properties("tinyusb/src/device/usbd.c" PROPERTIES COMPILE_FLAGS "-Wno-type-limits")

--- a/device/esp_tinyusb/CMakeLists_v2.txt
+++ b/device/esp_tinyusb/CMakeLists_v2.txt
@@ -1,0 +1,171 @@
+# ESP-IDF Build System v2 component definition.
+# Included from CMakeLists.txt when IDF_BUILD_V2 is set.
+
+idf_build_get_property(target IDF_TARGET)
+set(IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
+
+set(core_srcs
+    # esp_tinyusb core
+    "descriptors_control.c"
+    "tinyusb.c"
+    "usb_descriptors.c"
+    "tinyusb_task.c"
+
+    # TinyUSB core
+    "tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c"
+    "tinyusb/src/portable/synopsys/dwc2/dwc2_common.c"
+    "tinyusb/src/common/tusb_fifo.c"
+    "tinyusb/src/device/usbd.c"
+    "tinyusb/src/tusb.c"
+
+    # TinyUSB classes
+    "tinyusb/src/class/mtp/mtp_device.c"
+    "tinyusb/src/class/printer/printer_device.c"
+    "tinyusb/src/class/audio/audio_device.c"
+    "tinyusb/src/class/video/video_device.c"
+    "tinyusb/src/class/usbtmc/usbtmc_device.c"
+)
+
+add_library(${COMPONENT_TARGET} STATIC ${core_srcs})
+
+target_include_directories(${COMPONENT_TARGET} PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/include"
+    "${CMAKE_CURRENT_LIST_DIR}/tinyusb/src"
+)
+
+target_include_directories(${COMPONENT_TARGET} PRIVATE
+    "include_private"
+    "tinyusb/src/device"
+)
+
+# --- Always-required dependencies ---
+
+idf_component_include(freertos)
+target_link_libraries(${COMPONENT_TARGET} PRIVATE idf::freertos)
+
+# USB-PHY driver
+# For IDF 6.x and later, usb_phy driver is moved from usb to esp_hw_support
+if(IDF_VERSION VERSION_LESS "6.0.0")
+    idf_component_include(usb)
+    target_link_libraries(${COMPONENT_TARGET} PRIVATE idf::usb)
+else()
+    idf_component_include(esp_hw_support)
+    target_link_libraries(${COMPONENT_TARGET} PRIVATE idf::esp_hw_support)
+endif()
+
+# --- Feature-specific sources and dependencies ---
+
+if(CONFIG_TINYUSB_CDC_ENABLED)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "cdc.c"
+        "tinyusb_cdc_acm.c"
+        "tinyusb/src/class/cdc/cdc_device.c"
+    )
+    if(CONFIG_VFS_SUPPORT_IO)
+        target_sources(${COMPONENT_TARGET} PRIVATE
+            "tinyusb_console.c"
+            "vfs_tinyusb.c"
+        )
+        idf_component_include(vfs)
+        # vfs_tinyusb.h is a public header and includes esp_vfs_common.h
+        target_link_libraries(${COMPONENT_TARGET} PUBLIC
+            "$<$<TARGET_EXISTS:idf::vfs>:idf::vfs>")
+    endif() # CONFIG_VFS_SUPPORT_IO
+endif() # CONFIG_TINYUSB_CDC_ENABLED
+
+if(CONFIG_TINYUSB_MSC_ENABLED)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb_msc.c"
+        "storage_spiflash.c"
+        "tinyusb/src/class/msc/msc_device.c"
+    )
+    idf_component_include(fatfs)
+    idf_component_include(vfs)
+    idf_component_include(wear_levelling)
+    # tinyusb_msc.h is a public header and includes esp_vfs_fat.h and wear_levelling.h
+    target_link_libraries(${COMPONENT_TARGET} PUBLIC
+        idf::fatfs
+        "$<$<TARGET_EXISTS:idf::vfs>:idf::vfs>"
+        idf::wear_levelling)
+    if(CONFIG_SOC_SDMMC_HOST_SUPPORTED)
+        target_sources(${COMPONENT_TARGET} PRIVATE "storage_sdmmc.c")
+        idf_component_include(esp_driver_sdmmc)
+        # tinyusb_msc.h is a public header and includes driver/sdmmc_host.h
+        target_link_libraries(${COMPONENT_TARGET} PUBLIC idf::esp_driver_sdmmc)
+    endif() # CONFIG_SOC_SDMMC_HOST_SUPPORTED
+endif() # CONFIG_TINYUSB_MSC_ENABLED
+
+if(CONFIG_TINYUSB_NET_MODE_NCM)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb_net.c"
+        "tinyusb/src/class/net/ncm_device.c"
+    )
+endif() # CONFIG_TINYUSB_NET_MODE_NCM
+
+if(CONFIG_TINYUSB_NET_MODE_ECM_RNDIS)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb/src/class/net/ecm_rndis_device.c"
+        "tinyusb/lib/networking/rndis_reports.c"
+    )
+    target_include_directories(${COMPONENT_TARGET} PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/tinyusb/lib/networking")
+    idf_component_include(esp_netif)
+    # rndis_reports.c: #include "netif/ethernet.h"
+    target_link_libraries(${COMPONENT_TARGET} PRIVATE idf::esp_netif)
+endif()
+
+if(CONFIG_TINYUSB_DFU_MODE_DFU)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb/src/class/dfu/dfu_device.c"
+    )
+endif()
+
+if(CONFIG_TINYUSB_DFU_MODE_DFU_RUNTIME)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb/src/class/dfu/dfu_rt_device.c"
+    )
+endif()
+
+if(CONFIG_TINYUSB_HID_COUNT GREATER 0)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb/src/class/hid/hid_device.c"
+    )
+endif()
+
+if(CONFIG_TINYUSB_MIDI_COUNT GREATER 0)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb/src/class/midi/midi_device.c"
+        "tinyusb/src/class/midi/midi2_device.c"
+    )
+endif()
+
+if(CONFIG_TINYUSB_BTH_ENABLED)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb/src/class/bth/bth_device.c"
+    )
+endif()
+
+if(CONFIG_TINYUSB_VENDOR_COUNT GREATER 0)
+    target_sources(${COMPONENT_TARGET} PRIVATE
+        "tinyusb/src/class/vendor/vendor_device.c"
+    )
+endif()
+
+# Software VBUS monitoring is needed for chips with HS USB-OTG peripheral
+if(${target} STREQUAL "esp32p4" OR ${target} STREQUAL "esp32s31")
+    target_sources(${COMPONENT_TARGET} PRIVATE "tinyusb_vbus_monitor.c")
+    idf_component_include(esp_driver_gpio)
+    target_link_libraries(${COMPONENT_TARGET} PRIVATE idf::esp_driver_gpio)
+endif() # esp32p4/esp32s31
+
+if(${target} STREQUAL "esp32p4")
+    idf_component_include(esp_mm)
+    # required by dcd_dwc2.c: #include "esp_cache.h"
+    target_link_libraries(${COMPONENT_TARGET} PRIVATE idf::esp_mm)
+endif()
+
+string(TOUPPER "OPT_MCU_${target}" tusb_mcu)
+target_compile_options(${COMPONENT_TARGET} PUBLIC "-DCFG_TUSB_MCU=${tusb_mcu}")
+
+# when no builtin class driver is enabled, an uint8_t data compared with `BUILTIN_DRIVER_COUNT` will always be false
+set_source_files_properties("tinyusb/src/device/usbd.c" PROPERTIES COMPILE_FLAGS "-Wno-type-limits")

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -13,10 +13,7 @@ targets:
   - esp32h4
   - esp32s31
 dependencies:
-  idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
-  tinyusb:
-    version: '>=0.17.0~2' # 0.17.0~2 is the first version that supports deinit
-    public: true
+  idf: '>=5.3'
 files:
   exclude:
     - "test_apps"

--- a/device/esp_tinyusb/include/tusb_config.h
+++ b/device/esp_tinyusb/include/tusb_config.h
@@ -114,8 +114,7 @@ extern "C" {
 // Enable dcd_dcache clean/invalidate/clean_invalidate calls
 #   define CFG_TUD_MEM_DCACHE_ENABLE    1
 #define CFG_TUD_MEM_DCACHE_LINE_SIZE    CONFIG_CACHE_L1_CACHE_LINE_SIZE
-// NOTE: starting with esp-idf v5.3 there is specific attribute present: DRAM_DMA_ALIGNED_ATTR
-#   define CFG_TUSB_MEM_SECTION         __attribute__((aligned(CONFIG_CACHE_L1_CACHE_LINE_SIZE))) DRAM_ATTR
+#   define CFG_TUSB_MEM_SECTION         DRAM_DMA_ALIGNED_ATTR
 #else
 #   define CFG_TUD_MEM_DCACHE_ENABLE    0
 #   define CFG_TUD_MEM_CACHE_ENABLE     0


### PR DESCRIPTION
## TODO
- [x] Conditionally build all TinyUSB class sources
- [x] Write release note with migration guide
- [x] Provide esp-idf build system v2 CMakeLists.txt that will conditionally add priv requires (eg. esp_netif)

## Related
- Partially addresses https://github.com/espressif/esp-usb/issues/236
- Needs https://github.com/espressif/esp-usb/pull/544

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major packaging and build integration for the USB device stack; duplicate or mismatched TinyUSB copies and wrong Kconfig class selection can break linking or runtime USB behavior.
> 
> **Overview**
> **v3.0.0 embeds TinyUSB inside `esp_tinyusb`** via a git submodule (`device/esp_tinyusb/tinyusb`) instead of pulling a separate `tinyusb` / `espressif/tinyusb` component from the registry. Each release pins that submodule version; apps must drop standalone `tinyusb` dependencies to avoid building two stacks.
> 
> The component **builds TinyUSB sources directly** in CMake: core DWC2/portable code plus class drivers are added only when the matching Kconfig options are enabled (CDC, MSC, NCM, ECM/RNDIS, DFU, HID, MIDI, BTH, vendor, MTP). Public includes expose `tinyusb/src`; `CFG_TUSB_MCU` is set from the IDF target. A parallel **`CMakeLists_v2.txt`** path supports ESP-IDF build system v2 with feature-scoped `target_link_libraries` (e.g. `esp_netif` for RNDIS).
> 
> **New option `CONFIG_TINYUSB_DWC2_PTI_ENABLE`** maps to `CFG_TUD_DWC2_PTI_ENABLE` for DWC2 Periodic Transfer Interrupt (isochronous scheduling). CI/codespell tweaks exclude the submodule from app builds and ignore “synopsys”. Changelog and the v3 migration guide document the bundled stack and dependency removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5edfe60cc944f949a87f6e8709333efc219dd28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->