### PR TITLE
release(usb_host): v1.5.0

### DIFF
--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.0] - 2026-06-16
 
 ### Changed
 

--- a/host/usb/idf_component.yml
+++ b/host/usb/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 description: USB Host library
-version: "1.4.1"
+version: "1.5.0"
 url: https://github.com/espressif/esp-usb/tree/master/host/usb
 documentation: "https://docs.espressif.com/projects/esp-usb/en/latest/esp32p4/usb_host.html"
 issues: "https://github.com/espressif/esp-usb/issues"


### PR DESCRIPTION
## Release usb_host v1.5.0


## Related

- #445 
- #478 
- #476 
- #504 
- #501 
- #521
- #502

## Release notes

### Changed

- This component now requires ESP-IDF version >= 5.5.3

### Added

- Automatic root-port suspend before light sleep when `esp_light_sleep_start()` is called (https://github.com/espressif/esp-usb/pull/445), configurable in menuconfig via `CONFIG_ESP_SLEEP_EVENT_CALLBACKS`
- Added `USB_HOST_CLIENT_EVENT_DEV_REMOVED` and the `notify_dev_removed` client flag so clients can monitor removal of devices they have not opened.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version and changelog); no library source changes in this diff.
> 
> **Overview**
> Publishes **USB Host library v1.5.0** by bumping `host/usb/idf_component.yml` from `1.4.1` to **`1.5.0`** and replacing the **`[Unreleased]`** changelog heading with **`[1.5.0] - 2026-06-16`**, keeping the release notes that were already drafted there.
> 
> Those notes document what ships in this version: **ESP-IDF `>= 5.5.3`** as a requirement, automatic root-port suspend before light sleep (via `CONFIG_ESP_SLEEP_EVENT_CALLBACKS`), and **`USB_HOST_CLIENT_EVENT_DEV_REMOVED`** with the **`notify_dev_removed`** client flag for devices the client has not opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebd996a36508b4f92844e9ed03a1db37363d49a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->