### PR TITLE
feat(usb_host): USB Host device probe

### DIFF
--- a/docs/en/usb_host.rst
+++ b/docs/en/usb_host.rst
@@ -42,6 +42,7 @@ The Host Library has the following features:
     - Supports automatic global resume by submitting a transfer.
     - USB PHY (both, the UTMI and internal FSLS PHY) clocks are automatically controlled by the DWC2 when the core enters/exits resumed state, effectively lowering power consumption on the host side.
     - Automatic root-port suspend before light sleep (If option :ref:`CONFIG_USB_HOST_AUTO_PM_LIGHT_SLEEP` is enabled).
+    - Post-light-sleep device presence probe on Full-Speed root ports (enabled automatically with :ref:`CONFIG_USB_HOST_AUTO_PM_LIGHT_SLEEP` on targets with an internal FSLS PHY).
 
 Currently, the Host Library and the underlying Host Stack has the following limitations:
 
@@ -54,7 +55,7 @@ Currently, the Host Library and the underlying Host Stack has the following limi
     - The External Hub Driver: Remote Wakeup feature is not supported (External Hubs are active, even if there are no devices inserted).
     - The External Hub Driver: Doesn't handle error cases (overcurrent handling, errors during initialization etc. are not implemented yet).
     - The External Hub Driver: No Interface selection. The Driver uses the first available Interface with Hub Class code (09h).
-    - Light sleep: USB Host with a USB Device connected does not detect device reconnection during light sleep. Treats it as a suspend/resume cycle.
+    - Light sleep: On Full-Speed root ports, device disconnect/reconnect during light sleep is not detected unless :ref:`CONFIG_USB_HOST_AUTO_PM_LIGHT_SLEEP` is enabled. See `Post-light-sleep device probe`_.
     :esp32s31 or esp32p4: - The External Hub Driver: No Transaction Translator layer (No FS/LS Devices support when a Hub is attached to HS Host).
 
 
@@ -594,11 +595,26 @@ Figures are indicative; exact values depend on the connected device, bus speed, 
 
 **Exit (after light sleep).** The post-sleep hook does not start root-port resume. The synchronous work that runs inside the sleep exit callback only schedules the deferred suspend notification. The root port stays suspended until the application calls :cpp:func:`usb_host_lib_root_port_resume`, a submitted transfer triggers automatic resume, or a remote-wakeup-capable device initiates remote wakeup.
 
+Post-light-sleep device probe
+"""""""""""""""""""""""""""""
+
+On Full-Speed root ports that use the internal FSLS PHY, the USB controller cannot observe a disconnect followed by a reconnect while the SoC is in light sleep. After wake-up, the Host Library may still treat a previously enumerated device as connected even though the physical device was power-cycled or replaced during sleep.
+
+When :ref:`CONFIG_USB_HOST_AUTO_PM_LIGHT_SLEEP` is enabled on a target with an internal FSLS PHY, the library automatically enables a **device probe** that runs after the root port resumes from light sleep. The probe sends a ``GET_DESCRIPTOR(DEVICE)`` control transfer to the device and checks that it still responds at its assigned address.
+
+Probe outcome:
+
+- **Passed** — The device is still present and in addressed state. Clients that opened the device receive :cpp:enumerator:`USB_HOST_CLIENT_EVENT_DEV_RESUMED` as usual.
+- **Failed** — The device is absent, or a different (not yet enumerated) device is connected. The library removes the stale device from the stack; clients that opened it receive :cpp:enumerator:`USB_HOST_CLIENT_EVENT_DEV_GONE`.
+
+The probe requires no application code. It is installed and driven internally when :cpp:func:`usb_host_install` is called with automatic light-sleep integration enabled. Currently, only devices attached directly to the root port are probed (not devices behind external hubs).
 
 Disconnect during light sleep
 """""""""""""""""""""""""""""
 
 If a device disconnects while the SoC is in light sleep, the disconnect may only be observed after waking up from the light sleep. The USB OTG peripheral disconnect interrupt is delivered after exiting light sleep. Even though the library still thinks the device is present until :cpp:func:`usb_host_lib_handle_events` runs, the lower USB Host stack layers detect the disconnected port and suppress deferred suspend notification for that device. Thus no suspend notification is delivered to the clients when a disconnect happens during light sleep.
+
+If the device disconnects and then reconnects during light sleep on a Full-Speed root port, the disconnect interrupt is also missed. In that case, the `Post-light-sleep device probe`_ detects the stale device after resume and removes it from the stack so that clients can handle the event via :cpp:enumerator:`USB_HOST_CLIENT_EVENT_DEV_GONE`.
 
 Deep sleep usage with USB Host
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
@@ -1823,6 +1823,72 @@ TEST_CASE("light_sleep_dconn_no_dev", "[light_sleep][host_suspend_dconn_no_dev]"
     vTaskDelay(20); // Short delay to allow task to be cleaned up
 }
 
+// Only HS ports, shall be changed to SOC_ instead of target config
+#if !CONFIG_IDF_TARGET_ESP32P4 && !CONFIG_IDF_TARGET_ESP32S31
+/**
+ * @brief Test: Device reconnection during light sleep
+ */
+TEST_CASE("light_sleep_dconn_dev_reconnect", "[light_sleep][host_suspend_dev_reconnect]")
+{
+    nb_of_responses = 0;
+    test_install_cdc_driver(&driver_config_new_dev_cb);
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_enable_timer_wakeup(TIMER_LIGHT_SLEEP_WAKEUP_TIME_US));
+    printf("Light sleep timer wakeup source is ready\n");
+
+    cdc_acm_dev_hdl_t cdc_dev = NULL;
+    cdc_acm_host_device_config_t dev_config = default_dev_config;
+
+    printf("Opening CDC-ACM device\n");
+    wait_for_app_event(&new_dev_event, 100);
+    TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_open(0x303A, 0x4002, 0, &dev_config, &cdc_dev)); // 0x303A:0x4002 (TinyUSB Dual CDC device)
+    TEST_ASSERT_NOT_NULL(cdc_dev);
+
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_data_tx_blocking(cdc_dev, tx_buf, sizeof(tx_buf), 1000));
+    }
+    vTaskDelay(10); // Wait until responses are processed
+    TEST_ASSERT_EQUAL(NUM_ITERATIONS, nb_of_responses);
+
+    light_sleep_enter_catch();                                 // Enter light sleep
+
+    // Port was reconnected during light sleep (by USB Device): No disconnect interrupt is delivered on FS/LS Root ports
+    // Expect suspend event
+    wait_for_app_event(&suspend_event, pdMS_TO_TICKS(5000));
+
+    // Manually resume the root port, usb_host_lib automatically probes device if it's in addressed state
+    TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_root_port_resume());
+
+    // Probe check would not pass (device not in addressed state), expect NO device event
+    // TODO: Do we want no device event, or device gone?
+    wait_for_no_app_event(pdMS_TO_TICKS(2000));
+
+    TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_close(cdc_dev));
+    cdc_dev = NULL;
+    nb_of_responses = 0;
+
+    // Toggle power, to get new device enumeration
+    force_conn_state(false, 50);
+    force_conn_state(true, 50);
+
+    wait_for_app_event(&new_dev_event, pdMS_TO_TICKS(5000));
+
+    // Open the device again
+    printf("Opening CDC-ACM device\n");
+    TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_open(0x303A, 0x4002, 0, &dev_config, &cdc_dev)); // 0x303A:0x4002 (TinyUSB Dual CDC device)
+    TEST_ASSERT_NOT_NULL(cdc_dev);
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_data_tx_blocking(cdc_dev, tx_buf, sizeof(tx_buf), 1000));
+    }
+    vTaskDelay(10); // Wait until responses are processed
+    TEST_ASSERT_EQUAL(NUM_ITERATIONS, nb_of_responses);
+
+    TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_close(cdc_dev));
+    TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_uninstall());
+    vTaskDelay(20); // Short delay to allow task to be cleaned up
+}
+#endif // !CONFIG_IDF_TARGET_ESP32P4 && !CONFIG_IDF_TARGET_ESP32S31
+
 #endif // CONFIG_ESP_SLEEP_EVENT_CALLBACKS && CDC_HOST_SUSPEND_RESUME_API_SUPPORTED
 
 #define TIMER_DEEP_SLEEP_WAKEUP_TIME_US  (3 * 1000 * 1000) // 3 seconds

--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/usb_device.c
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/usb_device.c
@@ -140,6 +140,22 @@ static void cdc_acm_mock_device_run(void)
     printf("USB initialization DONE\n");
 }
 
+static void cdc_acm_mock_device_deinit(void)
+{
+    vQueueDelete(dev_evt_queue);
+    ESP_LOGI(CDC_DEV_TAG, "Deinitialization");
+
+    TEST_ASSERT(tud_disconnect());
+    vTaskDelay(50);
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_deinit(0));
+#if (CONFIG_TINYUSB_CDC_COUNT > 1)
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_deinit(1));
+#endif
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+    ESP_LOGI(CDC_DEV_TAG, "Deinitialization done");
+}
+
 /* Following test cases implement dual CDC-ACM USB device that can be used as mock device for CDC-ACM Host tests */
 
 /**
@@ -228,11 +244,69 @@ TEST_CASE("mock_dev_app_suspend_sudden_dconn", "[cdc_acm_mock_dev][suspend_sudde
 /**
  * @brief Run CDC-ACM Device with 2 interfaces in a loopback mode
  *
- * Device performs a disconnect receiving Suspend callback using long connection delay to simulate device not being present
+ * Device performs a disconnect upon receiving Suspend callback using long connection delay to simulate device not being present
  */
 TEST_CASE("mock_dev_app_suspend_dconn_no_dev", "[cdc_acm_mock_dev][suspend_dconn_no_dev][ignore]")
 {
     device_suspend_common(1000, 5000);
+}
+
+/**
+ * @brief Run CDC-ACM Device with 2 interfaces in a loopback mode
+ *
+ * Device performs sudden disconnect followed by a connect upon receiving Suspend callback
+ *
+ * @param[in] dconn_delay_ms Delay in ms before disconnecting the port
+ * @param[in] conn_delay_ms Delay in ms before connecting the port back
+ */
+static void device_suspend_reconnect(size_t dconn_delay_ms, size_t conn_delay_ms)
+{
+    cdc_acm_mock_device_run();
+    bool tinyusb_deinit = false;
+
+    while (!tinyusb_deinit) {
+        tinyusb_event_t dev_event;
+        if (xQueueReceive(dev_evt_queue, &dev_event, portMAX_DELAY)) {
+
+            switch (dev_event.id) {
+            case TINYUSB_EVENT_SUSPENDED:
+
+                // Optional delay before disconnection (depends on the test case whether sudden disconnect, or just disconnect)
+                dconn_conn_delay(dconn_delay_ms);
+                tinyusb_deinit = true;
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    // Deinit device and tinyusb driver to simulate hard disconnect
+    cdc_acm_mock_device_deinit();
+    dconn_conn_delay(conn_delay_ms);
+    // Init the device back to simulate hard connect
+    cdc_acm_mock_device_run();
+
+    while (1) {
+        tinyusb_event_t dev_event;
+        if (xQueueReceive(dev_evt_queue, &dev_event, portMAX_DELAY)) {
+
+            switch (dev_event.id) {
+            default:
+                break;
+            }
+        }
+    }
+}
+
+/**
+ * @brief Run CDC-ACM Device with 2 interfaces in a loopback mode
+ *
+ * Device performs a disconnect upon receiving Suspend callback using short connection delay to simulate device being present
+ */
+TEST_CASE("mock_dev_app_suspend_dev_reconnect", "[cdc_acm_mock_dev][suspend_dev_reconnect][ignore]")
+{
+    device_suspend_reconnect(1000, 1000);
 }
 
 static void device_resume_common(size_t dconn_delay_ms, size_t conn_delay_ms)

--- a/host/class/cdc/usb_host_cdc_acm/test_app/pytest_usb_host_cdc.py
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/pytest_usb_host_cdc.py
@@ -32,6 +32,7 @@ def test_usb_host_cdc(dut: Tuple[IdfDut, IdfDut]) -> None:
         ("remote_wake",             "host_remote_wake"),
         ("remote_wake_dconn",       "host_remote_wake_dconn"),
         ("suspend_dconn_no_dev",    "host_suspend_dconn_no_dev"),
+        ("suspend_dev_reconnect",   "host_suspend_dev_reconnect"),
     ]
 
     for dev_test_mode, host_test_case_group in tests:

--- a/host/usb/CMakeLists.txt
+++ b/host/usb/CMakeLists.txt
@@ -63,6 +63,10 @@ if(CONFIG_USB_HOST_HUBS_SUPPORTED)
                      "src/ext_port.c")
 endif()
 
+if(CONFIG_USB_HOST_LIGHT_SLEEP_PROBE)
+    list(APPEND srcs "src/usb_host_probe.c")
+endif()
+
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS ${include}
                        PRIV_INCLUDE_DIRS ${priv_includes}

--- a/host/usb/Kconfig
+++ b/host/usb/Kconfig
@@ -201,9 +201,21 @@ menu "USB-OTG"
 
     menu "Power management"
 
+        # Hidden option
+        config USB_HOST_LIGHT_SLEEP_PROBE
+            bool
+            default n
+            help
+                Internal option: Enable light sleep probe. On Full speed root ports (using internal PHY),
+                It's not possible to register device disconnect followed by device connect. Thus the device acting as
+                suspended, could either be the same device after power cycle, or a fresh, not enumerated device.
+                To make sure the connected device is the enumerated device, a ctrl transfer is automatically issued
+                to the device, making sure the device is in addressed state.
+
         config USB_HOST_AUTO_PM_LIGHT_SLEEP
             bool "Automatically suspend root port before light sleep"
             depends on ESP_SLEEP_EVENT_CALLBACKS
+            select USB_HOST_LIGHT_SLEEP_PROBE if SOC_USB_FSLS_PHY_NUM > 0
             default n
             help
                 Register light sleep event callbacks to automatically suspend the root port when the SoC

--- a/host/usb/private_include/hcd.h
+++ b/host/usb/private_include/hcd.h
@@ -26,6 +26,11 @@ extern "C" {
 #define AUTO_PM_LIGHT_SLEEP
 #endif // CONFIG_USB_HOST_AUTO_PM_LIGHT_SLEEP
 
+// Post-light-sleep GET_DESCRIPTOR probe on FS/LS root ports (disconnect cannot be detected during sleep)
+#ifdef CONFIG_USB_HOST_LIGHT_SLEEP_PROBE
+#define LIGHT_SLEEP_PROBE
+#endif // CONFIG_USB_HOST_LIGHT_SLEEP_PROBE
+
 // ----------------------- Configs -------------------------
 
 #define HCD_NUM_PORTS                           SOC_USB_OTG_PERIPH_NUM   // Each peripheral is a root port

--- a/host/usb/private_include/hub.h
+++ b/host/usb/private_include/hub.h
@@ -327,6 +327,22 @@ esp_err_t hub_dev_new(uint8_t dev_addr);
  */
 esp_err_t hub_dev_gone(uint8_t dev_addr);
 
+#ifdef LIGHT_SLEEP_PROBE
+/**
+ * @brief Report that a device is no longer present by its device-tree UID
+ *
+ * Propagates HUB_EVENT_DISCONNECTED for the node matching @p uid.
+ *
+ * @param[in] uid Device's node unique ID
+ *
+ * @return
+ *    - ESP_OK: Disconnect event propagated
+ *    - ESP_ERR_INVALID_STATE: Hub driver is not installed
+ *    - ESP_ERR_NOT_FOUND: Device tree node not found
+ */
+esp_err_t hub_dev_gone_by_uid(unsigned int uid);
+#endif // LIGHT_SLEEP_PROBE
+
 #if ENABLE_USB_HUBS
 /**
  * @brief Notify Hub driver that all devices should be freed

--- a/host/usb/private_include/usb_host_probe.h
+++ b/host/usb/private_include/usb_host_probe.h
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "hcd.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Event data object for Probe driver events
+ */
+typedef enum {
+    PROBE_EVENT_PASSED,             /**< Post-light-sleep probe succeeded; device is still present */
+    PROBE_EVENT_FAILED,             /**< Post-light-sleep probe failed; device is absent or changed */
+} probe_event_t;
+
+typedef struct {
+    probe_event_t event;            /**< Probe driver event */
+    union {
+        struct {
+            unsigned int uid;       /**< Unique node ID (probe passed) */
+        } passed;
+        struct {
+            unsigned int uid;       /**< Unique node ID (probe failed) */
+        } failed;
+    };
+} probe_event_data_t;
+
+// ---------------------- Callbacks ------------------------
+
+/**
+ * @brief Callback used to indicate that the Probe driver has an event
+ *
+ * @note This callback is called from within probe_process()
+ */
+typedef void (*probe_event_cb_t)(probe_event_data_t *event_data, void *arg);
+
+/**
+ * @brief Probe driver configuration
+ */
+typedef struct {
+    usb_proc_req_cb_t proc_req_cb;      /**< Processing request callback */
+    void *proc_req_cb_arg;              /**< Processing request callback argument */
+    probe_event_cb_t probe_event_cb;    /**< Probe event callback */
+    void *probe_event_cb_arg;           /**< Probe event callback argument */
+} probe_config_t;
+
+/**
+ * @brief Install the post-light-sleep device probe driver
+ *
+ * @param[in]  config     Probe driver configuration
+ * @param[out] client_ret Unique pointer to identify the probe driver as a USB Host client
+ *
+ * @return
+ *    - ESP_OK: Probe driver installed successfully
+ *    - ESP_ERR_INVALID_STATE: Probe driver is already installed
+ *    - ESP_ERR_INVALID_ARG: Invalid argument
+ *    - ESP_ERR_NO_MEM: Insufficient memory
+ */
+esp_err_t probe_install(probe_config_t *config, void **client_ret);
+
+/**
+ * @brief Uninstall the probe driver
+ *
+ * @return
+ *    - ESP_OK: Probe driver uninstalled successfully
+ *    - ESP_ERR_INVALID_STATE: Probe driver is not installed
+ */
+esp_err_t probe_uninstall(void);
+
+/**
+ * @brief Start a post-light-sleep presence probe for a device
+ *
+ * Issues GET_DESCRIPTOR(DEVICE) at the device's current address. Does not use the
+ * enumeration lock.
+ *
+ * @param[in] uid Unique device ID
+ *
+ * @return
+ *    - ESP_OK: Probe started
+ *    - ESP_ERR_INVALID_STATE: Probe driver not installed, probe already active, or enumeration is busy
+ *    - ESP_ERR_NOT_FOUND: Device not found
+ */
+esp_err_t probe_start(unsigned int uid);
+
+/**
+ * @brief Cancel an in-progress probe
+ *
+ * @param[in] uid Unique device ID (unused if probe is active; kept for symmetry with enum_cancel)
+ *
+ * @return
+ *    - ESP_OK: Probe canceled or not active
+ *    - ESP_ERR_INVALID_STATE: Probe driver is not installed
+ */
+esp_err_t probe_cancel(unsigned int uid);
+
+/**
+ * @brief Probe driver processing function
+ *
+ * @return
+ *    - ESP_OK: Processing completed normally
+ *    - ESP_ERR_INVALID_STATE: Probe driver is not installed
+ */
+esp_err_t probe_process(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/host/usb/private_include/usb_private.h
+++ b/host/usb/private_include/usb_private.h
@@ -59,7 +59,8 @@ typedef struct urb_s urb_t;
 typedef enum {
     USB_PROC_REQ_SOURCE_USBH = 0x01,
     USB_PROC_REQ_SOURCE_HUB = 0x02,
-    USB_PROC_REQ_SOURCE_ENUM = 0x03
+    USB_PROC_REQ_SOURCE_ENUM = 0x03,
+    USB_PROC_REQ_SOURCE_PROBE = 0x04,
 } usb_proc_req_source_t;
 
 /**

--- a/host/usb/private_include/usbh.h
+++ b/host/usb/private_include/usbh.h
@@ -323,6 +323,18 @@ esp_err_t usbh_devs_mark_all_free(void);
  */
 void usbh_devs_set_pm_actions_all(usbh_dev_ctrl_t device_ctrl);
 
+/**
+ * @brief Issue a power management related device action to a device by UID
+ *
+ * @param[in] uid          Unique ID assigned to the device
+ * @param[in] device_ctrl  Device control command
+ *
+ * @return
+ *    - ESP_OK: Device action issued successfully
+ *    - ESP_ERR_NOT_FOUND: Device with provided uid not found
+ */
+esp_err_t usbh_dev_set_pm_actions_by_uid(unsigned int uid, usbh_dev_ctrl_t device_ctrl);
+
 #ifdef AUTO_PM_LIGHT_SLEEP
 /**
  * @brief Halt and flush all endpoints on all devices (synchronous)
@@ -510,6 +522,19 @@ esp_err_t usbh_dev_enum_lock(usb_device_handle_t dev_hdl);
  *    - ESP_ERR_INVALID_STATE: Device is in an invalid state and enumeration lock can't be released
  */
 esp_err_t usbh_dev_enum_unlock(usb_device_handle_t dev_hdl);
+
+/**
+ * @brief Check whether a device is locked for enumeration by UID
+ *
+ * @param[in]  uid        Unique ID assigned to the device
+ * @param[out] is_locked  Whether the device is locked for enumeration
+ *
+ * @return
+ *    - ESP_OK: Enumeration lock status obtained successfully
+ *    - ESP_ERR_INVALID_ARG: Invalid argument
+ *    - ESP_ERR_NOT_FOUND: Device with provided uid not found
+ */
+esp_err_t usbh_dev_enum_is_locked_by_uid(unsigned int uid, bool *is_locked);
 
 /**
  * @brief Set the maximum packet size of EP0 for a device

--- a/host/usb/src/enum.c
+++ b/host/usb/src/enum.c
@@ -1139,7 +1139,7 @@ static void enum_control_transfer_complete(usb_transfer_t *ctrl_xfer)
 esp_err_t enum_install(enum_config_t *config, void **client_ret)
 {
     ENUM_CHECK(p_enum_driver == NULL, ESP_ERR_INVALID_STATE);
-    ENUM_CHECK(config != NULL, ESP_ERR_INVALID_ARG);
+    ENUM_CHECK(config != NULL && client_ret != NULL, ESP_ERR_INVALID_ARG);
 
     esp_err_t ret;
     enum_driver_t *enum_drv = heap_caps_calloc(1, sizeof(enum_driver_t), MALLOC_CAP_DEFAULT);

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -18,6 +18,9 @@
 #include "hcd.h"
 #include "hub.h"
 #include "usbh.h"
+#ifdef LIGHT_SLEEP_PROBE
+#include "usb_host_probe.h"
+#endif // LIGHT_SLEEP_PROBE
 
 #if ENABLE_USB_HUBS
 #include "ext_hub.h"
@@ -105,7 +108,8 @@ typedef struct {
             struct {
                 hub_flag_action_t actions: 8;       /**< Hub actions */
                 uint32_t light_sleep_auto_pm: 1;    /**< Root port was automatically suspended from light sleep callback, when entering light sleep */
-                uint32_t reserved23: 23;            /**< Reserved */
+                uint32_t light_sleep_probe_pending: 1; /**< Root port resume after light sleep auto-suspend should run an enum probe */
+                uint32_t reserved21: 21;            /**< Reserved */
             };
             uint32_t val;                           /**< Hub flag action value */
         } flags;                                    /**< Hub flags */
@@ -351,6 +355,48 @@ static esp_err_t dev_tree_node_remove_by_parent(ext_hub_handle_t parent, uint8_t
     return ESP_OK;
 }
 
+/**
+ * @brief Probe all connected devices, if they are in addressed state after returning from light sleep
+ *
+ * TODO: on esp32p4, once suspend/resume is supported also on the FS port, differentiate between FS and HS port
+ *       and perform probe only for the FS port
+ */
+#ifdef LIGHT_SLEEP_PROBE
+static void usbh_devs_probe(void)
+{
+    bool light_sleep_probe_pending = false;
+    HUB_DRIVER_ENTER_CRITICAL();
+    if (p_hub_driver_obj->dynamic.flags.light_sleep_probe_pending) {
+        p_hub_driver_obj->dynamic.flags.light_sleep_probe_pending = 0;
+        light_sleep_probe_pending = true;
+    }
+    HUB_DRIVER_EXIT_CRITICAL();
+
+    if (!light_sleep_probe_pending) {
+        // No device is waiting to be probed
+        return;
+    }
+
+    dev_tree_node_t *dev_tree_iter;
+    unsigned int probe_uid = 0;
+    bool probe_uid_found = false;
+    TAILQ_FOREACH(dev_tree_iter, &p_hub_driver_obj->single_thread.dev_nodes_tailq, tailq_entry) {
+        // Only check root port devices (without external hubs)
+        if (dev_tree_iter->parent == NULL) {
+            probe_uid = dev_tree_iter->uid;
+            probe_uid_found = true;
+            break;
+        }
+    }
+    if (probe_uid_found) {
+        const esp_err_t probe_ret = probe_start(probe_uid);
+        if (probe_ret != ESP_OK) {
+            ESP_LOGW(HUB_DRIVER_TAG, "Light sleep probe not started: %s", esp_err_to_name(probe_ret));
+        }
+    }
+}
+#endif // LIGHT_SLEEP_PROBE
+
 // ---------------------- Callbacks ------------------------
 
 static bool root_port_callback(hcd_port_handle_t port_hdl, hcd_port_event_t port_event, void *user_arg, bool in_isr)
@@ -504,6 +550,9 @@ reset_err:
 #ifdef AUTO_PM_LIGHT_SLEEP
             p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 0;
 #endif // AUTO_PM_LIGHT_SLEEP
+#ifdef LIGHT_SLEEP_PROBE
+            p_hub_driver_obj->dynamic.flags.light_sleep_probe_pending = 0;
+#endif // LIGHT_SLEEP_PROBE
             break;
         default:
             abort();    // Should never occur
@@ -639,9 +688,20 @@ static void root_port_req(root_hub_port_t *root_hub_port)
         root_hub_port->dynamic.state = ROOT_PORT_STATE_ENABLED;
         HUB_DRIVER_EXIT_CRITICAL();
 
+#ifndef LIGHT_SLEEP_PROBE
         // Root port, including all the connected devices were resumed (global resume)
         // Clear all EPs and propagate the resumed event to clients
         usbh_devs_set_pm_actions_all(USBH_DEV_RESUME | USBH_DEV_RESUME_EVT);    // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+
+        // Probe connected devices, to check if disconnection (power cycle) did not happen during light sleep
+        // On FS ports (internal FSLS PHY) it's not possible to detect disconnect interrupt during light sleep
+
+#else   // LIGHT_SLEEP_PROBE
+
+        // Only WH resume, events will be delivered by the probe event, based on the device presence
+        usbh_devs_set_pm_actions_all(USBH_DEV_RESUME);
+        usbh_devs_probe();
+#endif // LIGHT_SLEEP_PROBE
     }
 #ifdef AUTO_PM_LIGHT_SLEEP
     if (port_reqs & PORT_REQ_EXIT_LIGHT_SLEEP) {
@@ -653,6 +713,12 @@ static void root_port_req(root_hub_port_t *root_hub_port)
             // That indicates, that the device has been disconnected during light sleep
             // Clock gating will be disabled by recovery routine, nothing to do here
             // Deferred suspend event will not be delivered
+            HUB_DRIVER_ENTER_CRITICAL();
+            p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 0;
+#ifdef LIGHT_SLEEP_PROBE
+            p_hub_driver_obj->dynamic.flags.light_sleep_probe_pending = 0;
+#endif // LIGHT_SLEEP_PROBE
+            HUB_DRIVER_EXIT_CRITICAL();
             return;
         }
 
@@ -1142,6 +1208,9 @@ esp_err_t hub_root_light_sleep_suspend_bus(void)
 
     HUB_DRIVER_ENTER_CRITICAL();
     p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 1;
+#ifdef LIGHT_SLEEP_PROBE
+    p_hub_driver_obj->dynamic.flags.light_sleep_probe_pending = 1;
+#endif // LIGHT_SLEEP_PROBE
     root_hub_port->dynamic.state = ROOT_PORT_STATE_SUSPENDED;
     HUB_DRIVER_EXIT_CRITICAL();
     return ESP_OK;
@@ -1200,6 +1269,7 @@ esp_err_t hub_node_reset(unsigned int node_uid)
             ESP_LOGE(HUB_DRIVER_TAG, "Failed to issue root port reset");
         } else {
             ret = dev_tree_node_reset_completed(NULL, dev_tree_node->port_num);
+            printf("Reset completed\n");
         }
     } else {
 #if ENABLE_USB_HUBS
@@ -1328,6 +1398,16 @@ esp_err_t hub_notify_all_free(void)
     return ESP_OK;
 }
 #endif // ENABLE_USB_HUBS
+
+#ifdef LIGHT_SLEEP_PROBE
+esp_err_t hub_dev_gone_by_uid(unsigned int uid)
+{
+    HUB_DRIVER_CHECK(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
+    dev_tree_node_t *dev_tree_node = dev_tree_node_get_by_uid(uid);
+    HUB_DRIVER_CHECK(dev_tree_node != NULL, ESP_ERR_NOT_FOUND);
+    return dev_tree_node_dev_gone(dev_tree_node->parent, dev_tree_node->port_num);
+}
+#endif // LIGHT_SLEEP_PROBE
 
 esp_err_t hub_process(void)
 {

--- a/host/usb/src/usb_host.c
+++ b/host/usb/src/usb_host.c
@@ -24,9 +24,12 @@
 #include "hcd.h"
 #include "esp_private/usb_phy.h"
 #include "usb/usb_host.h"
-#ifdef  AUTO_PM_LIGHT_SLEEP
+#ifdef AUTO_PM_LIGHT_SLEEP
 #include "esp_private/sleep_event.h"        // For light sleep event callbacks
 #endif // AUTO_PM_LIGHT_SLEEP
+#ifdef LIGHT_SLEEP_PROBE
+#include "usb_host_probe.h"
+#endif // LIGHT_SLEEP_PROBE
 
 #if SOC_USB_OTG_SUPPORTED
 #include "esp_idf_version.h"
@@ -61,6 +64,9 @@ DEFINE_CRIT_SECTION_LOCK_STATIC(host_lock);
 #define PROCESS_REQUEST_PENDING_FLAG_USBH       (1 << 0)
 #define PROCESS_REQUEST_PENDING_FLAG_HUB        (1 << 1)
 #define PROCESS_REQUEST_PENDING_FLAG_ENUM       (1 << 2)
+#ifdef LIGHT_SLEEP_PROBE
+#define PROCESS_REQUEST_PENDING_FLAG_PROBE      (1 << 3)
+#endif // LIGHT_SLEEP_PROBE
 
 #define SHORT_DESC_REQ_LEN                      8
 #define CTRL_TRANSFER_MAX_DATA_LEN              CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE
@@ -164,6 +170,9 @@ typedef struct {
         TimerHandle_t auto_suspend_timer;             // Freertos timer used for automatic suspend of the root port
         usb_phy_handle_t phy_handles[HCD_NUM_PORTS];  // One per port; NULL if skip_phy_setup or port not enabled
         void *enum_client;                            // Pointer to Enum driver (acting as a client). Used to reroute completed USBH control transfers
+#ifdef LIGHT_SLEEP_PROBE
+        void *probe_client;                           // Pointer to Probe driver (acting as a client)
+#endif // LIGHT_SLEEP_PROBE
         void *hub_client;                             // Pointer to External Hub driver (acting as a client). Used to reroute completed USBH control transfers. NULL, when External Hub Driver not available.
     } constant;
 } host_lib_t;
@@ -239,6 +248,11 @@ static inline bool is_internal_client(void *client)
     if (p_host_lib_obj->constant.enum_client && (client == p_host_lib_obj->constant.enum_client)) {
         return true;
     }
+#ifdef LIGHT_SLEEP_PROBE
+    if (p_host_lib_obj->constant.probe_client && (client == p_host_lib_obj->constant.probe_client)) {
+        return true;
+    }
+#endif // LIGHT_SLEEP_PROBE
 #if ENABLE_USB_HUBS
     if (p_host_lib_obj->constant.hub_client && (client == p_host_lib_obj->constant.hub_client)) {
         return true;
@@ -348,6 +362,13 @@ static bool proc_req_callback(usb_proc_req_source_t source, bool in_isr, void *a
         break;
     case USB_PROC_REQ_SOURCE_ENUM:
         p_host_lib_obj->dynamic.process_pending_flags |= PROCESS_REQUEST_PENDING_FLAG_ENUM;
+        break;
+#ifdef LIGHT_SLEEP_PROBE
+    case USB_PROC_REQ_SOURCE_PROBE:
+        p_host_lib_obj->dynamic.process_pending_flags |= PROCESS_REQUEST_PENDING_FLAG_PROBE;
+        break;
+#endif // LIGHT_SLEEP_PROBE
+    default:
         break;
     }
     bool yield = _unblock_lib(in_isr);
@@ -460,11 +481,19 @@ static void hub_event_callback(hub_event_data_t *event_data, void *arg)
         enum_start(event_data->connected.uid);
         break;
     case HUB_EVENT_RESET_COMPLETED:
-        ESP_ERROR_CHECK(enum_proceed(event_data->reset_completed.uid));
+        bool enum_locked;
+        usbh_dev_enum_is_locked_by_uid(event_data->reset_completed.uid, &enum_locked);
+        if (enum_locked) {
+            // Proceed with enum only when enum lock is taken
+            ESP_ERROR_CHECK(enum_proceed(event_data->reset_completed.uid));
+        }
         break;
     case HUB_EVENT_DISCONNECTED:
         // Cancel enumeration process
         enum_cancel(event_data->disconnected.uid);
+#ifdef LIGHT_SLEEP_PROBE
+        probe_cancel(event_data->disconnected.uid);
+#endif // LIGHT_SLEEP_PROBE
         // We allow this to fail in case the device object was already freed
         usbh_devs_remove(event_data->disconnected.uid);
         break;
@@ -500,6 +529,31 @@ static void enum_event_callback(enum_event_data_t *event_data, void *arg)
         break;
     }
 }
+
+#ifdef LIGHT_SLEEP_PROBE
+static void probe_event_callback(probe_event_data_t *event_data, void *arg)
+{
+    probe_event_t event = event_data->event;
+
+    switch (event) {
+    case PROBE_EVENT_PASSED:
+        ESP_LOGI(USB_HOST_TAG, "PROBE_EVENT_PASSED");
+        // Send resume event only to those device which passed the probe
+        ESP_ERROR_CHECK_WITHOUT_ABORT(usbh_dev_set_pm_actions_by_uid(event_data->passed.uid, USBH_DEV_RESUME_EVT));
+        break;
+    case PROBE_EVENT_FAILED:
+        ESP_LOGI(USB_HOST_TAG, "PROBE_EVENT_FAILED");
+        // Connected device underwent a power cycle during light sleep, or it's different (not enumerated) device
+        // Remove the device
+        hub_node_reset(event_data->failed.uid);
+        //hub_dev_gone_by_uid(event_data->failed.uid);
+        break;
+    default:
+        abort();    // Should never occur
+        break;
+    }
+}
+#endif // LIGHT_SLEEP_PROBE
 
 // ------------------- Client Related ----------------------
 
@@ -753,6 +807,20 @@ esp_err_t usb_host_install(const usb_host_config_t *config)
         goto enum_err;
     }
 
+#ifdef LIGHT_SLEEP_PROBE
+    probe_config_t probe_config = {
+        .proc_req_cb = proc_req_callback,
+        .proc_req_cb_arg = NULL,
+        .probe_event_cb = probe_event_callback,
+        .probe_event_cb_arg = NULL,
+    };
+    ret = probe_install(&probe_config, &host_lib_obj->constant.probe_client);
+    if (ret != ESP_OK) {
+        ESP_LOGE(USB_HOST_TAG, "Probe driver install error: %s", esp_err_to_name(ret));
+        goto probe_err;
+    }
+#endif // LIGHT_SLEEP_PROBE
+
     // Install Hub
     hub_config_t hub_config = {
         .port_map = peripheral_map, // Each USB-OTG peripheral maps to a root port
@@ -818,6 +886,10 @@ sleep_cb_err:
 #endif // AUTO_PM_LIGHT_SLEEP
     ESP_ERROR_CHECK(hub_uninstall());
 hub_err:
+#ifdef LIGHT_SLEEP_PROBE
+    ESP_ERROR_CHECK(probe_uninstall());
+probe_err:
+#endif // LIGHT_SLEEP_PROBE
     ESP_ERROR_CHECK(enum_uninstall());
 enum_err:
     ESP_ERROR_CHECK(usbh_uninstall());
@@ -876,6 +948,9 @@ esp_err_t usb_host_uninstall(void)
     - USB PHY
     */
     ESP_ERROR_CHECK(hub_uninstall());
+#ifdef LIGHT_SLEEP_PROBE
+    ESP_ERROR_CHECK(probe_uninstall());
+#endif // LIGHT_SLEEP_PROBE
     ESP_ERROR_CHECK(enum_uninstall());
     ESP_ERROR_CHECK(usbh_uninstall());
     // Delete all PHYs that were created
@@ -931,6 +1006,11 @@ esp_err_t usb_host_lib_handle_events(TickType_t timeout_ticks, uint32_t *event_f
         if (process_pending_flags & PROCESS_REQUEST_PENDING_FLAG_ENUM) {
             ESP_ERROR_CHECK(enum_process());
         }
+#ifdef LIGHT_SLEEP_PROBE
+        if (process_pending_flags & PROCESS_REQUEST_PENDING_FLAG_PROBE) {
+            ESP_ERROR_CHECK(probe_process());
+        }
+#endif // LIGHT_SLEEP_PROBE
 
         ret = ESP_OK;
         // Set timeout_ticks to 0 so that we can check for events again without blocking

--- a/host/usb/src/usb_host_probe.c
+++ b/host/usb/src/usb_host_probe.c
@@ -1,0 +1,380 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include "esp_err.h"
+#include "esp_check.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "usb_private.h"
+#include "usbh.h"
+#include "usb_host_probe.h"
+#include "hub.h"
+#include "usb/usb_helpers.h"
+
+#define PROBE_CTRL_TRANSFER_MAX_DATA_LEN    CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE
+
+/**
+ * @brief Stages of the post-light-sleep device probe state machine
+ */
+typedef enum {
+    PROBE_STAGE_IDLE = 0,                   /**< No device to be probed */
+    PROBE_STAGE_GET_DEV_DESC,               /**< Probe the device by getting a device descriptor */
+    PROBE_STAGE_CHECK_DEV_DESC,             /**< Probe the device by checking a device descriptor */
+    PROBE_STAGE_DONE,                       /**< Probing done */
+} probe_stage_t;
+
+static const char *const probe_stage_strings[] = {
+    "IDLE",
+    "GET_DEV_DESC",
+    "CHECK_DEV_DESC",
+    "DONE",
+};
+
+typedef struct {
+    struct {
+        probe_stage_t stage;                /**< Current probing stage */
+        unsigned int node_uid;              /**< Unique node ID of device being probed */
+        usb_device_handle_t dev_hdl;        /**< Handle of device being probed */
+        uint8_t ep0_mps;                    /**< Endpoint 0 Max Packet Size */
+        int expect_num_bytes;               /**< Expected number of bytes for IN transfers stages. Set to 0 for OUT transfer */
+        bool probe_passed;                  /**< Flag indicating, that the probing passed */
+    } single_thread;                        /**< Single thread members don't require a critical section as long as they are never accessed from multiple threads */
+
+    struct {
+        urb_t *urb;                         /**< URB used for probe control transfers. Max data length of 8 for LS devices, 64 for FS/HS devices */
+        usb_proc_req_cb_t proc_req_cb;      /**< USB Host process request callback. Refer to proc_req_callback() in usb_host.c */
+        void *proc_req_cb_arg;              /**< USB Host process request callback argument */
+        probe_event_cb_t probe_event_cb;    /**< Probe event callback */
+        void *probe_event_cb_arg;           /**< Probe event callback argument */
+    } constant;                             /**< Constant members. Do not change after installation thus do not require a critical section or mutex */
+} probe_driver_t;
+
+static probe_driver_t *p_probe_driver = NULL;
+
+static const char *PROBE_TAG = "PROBE";
+
+// ---------------------------- Helpers ----------------------------------------
+
+#define PROBE_CHECK(cond, ret_val) ({               \
+            if (unlikely(!(cond))) {                \
+                return (ret_val);                   \
+            }                                       \
+})
+
+// ------------------------ Private functions ----------------------------------
+
+/**
+ * @brief Control transfer completion callback
+ *
+ * Is called by lower logic when the probe control transfer is completed with or without error
+ *
+ * @param[in] ctrl_xfer Pointer to a transfer buffer
+ */
+static void probe_control_transfer_complete(usb_transfer_t *ctrl_xfer)
+{
+    assert(ctrl_xfer);
+    assert(ctrl_xfer->context);
+    assert(p_probe_driver->single_thread.dev_hdl == ctrl_xfer->context);
+
+    // Request processing
+    p_probe_driver->constant.proc_req_cb(USB_PROC_REQ_SOURCE_PROBE, false, p_probe_driver->constant.proc_req_cb_arg);
+}
+
+/**
+ * @brief Control request: Get Device descriptor
+ *
+ * Prepares and submits a GET_DESCRIPTOR(DEVICE) control transfer for the device being probed
+ *
+ * @param[in] stage Current probe stage (for logging)
+ *
+ * @return
+ *    - ESP_OK: Control transfer submitted successfully
+ *    - Other: Error from usbh_dev_submit_ctrl_urb(); stage is set to PROBE_STAGE_DONE
+ */
+static esp_err_t probe_get_dev_desc(probe_stage_t stage)
+{
+    usb_transfer_t *transfer = &p_probe_driver->constant.urb->transfer;
+    const uint8_t ctrl_ep_mps = p_probe_driver->single_thread.ep0_mps;
+
+    USB_SETUP_PACKET_INIT_GET_DEVICE_DESC((usb_setup_packet_t *)transfer->data_buffer);
+    transfer->num_bytes = sizeof(usb_setup_packet_t) + usb_round_up_to_mps(sizeof(usb_device_desc_t), ctrl_ep_mps);
+    p_probe_driver->single_thread.expect_num_bytes = sizeof(usb_setup_packet_t) + sizeof(usb_device_desc_t);
+
+    esp_err_t ret = usbh_dev_submit_ctrl_urb(p_probe_driver->single_thread.dev_hdl, p_probe_driver->constant.urb);
+    if (ret != ESP_OK) {
+        ESP_LOGE(PROBE_TAG, "Control transfer submit error %s at %s", esp_err_to_name(ret), probe_stage_strings[stage]);
+
+        p_probe_driver->single_thread.stage = PROBE_STAGE_DONE;
+
+        // Request processing
+        p_probe_driver->constant.proc_req_cb(USB_PROC_REQ_SOURCE_PROBE, false, p_probe_driver->constant.proc_req_cb_arg);
+        return ret;
+    }
+
+    // Proceed to next stage
+    p_probe_driver->single_thread.stage = PROBE_STAGE_CHECK_DEV_DESC;
+    return ret;
+}
+
+/**
+ * @brief Parse Device descriptor control transfer response
+ *
+ * Validates transfer status, response length, and bDescriptorType of the received device descriptor
+ *
+ * @return
+ *    - ESP_OK: Device descriptor is valid; device is still present at its address
+ *    - ESP_ERR_NOT_FINISHED: Transfer did not complete successfully
+ *    - ESP_ERR_INVALID_SIZE: Response shorter than expected
+ *    - ESP_ERR_INVALID_RESPONSE: bDescriptorType is not USB_B_DESCRIPTOR_TYPE_DEVICE
+ */
+static esp_err_t probe_parse_xfer_response(void)
+{
+    usb_transfer_t *ctrl_xfer = &p_probe_driver->constant.urb->transfer;
+    esp_err_t ret = ESP_FAIL;
+
+    if (ctrl_xfer->status != USB_TRANSFER_STATUS_COMPLETED) {
+        ESP_LOGE(PROBE_TAG, "Bad transfer status %d at %s",
+                 ctrl_xfer->status, probe_stage_strings[p_probe_driver->single_thread.stage]);
+        ret = ESP_ERR_NOT_FINISHED;
+        goto probe_failed;
+    }
+
+    if (p_probe_driver->single_thread.expect_num_bytes != ctrl_xfer->actual_num_bytes) {
+        ESP_LOGW(PROBE_TAG, "Unexpected response length %d (expected %d)",
+                 ctrl_xfer->actual_num_bytes, p_probe_driver->single_thread.expect_num_bytes);
+        if (ctrl_xfer->actual_num_bytes < p_probe_driver->single_thread.expect_num_bytes) {
+            ESP_LOGE(PROBE_TAG, "Invalid response length");
+            ret = ESP_ERR_INVALID_SIZE;
+            goto probe_failed;
+        }
+    }
+
+    const usb_device_desc_t *dev_desc = (const usb_device_desc_t *)(ctrl_xfer->data_buffer + sizeof(usb_setup_packet_t));
+    if (dev_desc->bDescriptorType != USB_B_DESCRIPTOR_TYPE_DEVICE) {
+        ESP_LOGE(PROBE_TAG, "Probe dev desc has wrong bDescriptorType");
+        ret = ESP_ERR_INVALID_RESPONSE;
+        goto probe_failed;
+    }
+
+    // Descriptor check passed, device is in addressed state
+    ret = ESP_OK;
+
+probe_failed:
+    return ret;
+}
+
+/**
+ * @brief Control request response handling: Check Device descriptor
+ *
+ * Parses the GET_DESCRIPTOR(DEVICE) response and advances to PROBE_STAGE_DONE
+ */
+static void probe_check_dev_desc(void)
+{
+    if (ESP_OK == probe_parse_xfer_response()) {
+        // Device descriptor is valid, device is in addressed state
+        p_probe_driver->single_thread.probe_passed = true;
+    }
+
+    // Finish probe
+    p_probe_driver->single_thread.stage = PROBE_STAGE_DONE;
+    // Request processing
+    p_probe_driver->constant.proc_req_cb(USB_PROC_REQ_SOURCE_PROBE, false, p_probe_driver->constant.proc_req_cb_arg);
+}
+
+/**
+ * @brief Complete stage
+ *
+ * Closes the probed device, resets driver state to idle, and delivers PROBE_EVENT_PASSED or
+ * PROBE_EVENT_FAILED via the probe event callback
+ */
+static void probe_stage_done(void)
+{
+    const unsigned int node_uid = p_probe_driver->single_thread.node_uid;
+    usb_device_handle_t dev_hdl = p_probe_driver->single_thread.dev_hdl;
+    const bool probe_passed = p_probe_driver->single_thread.probe_passed;
+
+    if (dev_hdl != NULL) {
+        ESP_ERROR_CHECK(usbh_dev_close(dev_hdl));
+    }
+
+    // Cleanup
+    p_probe_driver->single_thread.node_uid = 0;
+    p_probe_driver->single_thread.dev_hdl = NULL;
+    p_probe_driver->single_thread.probe_passed = false;
+    p_probe_driver->single_thread.expect_num_bytes = 0;
+    p_probe_driver->constant.urb->transfer.context = NULL;
+    p_probe_driver->single_thread.stage = PROBE_STAGE_IDLE;
+
+    // Deliver event
+    probe_event_data_t event_data = {};
+    if (probe_passed) {
+        ESP_LOGI(PROBE_TAG, "Post-light-sleep probe passed for uid %u", node_uid);
+
+        const probe_event_data_t passed_event_data = {
+            .event = PROBE_EVENT_PASSED,
+            .passed = {
+                .uid = node_uid,
+            },
+        };
+        event_data = passed_event_data;
+    } else {
+        ESP_LOGW(PROBE_TAG, "Post-light-sleep probe failed for uid %u", node_uid);
+
+        const probe_event_data_t failed_event_data = {
+            .event = PROBE_EVENT_FAILED,
+            .failed = {
+                .uid = node_uid,
+            },
+        };
+        event_data = failed_event_data;
+    }
+
+    // Call event callback
+    p_probe_driver->constant.probe_event_cb(&event_data, p_probe_driver->constant.probe_event_cb_arg);
+}
+
+// -------------------------- Public API ---------------------------------------
+
+esp_err_t probe_install(probe_config_t *config, void **client_ret)
+{
+    PROBE_CHECK(p_probe_driver == NULL, ESP_ERR_INVALID_STATE);
+    PROBE_CHECK(config != NULL && client_ret != NULL, ESP_ERR_INVALID_ARG);
+
+    esp_err_t ret;
+    probe_driver_t *probe_drv = heap_caps_calloc(1, sizeof(probe_driver_t), MALLOC_CAP_DEFAULT);
+    PROBE_CHECK(probe_drv != NULL, ESP_ERR_NO_MEM);
+
+    urb_t *urb = urb_alloc(sizeof(usb_setup_packet_t) + PROBE_CTRL_TRANSFER_MAX_DATA_LEN, 0);
+    if (urb == NULL) {
+        ret = ESP_ERR_NO_MEM;
+        goto alloc_err;
+    }
+
+    // URB setup
+    urb->usb_host_client = (void *) probe_drv;   // Client is an address of the probe driver object
+    urb->transfer.callback = probe_control_transfer_complete;
+    // Driver setup
+    probe_drv->constant.urb = urb;
+    probe_drv->constant.proc_req_cb = config->proc_req_cb;
+    probe_drv->constant.proc_req_cb_arg = config->proc_req_cb_arg;
+    probe_drv->constant.probe_event_cb = config->probe_event_cb;
+    probe_drv->constant.probe_event_cb_arg = config->probe_event_cb_arg;
+    probe_drv->single_thread.stage = PROBE_STAGE_IDLE;
+
+    if (p_probe_driver != NULL) {
+        ret = ESP_ERR_INVALID_STATE;
+        goto err;
+    }
+
+    p_probe_driver = probe_drv;
+    *client_ret = (void *)probe_drv;
+
+    ESP_LOGD(PROBE_TAG, "USB Host probe driver installed");
+    return ESP_OK;
+
+err:
+    urb_free(urb);
+alloc_err:
+    heap_caps_free(probe_drv);
+    return ret;
+}
+
+esp_err_t probe_uninstall(void)
+{
+    PROBE_CHECK(p_probe_driver != NULL, ESP_ERR_INVALID_STATE);
+    PROBE_CHECK(p_probe_driver->single_thread.stage == PROBE_STAGE_IDLE, ESP_ERR_NOT_FINISHED);
+
+    probe_driver_t *probe_drv = p_probe_driver;
+    p_probe_driver = NULL;
+    // Free memory
+    urb_free(probe_drv->constant.urb);
+    heap_caps_free(probe_drv);
+    return ESP_OK;
+}
+
+esp_err_t probe_start(unsigned int uid)
+{
+    PROBE_CHECK(p_probe_driver != NULL, ESP_ERR_INVALID_STATE);
+    PROBE_CHECK(p_probe_driver->single_thread.stage == PROBE_STAGE_IDLE, ESP_ERR_NOT_FINISHED);
+
+    // Check if enum lock is taken for this device's uid
+    bool enum_locked;
+    ESP_RETURN_ON_ERROR(usbh_dev_enum_is_locked_by_uid(uid, &enum_locked), PROBE_TAG, "Failed to get device enum lock");
+    PROBE_CHECK(!enum_locked, ESP_ERR_NOT_SUPPORTED);
+
+    usb_device_handle_t dev_hdl;
+    esp_err_t ret = usbh_devs_open_uid(uid, &dev_hdl);
+    if (ret != ESP_OK) {
+        ESP_LOGE(PROBE_TAG, "Failed to open device uid %u: %s", uid, esp_err_to_name(ret));
+        return ret;
+    }
+
+    usb_device_info_t dev_info;
+    ESP_ERROR_CHECK(usbh_dev_get_info(dev_hdl, &dev_info));
+
+    uint8_t ctrl_ep_mps = (dev_info.speed == USB_SPEED_LOW) ? 8 : 64;
+    const usb_device_desc_t *dev_desc = NULL;
+    // Try to get cached device descriptor of the device
+    if (usbh_dev_get_desc(dev_hdl, &dev_desc) == ESP_OK && dev_desc != NULL) {
+        ctrl_ep_mps = dev_desc->bMaxPacketSize0;
+    }
+
+    ESP_LOGI(PROBE_TAG, "Start post-light-sleep probe for uid %u", uid);
+
+    p_probe_driver->single_thread.stage = PROBE_STAGE_GET_DEV_DESC;
+    p_probe_driver->single_thread.node_uid = uid;
+    p_probe_driver->single_thread.dev_hdl = dev_hdl;
+    p_probe_driver->single_thread.ep0_mps = ctrl_ep_mps;
+    p_probe_driver->single_thread.probe_passed = false;
+    p_probe_driver->constant.urb->transfer.context = (void *)dev_hdl;
+
+    // Request processing
+    p_probe_driver->constant.proc_req_cb(USB_PROC_REQ_SOURCE_PROBE, false, p_probe_driver->constant.proc_req_cb_arg);
+    return ESP_OK;
+}
+
+esp_err_t probe_cancel(unsigned int uid)
+{
+    (void)uid;
+    PROBE_CHECK(p_probe_driver != NULL, ESP_ERR_INVALID_STATE);
+
+    const probe_stage_t stage = p_probe_driver->single_thread.stage;
+    if (stage == PROBE_STAGE_IDLE || stage == PROBE_STAGE_DONE) {
+        return ESP_OK;
+    }
+
+    ESP_LOGV(PROBE_TAG, "Cancel at %s", probe_stage_strings[stage]);
+    p_probe_driver->single_thread.probe_passed = false;
+    p_probe_driver->single_thread.stage = PROBE_STAGE_DONE;
+
+    // Request processing
+    p_probe_driver->constant.proc_req_cb(USB_PROC_REQ_SOURCE_PROBE, false, p_probe_driver->constant.proc_req_cb_arg);
+    return ESP_OK;
+}
+
+esp_err_t probe_process(void)
+{
+    PROBE_CHECK(p_probe_driver != NULL, ESP_ERR_INVALID_STATE);
+    const probe_stage_t stage = p_probe_driver->single_thread.stage;
+
+    switch (stage) {
+    case PROBE_STAGE_GET_DEV_DESC:
+        probe_get_dev_desc(stage);
+        break;
+    case PROBE_STAGE_CHECK_DEV_DESC:
+        probe_check_dev_desc();
+        break;
+    case PROBE_STAGE_DONE:
+        probe_stage_done();
+        break;
+    default:
+        abort();
+        break;
+    }
+
+    return ESP_OK;
+}

--- a/host/usb/src/usbh.c
+++ b/host/usb/src/usbh.c
@@ -1168,27 +1168,78 @@ unlock:
     xSemaphoreGive(p_usbh_obj->constant.mux_lock);
     return ret;
 }
+
 #endif // AUTO_PM_LIGHT_SLEEP
+
+/**
+ * @brief Decode PM related device control commands to device actions flags
+ *
+ * @param[in] device_ctrl Device control command
+ * @param[out] dev_actions_flags Pointer to resulting device actions flags
+ */
+static void usbh_pm_actions_decode(usbh_dev_ctrl_t device_ctrl, uint32_t *dev_actions_flags)
+{
+    if (!dev_actions_flags) {
+        return;
+    }
+
+    if (device_ctrl & USBH_DEV_SUSPEND) {
+        *dev_actions_flags |= (DEV_ACTION_EPn_HALT_FLUSH | DEV_ACTION_EP0_FLUSH);
+    }
+
+    if (device_ctrl & USBH_DEV_RESUME) {
+        *dev_actions_flags |= (DEV_ACTION_EP0_CLEAR | DEV_ACTION_EPn_CLEAR);
+    }
+
+    if (device_ctrl & USBH_DEV_SUSPEND_EVT) {
+        *dev_actions_flags |= DEV_ACTION_PROP_SUSPEND_EVT;
+    }
+
+    if (device_ctrl & USBH_DEV_RESUME_EVT) {
+        *dev_actions_flags |= DEV_ACTION_PROP_RESUME_EVT;
+    }
+}
+
+esp_err_t usbh_dev_set_pm_actions_by_uid(unsigned int uid, usbh_dev_ctrl_t device_ctrl)
+{
+    uint32_t dev_actions_flags = 0;
+    usbh_pm_actions_decode(device_ctrl, &dev_actions_flags);
+
+    device_t *dev_obj = NULL;
+    bool call_proc_req_cb = false;
+
+    USBH_ENTER_CRITICAL();
+    // Find device object from it's uid
+    dev_obj = _find_dev_from_uid(uid);
+    USBH_CHECK_FROM_CRIT(dev_obj != NULL, ESP_ERR_NOT_FOUND);
+
+    // Update device state
+    if (device_ctrl & USBH_DEV_SUSPEND_EVT) {
+        // Change device state to suspended and backup the current device state for resuming
+        dev_obj->dynamic.last_state = dev_obj->dynamic.state;
+        dev_obj->dynamic.state = USB_DEVICE_STATE_SUSPENDED;
+    }
+    if (device_ctrl & USBH_DEV_RESUME_EVT) {
+        // Set the device state, to the state in which it was before suspending
+        dev_obj->dynamic.state = dev_obj->dynamic.last_state;
+    }
+
+    call_proc_req_cb |= _dev_set_actions(dev_obj, dev_actions_flags);
+    USBH_EXIT_CRITICAL();
+
+    if (call_proc_req_cb) {
+        p_usbh_obj->constant.proc_req_cb(USB_PROC_REQ_SOURCE_USBH, false, p_usbh_obj->constant.proc_req_cb_arg);
+    }
+
+    return ESP_OK;
+
+}
 
 void usbh_devs_set_pm_actions_all(usbh_dev_ctrl_t device_ctrl)
 {
     // Decode the device_ctrl to dev_actions flags
     uint32_t dev_actions_flags = 0;
-    if (device_ctrl & USBH_DEV_SUSPEND) {
-        dev_actions_flags |= (DEV_ACTION_EPn_HALT_FLUSH | DEV_ACTION_EP0_FLUSH);
-    }
-
-    if (device_ctrl & USBH_DEV_RESUME) {
-        dev_actions_flags |= (DEV_ACTION_EP0_CLEAR | DEV_ACTION_EPn_CLEAR);
-    }
-
-    if (device_ctrl & USBH_DEV_SUSPEND_EVT) {
-        dev_actions_flags |= DEV_ACTION_PROP_SUSPEND_EVT;
-    }
-
-    if (device_ctrl & USBH_DEV_RESUME_EVT) {
-        dev_actions_flags |= DEV_ACTION_PROP_RESUME_EVT;
-    }
+    usbh_pm_actions_decode(device_ctrl, &dev_actions_flags);
 
     USBH_ENTER_CRITICAL();
     /*
@@ -1483,6 +1534,22 @@ esp_err_t usbh_dev_enum_unlock(usb_device_handle_t dev_hdl)
     USBH_EXIT_CRITICAL();
 
     return ret;
+}
+
+esp_err_t usbh_dev_enum_is_locked_by_uid(unsigned int uid, bool *is_locked)
+{
+    USBH_CHECK(is_locked != NULL, ESP_ERR_INVALID_ARG);
+
+    USBH_ENTER_CRITICAL();
+    device_t *dev_obj = _find_dev_from_uid(uid);
+    USBH_CHECK_FROM_CRIT(dev_obj != NULL, ESP_ERR_NOT_FOUND);
+    if (dev_obj->dynamic.flags.enum_lock) {
+        *is_locked = true;
+    } else {
+        *is_locked = false;
+    }
+    USBH_EXIT_CRITICAL();
+    return ESP_OK;
 }
 
 esp_err_t usbh_dev_set_ep0_mps(usb_device_handle_t dev_hdl, uint16_t wMaxPacketSize)


### PR DESCRIPTION
## The problem

USB Enabled targets with FS/LS root ports can't detect device reconnect during light sleep. Currently, the Host:
- treats the reconnect in light sleep as a suspend sequence
- does not recognize device being power-cycled (reconnect) during light sleep
- does not recognize different device being connected during light sleep, new device is not enumerated
- interaction with the stale device would fail

## The Fix

This PR adds a feature that fixes this limitation:
- adding `usb_host_probe.c` module
- only compiled for FS targets when automatic suspend with light sleep is enabled
- USB Host issues a get descriptor transfer to probe the device and checks if the device is in addressed state
  - device in addressed state: no device reconnect during light sleep, device works as usual
  - device not in addressed state: device reconnected during light sleep (or another device connected) -> port reset

## Related

- IDF-16000 USB Host FS Port in light sleep device reconnect

TODO:
- [ ] Automatic re-enumeration after stale device detected
- [ ] Client events `new device` / `device gone` shall be delivered to client after stale device detected (port reset)
- [ ] Support for port reset in USBH/USB Host layers

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
