### PR TITLE
fix(uvc_host): do not abort in stream_close when device is stalled/disconnected (IEC-572)

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed ISOC handling so empty packets with invalid UVC payload headers do not discard the current frame.
 - Fixed basic UVC stream example to support MJPEG frame buffer size estimation
+- Fixed `uvc_host_stream_close()` aborting the whole system (`ESP_ERROR_CHECK`) when the device is stalled or disconnected; interface release failure is now logged and cleanup continues (https://github.com/espressif/esp-usb/issues/529)
 
 ## [2.5.1] - 2026-05-25
 

--- a/host/class/uvc/usb_host_uvc/host_test/main/opening/test_opening.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/opening/test_opening.cpp
@@ -133,6 +133,12 @@ SCENARIO("Test mocked device opening and closing", "[opening]")
             REQUIRE(ESP_OK == test_uvc_host_stream_close(stream));
         }
 
+        THEN("Stream close cleans up after interface release failure") {
+            uvc_host_stream_hdl_t stream = nullptr;
+            REQUIRE(ESP_OK == test_uvc_host_stream_open(&stream_config, 0, &stream, true));
+            REQUIRE(ESP_OK == test_uvc_host_stream_close(stream, ESP_ERR_INVALID_STATE));
+        }
+
         THEN("Multiple streams can be opened") {
             uvc_host_stream_hdl_t stream[10];
 

--- a/host/class/uvc/usb_host_uvc/host_test/main/test_fixtures.cpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/test_fixtures.cpp
@@ -93,9 +93,9 @@ esp_err_t test_uvc_host_stream_open(const uvc_host_stream_config_t *stream_confi
     return uvc_host_stream_open(stream_config, timeout, stream_hdl_ret);
 }
 
-esp_err_t test_uvc_host_stream_close(uvc_host_stream_hdl_t stream_hdl)
+esp_err_t test_uvc_host_stream_close(uvc_host_stream_hdl_t stream_hdl, esp_err_t interface_release_ret)
 {
-    usb_host_interface_release_ExpectAnyArgsAndReturn(ESP_OK); // Release data interface
+    usb_host_interface_release_ExpectAnyArgsAndReturn(interface_release_ret); // Release data interface
     usb_host_transfer_free_Stub(usb_host_transfer_free_mock_callback); // Free all transfers
     usb_host_device_close_ExpectAnyArgsAndReturn(ESP_OK);      // Close the device
 

--- a/host/class/uvc/usb_host_uvc/host_test/main/test_fixtures.hpp
+++ b/host/class/uvc/usb_host_uvc/host_test/main/test_fixtures.hpp
@@ -12,4 +12,4 @@
 esp_err_t test_uvc_host_install(const uvc_host_driver_config_t *driver_config);
 esp_err_t test_uvc_host_uninstall(void);
 esp_err_t test_uvc_host_stream_open(const uvc_host_stream_config_t *stream_config, int timeout, uvc_host_stream_hdl_t *stream_hdl_ret, bool is_isoc);
-esp_err_t test_uvc_host_stream_close(uvc_host_stream_hdl_t stream_hdl);
+esp_err_t test_uvc_host_stream_close(uvc_host_stream_hdl_t stream_hdl, esp_err_t interface_release_ret = ESP_OK);

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -922,14 +922,7 @@ esp_err_t uvc_host_stream_close(uvc_host_stream_hdl_t stream_hdl)
     }
 
     // Release all interfaces
-    // Do not assert here: with a stalled or disconnected device usb_host_interface_release()
-    // legitimately returns an error (e.g. ESP_ERR_INVALID_STATE). That is a normal runtime
-    // condition, and this close path is exactly what the application needs to recover from it.
-    // Log the failure and continue the cleanup so the stream resources are still freed.
-esp_err_t rel_ret = usb_host_interface_release(p_uvc_host_driver->usb_client_hdl, uvc_stream->constant.dev_hdl, uvc_stream->constant.bInterfaceNumber);
-if (rel_ret != ESP_OK) {
-    ESP_LOGW(TAG, "Interface release failed: %s (device gone?), continuing cleanup", esp_err_to_name(rel_ret));
-}
+    ESP_ERROR_CHECK_WITHOUT_ABORT(usb_host_interface_release(p_uvc_host_driver->usb_client_hdl, uvc_stream->constant.dev_hdl, uvc_stream->constant.bInterfaceNumber));
 
     UVC_ENTER_CRITICAL();
     SLIST_REMOVE(&p_uvc_host_driver->uvc_stream_list, uvc_stream, uvc_host_stream_s, list_entry);

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -926,10 +926,10 @@ esp_err_t uvc_host_stream_close(uvc_host_stream_hdl_t stream_hdl)
     // legitimately returns an error (e.g. ESP_ERR_INVALID_STATE). That is a normal runtime
     // condition, and this close path is exactly what the application needs to recover from it.
     // Log the failure and continue the cleanup so the stream resources are still freed.
-    esp_err_t rel_ret = usb_host_interface_release(p_uvc_host_driver->usb_client_hdl, uvc_stream->constant.dev_hdl, uvc_stream->constant.bInterfaceNumber);
-    if (rel_ret != ESP_OK) {
-        ESP_LOGE(TAG, "Interface release failed: %s (device gone?), continuing cleanup", esp_err_to_name(rel_ret));
-    }
+esp_err_t rel_ret = usb_host_interface_release(p_uvc_host_driver->usb_client_hdl, uvc_stream->constant.dev_hdl, uvc_stream->constant.bInterfaceNumber);
+if (rel_ret != ESP_OK) {
+    ESP_LOGW(TAG, "Interface release failed: %s (device gone?), continuing cleanup", esp_err_to_name(rel_ret));
+}
 
     UVC_ENTER_CRITICAL();
     SLIST_REMOVE(&p_uvc_host_driver->uvc_stream_list, uvc_stream, uvc_host_stream_s, list_entry);

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -922,7 +922,14 @@ esp_err_t uvc_host_stream_close(uvc_host_stream_hdl_t stream_hdl)
     }
 
     // Release all interfaces
-    ESP_ERROR_CHECK(usb_host_interface_release(p_uvc_host_driver->usb_client_hdl, uvc_stream->constant.dev_hdl, uvc_stream->constant.bInterfaceNumber));
+    // Do not assert here: with a stalled or disconnected device usb_host_interface_release()
+    // legitimately returns an error (e.g. ESP_ERR_INVALID_STATE). That is a normal runtime
+    // condition, and this close path is exactly what the application needs to recover from it.
+    // Log the failure and continue the cleanup so the stream resources are still freed.
+    esp_err_t rel_ret = usb_host_interface_release(p_uvc_host_driver->usb_client_hdl, uvc_stream->constant.dev_hdl, uvc_stream->constant.bInterfaceNumber);
+    if (rel_ret != ESP_OK) {
+        ESP_LOGE(TAG, "Interface release failed: %s (device gone?), continuing cleanup", esp_err_to_name(rel_ret));
+    }
 
     UVC_ENTER_CRITICAL();
     SLIST_REMOVE(&p_uvc_host_driver->uvc_stream_list, uvc_stream, uvc_host_stream_s, list_entry);


### PR DESCRIPTION
Fixes https://github.com/espressif/esp-usb/issues/529

### Problem

`uvc_host_stream_close()` wraps `usb_host_interface_release()` in `ESP_ERROR_CHECK`. When the UVC device has stalled or disconnected at the hardware level, that call legitimately returns `ESP_ERR_INVALID_STATE` — and the assert turns a normal, recoverable runtime condition into `abort()` + full system reset, precisely on the path an application must use to recover (close → reopen).

Field evidence (ESP32-P4, IDF v5.5.2, usb_host_uvc 2.5.1, camera stalls spontaneously):

```
E (5436016) uvc: uvc_host_usb_ctrl(1151): CTRL timeout
ESP_ERROR_CHECK failed: esp_err_t 0x103 (ESP_ERR_INVALID_STATE)
file: uvc_host.c line 925, func: uvc_host_stream_close
abort() was called ... rst:0xc (SW_CPU_RESET)
```

### Fix

Log the release failure and continue the cleanup (list removal + `uvc_device_remove()`), so stream resources are still freed and the application can recover. This mirrors:

- the open-path error handling in the same file (`err:` label calls `usb_host_interface_release()` unchecked), and
- the `hid_host` fix for the same failure pattern in #470.

Also adds a CHANGELOG entry under Unreleased/Fixed.

### Testing\n\n- Added a UVC Linux host regression test that forces `usb_host_interface_release()` to return `ESP_ERR_INVALID_STATE` and verifies `uvc_host_stream_close()` still returns `ESP_OK` while cleanup completes.\n- Local UVC host suite with `espressif/idf:latest`: 17 test cases, 7,253 assertions passed.\n- Local `pre-commit run --all-files`: passed.\n\nRunning in production on an always-on ESP32-P4 device (24/7 UVC MJPEG streaming with a camera unit that stalls every few hours): before the patch every stall escalated to a watchdog-visible full reboot (~25 s outage, secondary chip reset included); with the patch the same stall degrades to a ~15 s frozen picture followed by clean close/reopen recovery. No resource leaks observed across repeated stall/recover cycles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the USB stream teardown path on error conditions; behavior change is intentional (no abort) but apps no longer get a hard failure signal from `stream_close` when release fails.
> 
> **Overview**
> **`uvc_host_stream_close()`** no longer aborts the system when `usb_host_interface_release()` returns an error (e.g. `ESP_ERR_INVALID_STATE` after a stall or disconnect). The release call now uses **`ESP_ERROR_CHECK_WITHOUT_ABORT`**, so the failure is logged and teardown still runs (remove from stream list, `uvc_device_remove()`), allowing apps to close and reopen instead of resetting.
> 
> Host tests gain a **`test_uvc_host_stream_close(..., interface_release_ret)`** hook and a case that asserts close returns **`ESP_OK`** when the mocked release fails. **CHANGELOG** documents the fix (issue #529).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396a3a03ca1b76312d93bd9bcfac849bb5c83776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->