### PR TITLE
feat(esp_tinyusb): Add Power Management locks implementation

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -4,6 +4,15 @@ device/esp_tinyusb:
   enable:
     - if: SOC_USB_OTG_SUPPORTED == 1
 
+device/esp_tinyusb/test_apps/power_management:
+  depends_filepatterns:
+    - 'device/esp_tinyusb/**'
+  disable:
+    - if: CONFIG_NAME in ["otg_wake", "pm_otg_wake"] and IDF_TARGET not in ["esp32p4", "esp32s31"]
+      reason: USB OTG wakeup test configs only apply to esp32p4 and esp32s31
+  enable:
+    - if: SOC_USB_OTG_SUPPORTED == 1
+
 host/class/cdc:
   depends_filepatterns:
     - 'host/class/cdc/**'

--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- esp_tinyusb: Added power management lock to control automatic light sleep entry based on Device events
+- esp_tinyusb: Added USB Peripheral light sleep wake-up source integration to the esp_tinyusb (only available for USB HS ports)
+
 ## 2.2.1
 
 - esp_tinyusb: Add an explicit `tinyusb` dependency when the IDF component manager is disabled

--- a/device/esp_tinyusb/CMakeLists.txt
+++ b/device/esp_tinyusb/CMakeLists.txt
@@ -8,7 +8,10 @@ set(srcs
     "tinyusb_task.c"
     )
 
-set(priv_req "")
+# We don't use Kconfig based conditional as the Kconfig values are not evaluated yet
+# when components are being registered. Thus, always add the (private) requirements, regardless of Kconfig.
+# IDF version conditionals and Target conditionals are allowed for components
+set(priv_req esp_pm)
 set(req fatfs vfs)
 
 # USB-PHY driver
@@ -62,6 +65,16 @@ if(${target} STREQUAL "esp32p4" OR ${target} STREQUAL "esp32s31")
         list(APPEND priv_req driver)
     endif()
 endif() # esp32p4/esp32s31
+
+# TinyUSB PM locks
+if(CONFIG_TINYUSB_PM)
+    list(APPEND srcs "tinyusb_pm.c")
+endif()
+
+# USB Device light-sleep wakeup, must be also supported by the target
+if(CONFIG_TINYUSB_USB_OTG_WAKEUP)
+    list(APPEND srcs "tinyusb_usb_wakeup.c")
+endif()
 
 # idf_component.yml is ignored when the component manager is disabled, so the
 # dependency on tinyusb must be declared here instead. It belongs in REQUIRES

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -58,6 +58,88 @@ menu "TinyUSB Stack"
                 a linker error due to multiple definitions.
     endmenu # "TinyUSB callbacks"
 
+    menu "Power management"
+        # Proxy configs normalize SOC caps across IDF releases:
+        # - caps may be absent in older IDF (must stay hidden)
+        # - caps may be bool (plain "1") or int ("(1U)") in soc_caps.h
+
+        # Do not use "depends on SOC_* > 0" here as they are defined differently in different IDF releases
+        # IDF 5.4   SOC_PM_SUPPORT_USB_WAKEUP absent
+        # IDF 5.5   SOC_PM_SUPPORT_USB_WAKEUP (1U)
+        # IDF 6.1   SOC_PM_SUPPORT_USB_WAKEUP (1U)
+        # IDF 6.2   SOC_PM_SUPPORT_USB_WAKEUP 1
+
+        # Simple depends on SOC_PM_SUPPORT_USB_WAKEUP > 0 or
+        #        depends on SOC_PM_SUPPORT_USB_WAKEUP
+        # Fails in each IDF release differently
+        config TINYUSB_SOC_PM_USB_WAKEUP_SUPPORTED
+            bool
+            default y if SOC_PM_SUPPORT_USB_WAKEUP = y
+            default y if SOC_PM_SUPPORT_USB_WAKEUP = 1
+            default n
+
+        config TINYUSB_SOC_USB_UTMI_PHY_SUPPORTED
+            bool
+            default y if SOC_USB_UTMI_PHY_NUM = y
+            default y if SOC_USB_UTMI_PHY_NUM > 0
+            default n
+
+        config TINYUSB_USB_OTG_WAKEUP
+            bool "USB Device light sleep wakeup source"
+            default n
+            depends on SOC_PM_SUPPORT_CPU_PD
+            depends on SOC_PM_SUPPORT_CNNT_PD
+            depends on TINYUSB_SOC_PM_USB_WAKEUP_SUPPORTED
+            depends on TINYUSB_SOC_USB_UTMI_PHY_SUPPORTED
+            depends on TINYUSB_SUSPEND_CALLBACK
+            depends on TINYUSB_RESUME_CALLBACK
+            depends on PM_ENABLE
+            depends on FREERTOS_USE_TICKLESS_IDLE
+            depends on ESP_SLEEP_EVENT_CALLBACKS
+            help
+                Register light sleep event callbacks to prepare the UTMI PHY for USB wakeup when
+                entering light sleep while the USB bus is suspended.
+
+                Available only on USB HS ports, due to PHY limitation. The USB wakeup source
+                (esp_sleep_enable_usb_wakeup()) is enabled automatically during
+                tinyusb_driver_install(). The USB connection power domain must be kept on during
+                light sleep.
+
+                Requires the TinyUSB suspend and resume callbacks (TINYUSB_SUSPEND_CALLBACK and
+                TINYUSB_RESUME_CALLBACK) to be registered inside esp_tinyusb, so the driver is
+                notified about USB suspend/resume. Without them the wakeup state cannot be tracked
+                and the feature is not usable.
+
+                Independent of TinyUSB Power Management (PM locks). USB wakeup works whether light
+                sleep is entered manually or triggered automatically after the PM lock is released
+                on USB suspend.
+
+        config TINYUSB_PM
+            bool "Enable tinyusb Power Management"
+            default n
+            depends on TINYUSB_SUSPEND_CALLBACK
+            depends on TINYUSB_RESUME_CALLBACK
+            depends on PM_ENABLE
+            depends on FREERTOS_USE_TICKLESS_IDLE
+            help
+                Enable TinyUSB power management using ESP-IDF PM locks.
+
+                When enabled together with `tinyusb_config_t.pm_lock_enable`, esp_tinyusb creates an
+                ESP_PM_NO_LIGHT_SLEEP lock and releases it while the USB device is suspended, allowing
+                automatic light sleep when automatic light sleep is configured through esp_pm_configure().
+
+                Requires the TinyUSB suspend and resume callbacks (TINYUSB_SUSPEND_CALLBACK and
+                TINYUSB_RESUME_CALLBACK) to be registered inside esp_tinyusb. The PM lock is released
+                on USB suspend and re-acquired on USB resume, so without those events the lock would
+                never be released and automatic light sleep would never happen.
+
+                It is recommended to pair this config with the TINYUSB_USB_OTG_WAKEUP config above, so the USB
+                peripheral can act as a wakeup source from the light sleep. Without enabling the TINYUSB_USB_OTG_WAKEUP
+                the USB peripheral can NOT act as a light sleep wakeup source.
+
+    endmenu # "Power management"
+
+
     menu "Descriptor configuration"
         comment "You can provide your custom descriptors via tinyusb_driver_install()"
         config TINYUSB_DESC_USE_ESPRESSIF_VID

--- a/device/esp_tinyusb/README.md
+++ b/device/esp_tinyusb/README.md
@@ -253,6 +253,47 @@ If any descriptor field is set to `NULL`, default descriptor will be assigned du
   }
 ```
 
+### Light sleep with USB wakeup
+
+On high-speed ports (ESP32-P4 HS port and ESP32-S31), the device can wake from light sleep on USB activity while the bus is suspended.
+The feature is **NOT** available on FS/LS only ports due to PHY limitations.
+
+**USB Device wakeup** source can be enabled in menuconfig by `CONFIG_TINYUSB_USB_OTG_WAKEUP`.
+When enabled, the driver enables the USB wakeup source (`esp_sleep_enable_usb_wakeup()`) automatically
+during `tinyusb_driver_install()`.
+
+This feature depends on the esp_tinyusb suspend and resume callbacks
+(`CONFIG_TINYUSB_SUSPEND_CALLBACK` and `CONFIG_TINYUSB_RESUME_CALLBACK`, see
+[Suspend / Resume Device Events](#suspend--resume-device-events)). They are required so the driver is
+notified about USB suspend/resume and can track the light sleep wakeup state.
+
+Before using light sleep, configure the USB connection power domain on during light sleep:
+
+```c
+  esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_ON);
+```
+
+### Power management locks
+
+For automatic light sleep through PM locks on any supported target, enable **Power management** `CONFIG_TINYUSB_PM`
+in menuconfig, configure the ESP-IDF PM module and install TinyUSB with the PM lock enabled:
+
+```c
+  const esp_pm_config_t pm_config = {
+      .max_freq_mhz = CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ,
+      .min_freq_mhz = CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ,
+      .light_sleep_enable = true,
+  };
+  ESP_ERROR_CHECK(esp_pm_configure(&pm_config));
+
+  tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(event_handler);
+  tusb_cfg.pm_lock_enable = true;
+  ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
+```
+
+USB wakeup and PM locks are independent: you can use USB wakeup with manual
+`esp_light_sleep_start()` calls, with automatic light sleep via PM locks, or both.
+
 ### USB PHY configuration & Self-Powered Device
 
 USB 2.0 requires self‑powered devices to sense VBUS and only present the pull‑up (attach) when VBUS is valid. If VBUS falls out of range, the device must detach and must not back‑power the bus. TinyUSB uses VBUS presence to drive connect/disconnect events in the DCD layer, so the VBUS sense signal must be correct. More information is available [here](https://docs.espressif.com/projects/esp-usb/en/latest/esp32p4/usb_device.html#self-powered-device).

--- a/device/esp_tinyusb/include/tinyusb.h
+++ b/device/esp_tinyusb/include/tinyusb.h
@@ -119,6 +119,10 @@ typedef struct {
     tinyusb_phy_config_t phy;                /*!< USB PHY configuration. */
     tinyusb_task_config_t task;              /*!< USB device task configuration. */
     tinyusb_desc_config_t descriptor;        /*!< USB descriptor configuration. */
+    bool pm_lock_enable;                     /*!< Enable ESP_PM_NO_LIGHT_SLEEP lock management while the USB
+                                                 bus is active. When enabled, the lock is released on USB suspend
+                                                 to allow automatic light sleep. On supported high-speed targets
+                                                 this also manages UTMI OTG suspend state for USB wakeup. */
     tinyusb_event_cb_t event_cb;             /*!< Optional event callback. */
     void *event_arg;                         /*!< User argument passed to `event_cb`. */
 } tinyusb_config_t;
@@ -140,7 +144,8 @@ typedef struct {
  *      - ESP_ERR_INVALID_ARG if `config` is NULL or contains unsupported port or task settings
  *      - ESP_ERR_INVALID_STATE if the TinyUSB device task is already running
  *      - ESP_ERR_NO_MEM if memory allocation fails during startup
- *      - Other error codes from TinyUSB task startup, USB PHY setup, or descriptor setup
+ *      - Other error codes from TinyUSB task startup, USB PHY setup, descriptor setup,
+ *        or power management initialization
  */
 esp_err_t tinyusb_driver_install(const tinyusb_config_t *config);
 
@@ -166,10 +171,29 @@ esp_err_t tinyusb_driver_uninstall(void);
  *
  * @return
  *      - ESP_OK on success
- *      - ESP_ERR_INVALID_STATE if remote wakeup is not enabled by the host
+ *      - ESP_ERR_INVALID_STATE if the TinyUSB driver is not installed, or remote wakeup is not enabled by the host
+ *      - ESP_ERR_NOT_ALLOWED if the USB device is not suspended
  *      - ESP_FAIL if the remote wakeup request cannot be sent
+ *      - Other error codes from PM lock acquire when `CONFIG_TINYUSB_PM` is enabled
  */
 esp_err_t tinyusb_remote_wakeup(void);
+
+#if CONFIG_TINYUSB_PM
+/**
+ * @brief Get TinyUSB PM lock acquisition state.
+ *
+ * Returns whether the `ESP_PM_NO_LIGHT_SLEEP` lock managed by esp_tinyusb is currently held.
+ *
+ * @param[out] acquired Whether the PM lock is currently held
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if `acquired` is NULL
+ *      - ESP_ERR_INVALID_STATE if the TinyUSB driver is not installed or the PM lock is not enabled
+ */
+esp_err_t tinyusb_pm_get_lock_status(bool *acquired);
+
+#endif // CONFIG_TINYUSB_PM
 
 #ifdef __cplusplus
 }

--- a/device/esp_tinyusb/include/tinyusb_default_config.h
+++ b/device/esp_tinyusb/include/tinyusb_default_config.h
@@ -111,6 +111,7 @@ extern "C" {
             .full_speed_config = NULL,                  \
             .high_speed_config = NULL,                  \
         },                                              \
+        .pm_lock_enable = false,                        \
         .event_cb = (event_hdl),                        \
         .event_arg = (arg),                             \
     }
@@ -147,6 +148,7 @@ extern "C" {
             .full_speed_config = NULL,                  \
             .high_speed_config = NULL,                  \
         },                                              \
+        .pm_lock_enable = false,                        \
         .event_cb = (event_hdl),                        \
         .event_arg = (arg),                             \
     }

--- a/device/esp_tinyusb/include_private/tinyusb_pm.h
+++ b/device/esp_tinyusb/include_private/tinyusb_pm.h
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include "tinyusb.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief TinyUSB power management configuration.
+ */
+typedef struct {
+    bool lock_enable;                        /*!< Enable ESP_PM_NO_LIGHT_SLEEP lock management. */
+} tinyusb_pm_config_t;
+
+/**
+ * @brief Initialize TinyUSB power management according to driver configuration
+ *
+ * When the pm lock is enabled, this function creates an `ESP_PM_NO_LIGHT_SLEEP` lock
+ * and acquires it.
+ *
+ * @note without acquiring the lock immediately after creating it, the PM module would automatically enter
+ * the light sleep (if no other locks are used in the app) and the USB Device would not even be mounted to the USB host
+ *
+ * @param[in] config PM configuration
+ *
+ * @return
+ *      - ESP_OK on success, or PM Lock is not enabled by the user
+ *      - ESP_ERR_INVALID_ARG if the argument is not valid
+ *      - ESP_ERR_INVALID_STATE if the PM module is already initialized
+ *      - Other error codes from called functions
+ */
+esp_err_t tinyusb_pm_init(const tinyusb_pm_config_t *config);
+
+/**
+ * @brief Tear down TinyUSB power management
+ *
+ * Releases the PM lock when it was enabled and deletes the lock object.
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - Other error codes from called functions
+ */
+esp_err_t tinyusb_pm_deinit(void);
+
+/**
+ * @brief Update PM lock state based on a TinyUSB device event
+ *
+ * On supported events it acquires or releases the PM lock when the USB bus is attached,
+ * detached, suspended, or resumed.
+ *
+ * @param[in] event TinyUSB device event
+ */
+void tinyusb_pm_on_event(tinyusb_event_t *event);
+
+/**
+ * @brief Update PM lock state based on user's remote wakeup call
+ *
+ * In case the TINYUSB_USB_OTG_WAKEUP is not enabled, or not supported the SoC can be woken from light sleep using
+ * different source than the USB peripheral (timer, gpio..) the user can call remote wakeup which effectively resumes
+ * the USB peripheral. The remote wakeup takes some time to finish, thus we need to acquire the PM lock in the meanwhile
+ * to restrict the SoC from entering the light sleep automatically while waiting for the remote wakeup to complete.
+ *
+ * @return
+ *   - ESP_OK on success, or when the PM lock is not enabled (no-op)
+ *   - Other error codes from called functions
+ */
+esp_err_t tinyusb_pm_remote_wake(void);
+
+/**
+ * @brief Get TinyUSB PM lock acquisition state
+ *
+ * @param[out] lock_taken PM lock acquisition state
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if the argument is not valid
+ *      - ESP_ERR_INVALID_STATE if the PM lock is not enabled
+ */
+esp_err_t tinyusb_pm_lock_get(bool *lock_taken);
+
+#ifdef __cplusplus
+}
+#endif

--- a/device/esp_tinyusb/include_private/tinyusb_usb_wakeup.h
+++ b/device/esp_tinyusb/include_private/tinyusb_usb_wakeup.h
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include "tinyusb.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Acquire the PM lock after exiting light sleep while USB remains suspended
+ *
+ * Called from the light-sleep exit callback once UTMI OTG state has been restored.
+ * Intended for use by `tinyusb_pm.c` to re-acquire `ESP_PM_NO_LIGHT_SLEEP` immediately
+ * after waking from light sleep on USB activity.
+ *
+ * @return
+ *      - ESP_OK on success, when the PM lock is not enabled, or when the device is not in USB suspend PM state
+ *      - Other error codes from PM lock acquire
+ */
+typedef esp_err_t (*tinyusb_usb_wakeup_pm_lock_acquire_cb_t)(void);
+
+/**
+ * @brief Query USB suspend PM state before entering light sleep
+ *
+ * Called from the light-sleep enter callback to decide whether UTMI OTG suspend
+ * preparation is required. Intended for use by `tinyusb_pm.c` to read the PM
+ * module's synchronized suspend state when PM locks are enabled.
+ *
+ * @return True when the device is in USB suspend PM state
+ */
+typedef bool (*tinyusb_usb_wakeup_pm_state_cb_t)(void);
+
+/**
+ * @brief Optional PM integration callbacks for USB light-sleep wakeup
+ *
+ * Register both handlers together via `tinyusb_usb_wakeup_register_pm_cbs()`.
+ * Pass NULL to `tinyusb_usb_wakeup_register_pm_cbs()` to clear all handlers.
+ */
+typedef struct {
+    tinyusb_usb_wakeup_pm_state_cb_t pm_state;                /*!< Query USB suspend PM state on sleep enter, or NULL to use `tud_suspended()` */
+    tinyusb_usb_wakeup_pm_lock_acquire_cb_t acquire_pm_lock;  /*!< Acquire PM lock on sleep exit, or NULL to skip */
+} tinyusb_usb_wakeup_pm_cbs_t;
+
+/**
+ * @brief Register or clear PM integration callbacks for USB light-sleep wakeup
+ *
+ * @param[in] cbs Callback group to register, or NULL to clear all callbacks
+ */
+void tinyusb_usb_wakeup_register_pm_cbs(const tinyusb_usb_wakeup_pm_cbs_t *cbs);
+
+/**
+ * @brief Initialize USB Device light-sleep wakeup integration
+ *
+ * Registers light-sleep event callbacks that prepare and restore UTMI OTG suspend state
+ * when entering or exiting light sleep while the USB bus is suspended.
+ * Also enables USB as a light-sleep wakeup source via `esp_sleep_enable_usb_wakeup()`.
+ *
+ * @param[in] port USB port used by the driver
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - Other error codes from light-sleep callback registration
+ */
+esp_err_t tinyusb_usb_wakeup_init(tinyusb_port_t port);
+
+/**
+ * @brief Tear down USB Device light-sleep wakeup integration
+ *
+ * Unregisters light-sleep callbacks and restores UTMI OTG suspend state if needed.
+ * Also disables the USB light-sleep wakeup source via `esp_sleep_disable_usb_wakeup()`.
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - Other error codes from light-sleep callback unregistration
+ */
+esp_err_t tinyusb_usb_wakeup_deinit(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/device/esp_tinyusb/test_apps/power_management/README.md
+++ b/device/esp_tinyusb/test_apps/power_management/README.md
@@ -7,6 +7,7 @@ The tests focus on:
 - Power management of the USB Device
 - Testing tinyusb suspend/resume callbacks delivery
 - Testing remote wakeup signalizing by the device
+- Testing USB light-sleep wakeup on high-speed ports
 - Calling esp_tinyusb public API when the USB Device is in suspended state
 - Init/Deinit of esp_tinyusb driver with device in suspended state
 

--- a/device/esp_tinyusb/test_apps/power_management/main/common_pm.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/common_pm.c
@@ -1,0 +1,261 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+
+#include <stdio.h>
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/semphr.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "unity.h"
+#include "tinyusb.h"
+#include "tinyusb_default_config.h"
+#include "tinyusb_cdc_acm.h"
+#include "tusb_config.h"
+#include "sdkconfig.h"
+#include "common_pm.h"
+
+#if (CONFIG_PM_ENABLE)
+#include "esp_pm.h"
+#endif // CONFIG_PM_ENABLE
+
+// ----------------------------------------------- Static declarations -------------------------------------------------
+
+static const char *TAG = "PM_Common";
+
+static char err_msg_buf[128];
+
+// Static event group for device event delivery
+static EventGroupHandle_t device_event_group = NULL;
+static StaticEventGroup_t device_event_group_buffer;
+// Static binary semaphore for RX data callback
+static SemaphoreHandle_t rx_data_sem = NULL;
+static StaticSemaphore_t rx_data_sem_buffer;
+
+static const tusb_desc_device_t cdc_device_descriptor = {
+    .bLength = sizeof(cdc_device_descriptor),
+    .bDescriptorType = TUSB_DESC_DEVICE,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .idVendor = TINYUSB_ESPRESSIF_VID,
+    .idProduct = 0x4002,
+    .bcdDevice = 0x0100,
+    .iManufacturer = 0x01,
+    .iProduct = 0x02,
+    .iSerialNumber = 0x03,
+    .bNumConfigurations = 0x01
+};
+
+#if (TUD_OPT_HIGH_SPEED)
+static const tusb_desc_device_qualifier_t device_qualifier = {
+    .bLength = sizeof(tusb_desc_device_qualifier_t),
+    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .bNumConfigurations = 0x01,
+    .bReserved = 0
+};
+#endif // TUD_OPT_HIGH_SPEED
+
+static tinyusb_config_cdcacm_t acm_cfg = {
+    .cdc_port = TINYUSB_CDC_ACM_0,
+    .callback_rx = NULL,
+    .callback_rx_wanted_char = NULL,
+    .callback_line_state_changed = NULL,
+    .callback_line_coding_changed = NULL
+};
+
+static const uint16_t cdc_desc_config_len = TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN;
+static const uint8_t cdc_desc_configuration_remote_wakeup[] = {
+    TUD_CONFIG_DESCRIPTOR(1, 2, 0, cdc_desc_config_len, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CDC_DESCRIPTOR(0, 4, 0x81, 8, 0x02, 0x82, (TUD_OPT_HIGH_SPEED ? 512 : 64)),
+};
+
+// ---------------------------------------------------- Private API -----------------------------------------------------
+
+/**
+ * @brief CDC Device RX callback
+ */
+static void tinyusb_cdc_rx_callback(int itf, cdcacm_event_t *event)
+{
+    if (rx_data_sem != NULL) {
+        ESP_LOGI(TAG, "RX data cb");
+        xSemaphoreGive(rx_data_sem);
+    }
+}
+
+/**
+ * @brief Device event handler providing event group bits
+ */
+static void device_event_handler(tinyusb_event_t *event, void *arg)
+{
+    uint32_t event_bits = UINT32_MAX;
+
+    switch (event->id) {
+    case TINYUSB_EVENT_ATTACHED:
+        printf("TINYUSB_EVENT_ATTACHED\n");
+        event_bits = EVENT_BITS_ATTACHED;
+        break;
+    case TINYUSB_EVENT_DETACHED:
+        printf("TINYUSB_EVENT_DETACHED\n");
+        event_bits = EVENT_BITS_DETACHED;
+        break;
+#if CONFIG_TINYUSB_SUSPEND_CALLBACK
+    case TINYUSB_EVENT_SUSPENDED:
+        if (event->suspended.remote_wakeup) {
+            printf("TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_EN\n");
+            event_bits = EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN;
+        } else {
+            printf("TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_DIS\n");
+            event_bits = EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS;
+        }
+        break;
+#endif // CONFIG_TINYUSB_SUSPEND_CALLBACK
+#if CONFIG_TINYUSB_RESUME_CALLBACK
+    case TINYUSB_EVENT_RESUMED:
+        printf("TINYUSB_EVENT_RESUMED\n");
+        event_bits = EVENT_BITS_RESUMED;
+        break;
+#endif // CONFIG_TINYUSB_RESUME_CALLBACK
+    default:
+        return;
+    }
+
+    if (device_event_group != NULL) {
+        xEventGroupSetBits(device_event_group, event_bits);
+    }
+}
+
+/**
+ * @brief Expect device event
+ *
+ * @param[in] expected_event Expected device event
+ * @param[in] ticks time to expect the event
+ * @param[in] file file from which the function was called
+ * @param[in] line line from which the function was called
+ */
+void expect_device_event_impl(const uint32_t expected_event, TickType_t ticks, const char *file, int line)
+{
+    const EventBits_t bits = xEventGroupWaitBits(device_event_group, expected_event, pdTRUE, pdTRUE, ticks);
+    if ((bits & expected_event) == expected_event) {
+        return;
+    }
+
+    if (bits != 0) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf),
+                 "Unexpected event at %s:%d\n %ld expected, %ld delivered\n",
+                 file, line, expected_event, (uint32_t)bits);
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
+
+    snprintf(err_msg_buf, sizeof(err_msg_buf),
+             "Event %ld at %s:%d\n was not delivered on time",
+             expected_event, file, line);
+    TEST_FAIL_MESSAGE(err_msg_buf);
+}
+
+SemaphoreHandle_t test_pm_get_rx_sem(void)
+{
+    return rx_data_sem;
+}
+
+/**
+ * @brief Initialize freertos power management
+ */
+static void test_esp_pm_init(const bool light_sleep_enable)
+{
+#if CONFIG_TINYUSB_PM
+    esp_pm_config_t pm_config = {
+        .max_freq_mhz = CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ,
+        .min_freq_mhz = CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ,
+        .light_sleep_enable = light_sleep_enable,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, esp_pm_configure(&pm_config));
+#endif // CONFIG_TINYUSB_PM
+}
+
+/**
+ * @brief Initialize freertos primitives for the test
+ *
+ * Event group bits for device events delivery (suspend, resume, attach, detach)
+ * Semaphore for RX callback notifications
+ */
+static void test_pm_sync_init(void)
+{
+    if (device_event_group == NULL) {
+        device_event_group = xEventGroupCreateStatic(&device_event_group_buffer);
+    }
+    xEventGroupClearBits(device_event_group, DEVICE_EVENT_BITS_ALL);
+
+    if (rx_data_sem == NULL) {
+        rx_data_sem = xSemaphoreCreateBinaryStatic(&rx_data_sem_buffer);
+    }
+    while (xSemaphoreTake(rx_data_sem, 0) == pdTRUE) {
+    }
+}
+
+// ---------------------------------------------------- Public API -----------------------------------------------------
+
+/**
+ * @brief Install TinyUSB driver and initialize CDC ACM for PM tests
+ *
+ * @param[in] rx_cb     Optional CDC RX callback (may be NULL)
+ *
+ * @return tinyusb_config_t used for driver install (for reuse on reinstall)
+ */
+tinyusb_config_t test_pm_init_tinyusb_cdc(const test_pm_install_opts_t *opts)
+{
+    // Initialize freertos primitives
+    test_pm_sync_init();
+
+    // Initialize ESP_PM module
+    test_esp_pm_init(opts->auto_light_sleep_enable);
+
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(device_event_handler);
+    tusb_cfg.descriptor.device = &cdc_device_descriptor;
+    tusb_cfg.descriptor.full_speed_config = cdc_desc_configuration_remote_wakeup;
+#if (TUD_OPT_HIGH_SPEED)
+    tusb_cfg.descriptor.qualifier = &device_qualifier;
+    tusb_cfg.descriptor.high_speed_config = cdc_desc_configuration_remote_wakeup;
+#endif // TUD_OPT_HIGH_SPEED
+
+    tusb_cfg.pm_lock_enable = opts->pm_lock_enable;
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+    acm_cfg.callback_rx = tinyusb_cdc_rx_callback;
+    TEST_ASSERT_FALSE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_init(&acm_cfg));
+    TEST_ASSERT_TRUE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
+
+    return tusb_cfg;
+}
+
+void test_pm_assert_lock_acquired(bool expected_acquired)
+{
+#if CONFIG_TINYUSB_PM
+    bool lock_held;
+    const esp_err_t err = tinyusb_pm_get_lock_status(&lock_held);
+
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, err, "Tinyusb PM lock read error");
+    TEST_ASSERT_EQUAL_MESSAGE(expected_acquired, lock_held, "Tinyusb PM lock assert error");
+#else
+    (void)expected_acquired;
+    TEST_FAIL_MESSAGE("TinyUSB PM lock Not available");
+#endif // CONFIG_TINYUSB_PM
+}
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/power_management/main/common_pm.h
+++ b/device/esp_tinyusb/test_apps/power_management/main/common_pm.h
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/event_groups.h"
+#include "esp_bit_defs.h"
+#include "tinyusb.h"
+#include "tinyusb_cdc_acm.h"
+#include "tusb_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DEVICE_EVENT_WAIT_MS                    5000    /** Maximum time to wait for a device event, in milliseconds. */
+#define DATA_RECEPTION_WAIT_MS                  7000    /** Maximum time to wait for CDC RX data, in milliseconds. */
+#define SUSPEND_RESUME_TEST_ITERATIONS          5       /** Number of host-driven suspend/resume iterations in PM loop tests. */
+#define PM_LIGHT_SLEEP_TIMER_US                 (2 * 1000 * 1000ULL) /** Light sleep timer wakeup period for PM-only tests, in microseconds. */
+#define PM_LIGHT_SLEEP_WAKE_WAIT_MS             10000   /** Maximum time to wait for a timer light sleep wakeup, in milliseconds. */
+#define TINYUSB_CDC_RX_BUFSIZE                  CONFIG_TINYUSB_CDC_RX_BUFSIZE
+
+#define EVENT_BITS_ATTACHED                     BIT0    /**< Device attached event */
+#define EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN     BIT1    /**< Device suspended with remote wakeup enabled event */
+#define EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS    BIT2    /**< Device suspended with remote wakeup disabled event */
+#define EVENT_BITS_RESUMED                      BIT3    /**< Device resumed event */
+#define EVENT_BITS_DETACHED                     BIT4    /**< Device detached event */
+
+/** @brief Bit mask of all device event bits used by the PM test helpers. */
+#define DEVICE_EVENT_BITS_ALL   (EVENT_BITS_ATTACHED |                  \
+                                 EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN  | \
+                                 EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS | \
+                                 EVENT_BITS_RESUMED |                   \
+                                 EVENT_BITS_DETACHED)
+
+/**
+ * @brief Runtime options for installing TinyUSB in PM test cases
+ */
+typedef struct {
+    bool pm_lock_enable;              /*!< Enable ESP_PM_NO_LIGHT_SLEEP lock in `tinyusb_config_t`. */
+    bool auto_light_sleep_enable;     /*!< Call `esp_pm_configure()` with automatic light sleep enabled. */
+} test_pm_install_opts_t;
+
+/**
+ * @brief Wait for an expected device event bit mask
+ *
+ * Fails the Unity test case when the expected bits are not received within the timeout
+ * or when a different event bit mask is delivered first.
+ *
+ * @param[in] expected_event Event bit mask from `EVENT_BITS_*`
+ * @param[in] ticks          FreeRTOS timeout in ticks
+ * @param[in] file           File from which the function was called
+ * @param[in] line           Line from which the function was called
+ */
+void expect_device_event_impl(uint32_t expected_event, TickType_t ticks, const char *file, int line);
+#define expect_device_event(expected_event, ticks) expect_device_event_impl((expected_event), (ticks), __FILE__, __LINE__)
+
+/**
+ * @brief Get the RX synchronization semaphore used by PM tests
+ *
+ * @return Binary semaphore signaled by `tinyusb_cdc_rx_callback()`
+ */
+SemaphoreHandle_t test_pm_get_rx_sem(void);
+
+/**
+ * @brief Install TinyUSB and CDC ACM using PM test helpers
+ *
+ * Initializes synchronization primitives, optionally configures esp_pm, installs the
+ * driver with the shared descriptors, and initializes CDC ACM port 0.
+ *
+ * @param[in] opts Install options for PM lock and esp_pm configuration
+ */
+tinyusb_config_t test_pm_init_tinyusb_cdc(const test_pm_install_opts_t *opts);
+
+/**
+ * @brief Assert TinyUSB PM lock acquisition state
+ *
+ * Queries `tinyusb_pm_get_lock_status()` and verifies the lock state. Prints
+ * `PM_LOCK_ACQUIRED=0/1` markers for pytest, or `PM_LOCK_UNAVAILABLE` when PM is
+ * disabled in sdkconfig.
+ *
+ * @param[in] acquired Expected lock state: `true` if the lock should be held
+ */
+void test_pm_assert_lock_acquired(bool acquired);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/power_management/main/test_app_main.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_app_main.c
@@ -50,7 +50,7 @@ void app_main(void)
     printf("  \\_/ \\____/\\____/  \\_/                            \n");
 
     unity_utils_setup_heap_record(80);
-    unity_utils_set_leak_level(128);
+    unity_utils_set_leak_level(150);
     unity_run_menu();
 }
 
@@ -66,5 +66,6 @@ void tearDown(void)
     ESP_LOGI(TAG, "Cleanup");
     tinyusb_cdcacm_deinit(TINYUSB_CDC_ACM_0);
     tinyusb_driver_uninstall();
+    esp_reent_cleanup();    //clean up some of the newlib's lazy allocations
     unity_utils_evaluate_leaks();
 }

--- a/device/esp_tinyusb/test_apps/power_management/main/test_device_pm.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_device_pm.c
@@ -10,213 +10,21 @@
 #include <stdio.h>
 #include <string.h>
 #include "esp_system.h"
+#include "esp_sleep.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "freertos/event_groups.h"
 #include "freertos/semphr.h"
 #include "esp_log.h"
 #include "esp_err.h"
-#include "esp_bit_defs.h"
-
 #include "unity.h"
 #include "tinyusb.h"
 #include "tinyusb_default_config.h"
 #include "tinyusb_cdc_acm.h"
 #include "tusb_config.h"
+#include "common_pm.h"
 #include "sdkconfig.h"
 
-#define TINYUSB_CDC_RX_BUFSIZE                  CONFIG_TINYUSB_CDC_RX_BUFSIZE
-#define SUSPEND_RESUME_TEST_ITERATIONS          5
-#define DEVICE_EVENT_WAIT_MS                    5000
-
-#define EVENT_BITS_ATTACHED                     BIT0   /**< Device attached event */
-#define EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN     BIT1   /**< Device suspended with remote wakeup enabled event */
-#define EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS    BIT2   /**< Device suspended with remote wakeup disabled event */
-#define EVENT_BITS_RESUMED                      BIT3   /**< Device resumed event */
-#define DEVICE_EVENT_BITS_ALL   (EVENT_BITS_ATTACHED | EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN | \
-                                 EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS | EVENT_BITS_RESUMED)
-
-static char err_msg_buf[128];
 const static char *TAG = "PM_Device";
-
-// Static event group for device event delivery
-static EventGroupHandle_t device_event_group = NULL;
-static StaticEventGroup_t device_event_group_buffer;
-// Static binary semaphore for RX data callback
-static SemaphoreHandle_t rx_data_sem = NULL;
-static StaticSemaphore_t rx_data_sem_buffer;
-
-static const tusb_desc_device_t cdc_device_descriptor = {
-    .bLength = sizeof(cdc_device_descriptor),
-    .bDescriptorType = TUSB_DESC_DEVICE,
-    .bcdUSB = 0x0200,
-    .bDeviceClass = TUSB_CLASS_MISC,
-    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
-    .bDeviceProtocol = MISC_PROTOCOL_IAD,
-    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
-    .idVendor = TINYUSB_ESPRESSIF_VID,
-    .idProduct = 0x4002,
-    .bcdDevice = 0x0100,
-    .iManufacturer = 0x01,
-    .iProduct = 0x02,
-    .iSerialNumber = 0x03,
-    .bNumConfigurations = 0x01
-};
-
-#if (TUD_OPT_HIGH_SPEED)
-static const tusb_desc_device_qualifier_t device_qualifier = {
-    .bLength = sizeof(tusb_desc_device_qualifier_t),
-    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
-    .bcdUSB = 0x0200,
-    .bDeviceClass = TUSB_CLASS_MISC,
-    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
-    .bDeviceProtocol = MISC_PROTOCOL_IAD,
-    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
-    .bNumConfigurations = 0x01,
-    .bReserved = 0
-};
-#endif // TUD_OPT_HIGH_SPEED
-
-static tinyusb_config_cdcacm_t acm_cfg = {
-    .cdc_port = TINYUSB_CDC_ACM_0,
-    .callback_rx = NULL,
-    .callback_rx_wanted_char = NULL,
-    .callback_line_state_changed = NULL,
-    .callback_line_coding_changed = NULL
-};
-
-static const uint16_t cdc_desc_config_len = TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN;
-static const uint8_t cdc_desc_configuration_remote_wakeup[] = {
-    TUD_CONFIG_DESCRIPTOR(1, 2, 0, cdc_desc_config_len, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
-    TUD_CDC_DESCRIPTOR(0, 4, 0x81, 8, 0x02, 0x82, (TUD_OPT_HIGH_SPEED ? 512 : 64)),
-};
-
-/**
- * @brief Initialize freertos primitives for the test
- *
- * Event group bits for device events delivery (suspend, resume, attach, detach)
- * Semaphore for RX callback notifications
- */
-static void test_pm_sync_init(void)
-{
-    if (device_event_group == NULL) {
-        device_event_group = xEventGroupCreateStatic(&device_event_group_buffer);
-    }
-    xEventGroupClearBits(device_event_group, DEVICE_EVENT_BITS_ALL);
-
-    if (rx_data_sem == NULL) {
-        rx_data_sem = xSemaphoreCreateBinaryStatic(&rx_data_sem_buffer);
-    }
-    while (xSemaphoreTake(rx_data_sem, 0) == pdTRUE) {
-    }
-}
-
-/**
- * @brief CDC Device RX callback for tinyusb_suspend_resume_events test case
- */
-static void tinyusb_cdc_rx_callback(int itf, cdcacm_event_t *event)
-{
-    if (rx_data_sem != NULL) {
-        ESP_LOGI(TAG, "RX data cb");
-        xSemaphoreGive(rx_data_sem);
-    }
-}
-
-/**
- * @brief Device event handler providing event group bits
- */
-static void device_event_handler(tinyusb_event_t *event, void *arg)
-{
-    uint32_t event_bits = UINT32_MAX;
-
-    switch (event->id) {
-    case TINYUSB_EVENT_ATTACHED:
-        printf("TINYUSB_EVENT_ATTACHED\n");
-        event_bits = EVENT_BITS_ATTACHED;
-        break;
-    case TINYUSB_EVENT_DETACHED:
-        printf("TINYUSB_EVENT_DETACHED\n");
-        // No event bits for detached event
-        return;
-    case TINYUSB_EVENT_SUSPENDED:
-        if (event->suspended.remote_wakeup) {
-            printf("TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_EN\n");
-            event_bits = EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN;
-        } else {
-            printf("TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_DIS\n");
-            event_bits = EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS;
-        }
-        break;
-    case TINYUSB_EVENT_RESUMED:
-        printf("TINYUSB_EVENT_RESUMED\n");
-        event_bits = EVENT_BITS_RESUMED;
-        break;
-    default:
-        return;
-    }
-
-    if (device_event_group != NULL) {
-        xEventGroupSetBits(device_event_group, event_bits);
-    }
-}
-
-/**
- * @brief Expect device event
- *
- * @param[in] expected_event Expected device event
- * @param[in] ticks time to expect the event
- * @param[in] file file from which the function was called
- * @param[in] line line from which the function was called
- */
-static void expect_device_event_impl(const uint32_t expected_event, TickType_t ticks, const char *file, int line)
-{
-    const EventBits_t bits = xEventGroupWaitBits(device_event_group, expected_event, pdTRUE, pdTRUE, ticks);
-    if ((bits & expected_event) == expected_event) {
-        return;
-    }
-
-    if (bits != 0) {
-        snprintf(err_msg_buf, sizeof(err_msg_buf),
-                 "Unexpected event at %s:%d\n %ld expected, %ld delivered\n",
-                 file, line, expected_event, (uint32_t)bits);
-        TEST_FAIL_MESSAGE(err_msg_buf);
-    }
-
-    snprintf(err_msg_buf, sizeof(err_msg_buf),
-             "Event %ld at %s:%d\n was not delivered on time",
-             expected_event, file, line);
-    TEST_FAIL_MESSAGE(err_msg_buf);
-}
-#define expect_device_event(expected_event, ticks) expect_device_event_impl((expected_event), (ticks), __FILE__, __LINE__)
-
-/**
- * @brief Install TinyUSB driver and initialize CDC ACM for PM tests
- *
- * @param[in] rx_cb     Optional CDC RX callback (may be NULL)
- *
- * @return tinyusb_config_t used for driver install (for reuse on reinstall)
- */
-static tinyusb_config_t test_pm_init_tinyusb_cdc(tusb_cdcacm_callback_t rx_cb)
-{
-    // Initialize freertos primitives
-    test_pm_sync_init();
-
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(device_event_handler);
-    tusb_cfg.descriptor.device = &cdc_device_descriptor;
-    tusb_cfg.descriptor.full_speed_config = cdc_desc_configuration_remote_wakeup;
-#if (TUD_OPT_HIGH_SPEED)
-    tusb_cfg.descriptor.qualifier = &device_qualifier;
-    tusb_cfg.descriptor.high_speed_config = cdc_desc_configuration_remote_wakeup;
-#endif // TUD_OPT_HIGH_SPEED
-
-    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
-    acm_cfg.callback_rx = rx_cb;
-    TEST_ASSERT_FALSE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
-    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_init(&acm_cfg));
-    TEST_ASSERT_TRUE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
-
-    return tusb_cfg;
-}
 
 /**
  * @brief Tinyusb power management suspend/resume events
@@ -228,14 +36,19 @@ static tinyusb_config_t test_pm_init_tinyusb_cdc(tusb_cdcacm_callback_t rx_cb)
  * Device resumes, receives and validates the data, sends a response and goes to suspended state (auto suspend)
  * Pytest expect TINYUSB_EVENT_SUSPENDED ...
  */
-TEST_CASE("tinyusb_suspend_resume_events", "[esp_tinyusb][device_pm_suspend_resume]")
+TEST_CASE("tinyusb_suspend_resume_events", "[device_events][tinyusb_suspend_resume_events]")
 {
     // Install and initialize cdc
-    test_pm_init_tinyusb_cdc(tinyusb_cdc_rx_callback);
+    const test_pm_install_opts_t opts = {
+        .auto_light_sleep_enable = false,
+        .pm_lock_enable = false,
+    };
+    test_pm_init_tinyusb_cdc(&opts);
 
     uint8_t buf[TINYUSB_CDC_RX_BUFSIZE + 1];
     const char expect_reply[] = "Time to resume\r\n";
     const char send_message[] = "Time to suspend\r\n";
+    SemaphoreHandle_t rx_data_sem = test_pm_get_rx_sem();
 
     // Expect attach event
     expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
@@ -244,7 +57,7 @@ TEST_CASE("tinyusb_suspend_resume_events", "[esp_tinyusb][device_pm_suspend_resu
     do {
         expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
         // Wait for new data from the host (Sent by pytest)
-        if (pdTRUE == xSemaphoreTake(rx_data_sem, pdMS_TO_TICKS(10000))) {
+        if (pdTRUE == xSemaphoreTake(rx_data_sem, pdMS_TO_TICKS(DATA_RECEPTION_WAIT_MS))) {
 
             expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
             size_t rx_size = 0;
@@ -269,7 +82,6 @@ TEST_CASE("tinyusb_suspend_resume_events", "[esp_tinyusb][device_pm_suspend_resu
     expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
 }
 
-
 /**
  * @brief Tinyusb power management remote wakeup
  *
@@ -282,10 +94,20 @@ TEST_CASE("tinyusb_suspend_resume_events", "[esp_tinyusb][device_pm_suspend_resu
  * - Expect auto suspend device event with remote wakeup enabled
  * - Signalize remote wakeup and expect resume event
  */
-TEST_CASE("tinyusb_remote_wakeup_reporting", "[esp_tinyusb][device_pm_remote_wake]")
+TEST_CASE("tinyusb_remote_wakeup_reporting", "[device_events][tinyusb_remote_wakeup_reporting]")
 {
+    // Call esp_tinyusb public API before installing the Tinyusb
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, tinyusb_remote_wakeup());
+
     // Install and initialize cdc
-    test_pm_init_tinyusb_cdc(NULL);
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = true,
+        .auto_light_sleep_enable = true,
+    };
+    test_pm_init_tinyusb_cdc(&opts);
+
+    // Call esp_tinyusb public API when not suspended
+    TEST_ASSERT_EQUAL(ESP_ERR_NOT_ALLOWED, tinyusb_remote_wakeup());
 
     // Expect attach event
     expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
@@ -325,7 +147,11 @@ TEST_CASE("tinyusb_remote_wakeup_reporting", "[esp_tinyusb][device_pm_remote_wak
 TEST_CASE("tinyusb_cdc_public_api_error_handling", "[esp_tinyusb][cdc_device_pm_public_api]")
 {
     // Install and initialize cdc
-    test_pm_init_tinyusb_cdc(tinyusb_cdc_rx_callback);
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = false,
+        .auto_light_sleep_enable = false,
+    };
+    test_pm_init_tinyusb_cdc(&opts);
 
     // Wait for attach event
     expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
@@ -352,6 +178,7 @@ TEST_CASE("tinyusb_cdc_public_api_error_handling", "[esp_tinyusb][cdc_device_pm_
     // Pytest resumes the device by accessing it
     expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
 
+    SemaphoreHandle_t rx_data_sem = test_pm_get_rx_sem();
     // Expect data from the host
     if (pdTRUE == xSemaphoreTake(rx_data_sem, pdMS_TO_TICKS(10000))) {
 
@@ -382,10 +209,14 @@ TEST_CASE("tinyusb_cdc_public_api_error_handling", "[esp_tinyusb][cdc_device_pm_
  * - Deinit CDC and uninstall TinyUSB driver while suspended
  * - Reinstall TinyUSB driver and reinit CDC while still suspended
  */
-TEST_CASE("tinyusb_init_deinit_from_suspended", "[esp_tinyusb][device_pm]")
+TEST_CASE("tinyusb_init_deinit_from_suspended", "[esp_tinyusb][driver_init_deinit]")
 {
     // Install and initialize cdc
-    const tinyusb_config_t tusb_cfg = test_pm_init_tinyusb_cdc(NULL);
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = false,
+        .auto_light_sleep_enable = false,
+    };
+    test_pm_init_tinyusb_cdc(&opts);
 
     // Wait for attach event
     expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
@@ -401,12 +232,68 @@ TEST_CASE("tinyusb_init_deinit_from_suspended", "[esp_tinyusb][device_pm]")
     vTaskDelay(10);
 
     // Install the driver and init the device while in suspended state
-    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+    test_pm_init_tinyusb_cdc(&opts);
 
-    // Init CDC device
-    TEST_ASSERT_FALSE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
-    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_init(&acm_cfg));
-    TEST_ASSERT_TRUE(tinyusb_cdcacm_initialized(TINYUSB_CDC_ACM_0));
+    // Let the driver to be installed
+    vTaskDelay(10);
 }
 
-#endif
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+TEST_CASE("tinyusb_light_sleep_usb_wakeup", "[device_pm][tinyusb_light_sleep_otg_wake]")
+{
+    // Enable HS Connect power domain to stay ON during light sleep
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_ON));
+
+    // Install and initialize cdc
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = false,
+        .auto_light_sleep_enable = false,
+    };
+    test_pm_init_tinyusb_cdc(&opts);
+
+    // Expect attach and suspend events
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    // Prepare for light sleep entry
+    printf("LIGHT_SLEEP_ENTER\n");
+    fflush(stdout);
+    vTaskDelay(10);
+
+    // Enter light sleep (OTG suspend state is prepared by the light-sleep enter callback)
+    TEST_ASSERT_EQUAL(ESP_OK, esp_light_sleep_start());
+
+    // Pytest wakes up the SoC, find out the wakeup reason
+    const uint32_t wakeup_causes = esp_sleep_get_wakeup_causes();
+    TEST_ASSERT_TRUE_MESSAGE(wakeup_causes & BIT(ESP_SLEEP_WAKEUP_USB), "Expected to wake from USB during light sleep");
+
+    // Expect resume event (OTG state is restored by the light-sleep exit callback)
+    expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    // Disable HS Connect power domain
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_OFF));
+
+    SemaphoreHandle_t rx_data_sem = test_pm_get_rx_sem();
+    // Wait for the data from the Pytest to be received
+    TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, xSemaphoreTake(rx_data_sem, pdMS_TO_TICKS(DATA_RECEPTION_WAIT_MS)), "Wake-up string not received on time from host");
+
+    uint8_t buf[TINYUSB_CDC_RX_BUFSIZE + 1];
+    size_t rx_size = 0;
+    const char expect_message[] = "Light sleep wake\r\n";
+    const char send_message[] = "Light sleep ok\r\n";
+
+    // Read the data and validate
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_read(TINYUSB_CDC_ACM_0, buf, TINYUSB_CDC_RX_BUFSIZE, &rx_size));
+    TEST_ASSERT_GREATER_THAN(0, rx_size);
+    ESP_LOGI(TAG, "Intf %d, RX %d bytes", TINYUSB_CDC_ACM_0, rx_size);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expect_message, buf, sizeof(expect_message) - 1);
+
+    // Reply back
+    strncpy((char *)buf, send_message, sizeof(send_message) - 1);
+    TEST_ASSERT_EQUAL(sizeof(send_message) - 1, tinyusb_cdcacm_write_queue(TINYUSB_CDC_ACM_0, buf, sizeof(send_message) - 1));
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, 0));
+    printf("LIGHT_SLEEP_DATA_RX\n");
+}
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/power_management/main/test_esp_pm_integration.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_esp_pm_integration.c
@@ -1,0 +1,179 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+#include "sdkconfig.h"
+
+#if SOC_USB_OTG_SUPPORTED && CONFIG_TINYUSB_PM
+
+#include <stdio.h>
+#include <string.h>
+#include "esp_sleep.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "esp_log.h"
+#include "unity.h"
+#include "tinyusb.h"
+#include "tinyusb_cdc_acm.h"
+#include "tusb_config.h"
+#include "common_pm.h"
+
+static const char *TAG = "PM_EspPM";
+
+#if !CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+static void pm_wait_light_sleep_timer_wakeup(void)
+{
+    const TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(PM_LIGHT_SLEEP_WAKE_WAIT_MS);
+
+    while (xTaskGetTickCount() < deadline) {
+        const uint32_t causes = esp_sleep_get_wakeup_causes();
+        if (causes & BIT(ESP_SLEEP_WAKEUP_TIMER)) {
+            printf("Woken form light sleep by timer\n");
+            return;
+        }
+        vTaskDelay(pdMS_TO_TICKS(50));
+    }
+
+    TEST_FAIL_MESSAGE("Timed out waiting for light sleep timer wakeup");
+}
+
+/**
+ * @brief PM-only suspend/resume cycles using timer light sleep wakeup and USB remote wakeup
+ *
+ * After host suspend the PM lock is released and the SoC may enter automatic light sleep.
+ * USB host traffic cannot wake FS targets from light sleep, so a sleep timer wakes the SoC.
+ * The device then signals remote wakeup to resume the USB bus and re-acquire the PM lock.
+ */
+static void run_esp_pm_light_sleep_suspend_resume_cycles(void)
+{
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    test_pm_assert_lock_acquired(true);
+
+    int test_iterations = 0;
+    do {
+        ESP_LOGI(TAG, "PM light sleep iteration %d", test_iterations);
+        expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+        test_pm_assert_lock_acquired(false);
+
+        pm_wait_light_sleep_timer_wakeup();
+
+        TEST_ASSERT_EQUAL(ESP_OK, tinyusb_remote_wakeup());
+        test_pm_assert_lock_acquired(true);
+        expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+        TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_enable_timer_wakeup(PM_LIGHT_SLEEP_TIMER_US));
+        test_iterations++;
+    } while (test_iterations < SUSPEND_RESUME_TEST_ITERATIONS);
+
+    ESP_LOGI(TAG, "PM light test cleanup");
+    vTaskDelay(10);
+}
+
+/**
+ * @brief Verify PM lock acquire/release during host-driven suspend/resume (PM only, no USB wakeup)
+ */
+TEST_CASE("tinyusb_power_management", "[device_pm][tinyusb_pm]")
+{
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = true,
+        .auto_light_sleep_enable = true,
+    };
+    test_pm_init_tinyusb_cdc(&opts);
+
+#if SOC_PM_SUPPORT_CNNT_PD
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_ON));
+#endif // SOC_PM_SUPPORT_CNNT_PD
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_enable_timer_wakeup(PM_LIGHT_SLEEP_TIMER_US));
+    run_esp_pm_light_sleep_suspend_resume_cycles();
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
+#if SOC_PM_SUPPORT_CNNT_PD
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_OFF));
+#endif // SOC_PM_SUPPORT_CNNT_PD
+
+    // esp32s2 does not support cpu retention
+#if SOC_PM_SUPPORT_CPU_PD
+    // esp_pm_configure({light_sleep_enable: true}) calls cpu retention init, we need to deinit manually to prevent memory leaks
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_cpu_retention_deinit());
+#endif // SOC_PM_SUPPORT_CPU_PD
+}
+
+#endif // !CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+static void run_esp_pm_suspend_resume_cycles(void)
+{
+    const uint32_t suspend_event = EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN;
+    const uint32_t resume_event = EVENT_BITS_RESUMED;
+
+    uint8_t buf[TINYUSB_CDC_RX_BUFSIZE + 1];
+    const char expect_reply[] = "Time to resume\r\n";
+    const char send_message[] = "Time to suspend\r\n";
+    SemaphoreHandle_t rx_data_sem = test_pm_get_rx_sem();
+
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    test_pm_assert_lock_acquired(true);
+
+    int test_iterations = 0;
+    do {
+        expect_device_event(suspend_event, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+        test_pm_assert_lock_acquired(false);
+
+        if (pdTRUE == xSemaphoreTake(rx_data_sem, pdMS_TO_TICKS(DATA_RECEPTION_WAIT_MS))) {
+
+            expect_device_event(resume_event, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+            test_pm_assert_lock_acquired(true);
+
+            size_t rx_size = 0;
+            TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_read(TINYUSB_CDC_ACM_0, buf, TINYUSB_CDC_RX_BUFSIZE, &rx_size));
+            if (rx_size > 0) {
+                ESP_LOGI(TAG, "Intf %d, RX %d bytes", TINYUSB_CDC_ACM_0, rx_size);
+                // Check if received string is equal to expect_reply string
+                TEST_ASSERT_EQUAL_UINT8_ARRAY(expect_reply, buf, sizeof(expect_reply) - 1);
+
+                // Reply to the host with send_message string
+                strncpy((char *)buf, send_message, sizeof(send_message) - 1);
+                tinyusb_cdcacm_write_queue(TINYUSB_CDC_ACM_0, buf, sizeof(send_message) - 1);
+                tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, 0);
+                test_iterations++;
+            }
+        } else {
+            TEST_FAIL_MESSAGE("RX Data CB not received on time");
+        }
+    } while (test_iterations < SUSPEND_RESUME_TEST_ITERATIONS);
+
+    expect_device_event(suspend_event, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    test_pm_assert_lock_acquired(false);
+}
+
+/**
+ * @brief Verify PM lock acquire/release during host-driven suspend/resume (esp_tinyusb callbacks)
+ */
+TEST_CASE("tinyusb_power_management_usb_wakeup", "[device_pm][tinyusb_pm_otg_wake]")
+{
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = true,
+        .auto_light_sleep_enable = true,
+    };
+    test_pm_init_tinyusb_cdc(&opts);
+
+    // Enable HS Connect power domain to stay ON during light sleep
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_ON));
+
+    run_esp_pm_suspend_resume_cycles();
+
+    // Disable HS Connect power domain
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_OFF));
+    // esp_pm_configure({light_sleep_enable: true}) calls cpu retention init, we need to deinit manually to prevent memory leaks
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_cpu_retention_deinit());
+    ESP_LOGI(TAG, "PM usb wakeup test cleanup");
+}
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+#endif // SOC_USB_OTG_SUPPORTED && CONFIG_TINYUSB_PM

--- a/device/esp_tinyusb/test_apps/power_management/main/test_esp_pm_public_api.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_esp_pm_public_api.c
@@ -1,0 +1,167 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+#if SOC_USB_OTG_SUPPORTED
+
+#include "esp_err.h"
+#include "esp_sleep.h"
+#include "unity.h"
+#include "tinyusb.h"
+#include "sdkconfig.h"
+#include "common_pm.h"
+
+#if CONFIG_TINYUSB_PM
+
+#define TEST_PM_PUBLIC_API_GROUP "[device_pm][public_api_tinyusb_pm]"
+
+/**
+ * @brief Verify `tinyusb_pm_get_lock_status()` when the PM lock is disabled
+ *
+ * Scenario: Query lock status before install and after install with `pm_lock_enable=false`
+ * Awaiting: `ESP_ERR_INVALID_STATE` in both cases; `ESP_ERR_INVALID_ARG` for a NULL output pointer
+ */
+TEST_CASE("tinyusb_pm_get_lock_status_lock_disabled", TEST_PM_PUBLIC_API_GROUP)
+{
+    bool lock_held;
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, tinyusb_pm_get_lock_status(&lock_held));
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, tinyusb_pm_get_lock_status(NULL));
+
+    const test_pm_install_opts_t opts = {
+        .auto_light_sleep_enable = false,
+        .pm_lock_enable = false,
+    };
+
+    test_pm_init_tinyusb_cdc(&opts);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, tinyusb_pm_get_lock_status(&lock_held));
+}
+
+/**
+ * @brief Verify `tinyusb_pm_get_lock_status()` driver-state and argument checks
+ *
+ * Scenario: Call the API before driver install and with a NULL pointer after install
+ * Awaiting: `ESP_ERR_INVALID_STATE` before install; `ESP_ERR_INVALID_ARG` for NULL after install
+ */
+TEST_CASE("tinyusb_pm_get_lock_status_api_validation", TEST_PM_PUBLIC_API_GROUP)
+{
+    bool lock_held;
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, tinyusb_pm_get_lock_status(&lock_held));
+
+    const test_pm_install_opts_t opts = {
+        .auto_light_sleep_enable = false,
+        .pm_lock_enable = true,
+    };
+
+    test_pm_init_tinyusb_cdc(&opts);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, tinyusb_pm_get_lock_status(NULL));
+}
+
+/**
+ * @brief Verify the PM lock remains held after driver install and host enumeration
+ *
+ * Scenario: Install with the PM lock enabled, then wait for host attach
+ * Awaiting: Lock is held immediately after install and remains held after enumeration
+ */
+TEST_CASE("tinyusb_pm_get_lock_status_lock_held_on_install", TEST_PM_PUBLIC_API_GROUP)
+{
+    bool lock_held;
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = true,
+        .auto_light_sleep_enable = true,
+    };
+
+    test_pm_init_tinyusb_cdc(&opts);
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_pm_get_lock_status(&lock_held));
+    TEST_ASSERT_TRUE(lock_held);
+
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_pm_get_lock_status(&lock_held));
+    TEST_ASSERT_TRUE(lock_held);
+
+    // esp32s2 does not support cpu retention
+#if SOC_PM_SUPPORT_CPU_PD
+    // esp_pm_configure({light_sleep_enable: true}) calls cpu retention init, we need to deinit manually to prevent memory leaks
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_cpu_retention_deinit());
+#endif // SOC_PM_SUPPORT_CPU_PD
+}
+
+/**
+ * @brief Verify PM lock status survives a driver deinit/reinit cycle
+ *
+ * Scenario: Install, enumerate, uninstall, then install again with the same PM options
+ * Awaiting: Lock is held after each install once the host re-enumerates the device
+ */
+TEST_CASE("tinyusb_pm_get_lock_status_reinstall", TEST_PM_PUBLIC_API_GROUP)
+{
+    bool lock_held;
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = true,
+        .auto_light_sleep_enable = true,
+    };
+
+    test_pm_init_tinyusb_cdc(&opts);
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_pm_get_lock_status(&lock_held));
+    TEST_ASSERT_TRUE(lock_held);
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_cdcacm_deinit(TINYUSB_CDC_ACM_0));
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+
+    test_pm_init_tinyusb_cdc(&opts);
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_pm_get_lock_status(&lock_held));
+    TEST_ASSERT_TRUE(lock_held);
+
+    // esp32s2 does not support cpu retention
+#if SOC_PM_SUPPORT_CPU_PD
+    // esp_pm_configure({light_sleep_enable: true}) calls cpu retention init, we need to deinit manually to prevent memory leaks
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_cpu_retention_deinit());
+#endif // SOC_PM_SUPPORT_CPU_PD
+}
+
+/**
+ * @brief Verify PM lock is released when esp_tinyusb handles USB suspend internally
+ *
+ * Scenario: Install with PM lock enabled, enumerate, then wait for host auto-suspend
+ * Awaiting: Lock held while active; lock released after `TINYUSB_EVENT_SUSPENDED`
+ */
+TEST_CASE("tinyusb_pm_get_lock_status_lifecycle", TEST_PM_PUBLIC_API_GROUP)
+{
+    bool lock_held;
+    const test_pm_install_opts_t opts = {
+        .pm_lock_enable = true,
+        .auto_light_sleep_enable = true,
+    };
+
+    test_pm_init_tinyusb_cdc(&opts);
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_pm_get_lock_status(&lock_held));
+    TEST_ASSERT_TRUE(lock_held);
+
+    expect_device_event(EVENT_BITS_ATTACHED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_pm_get_lock_status(&lock_held));
+    TEST_ASSERT_TRUE(lock_held);
+
+    expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_pm_get_lock_status(&lock_held));
+    TEST_ASSERT_FALSE(lock_held);
+
+    // esp32s2 does not support cpu retention
+#if SOC_PM_SUPPORT_CPU_PD
+    // esp_pm_configure({light_sleep_enable: true}) calls cpu retention init, we need to deinit manually to prevent memory leaks
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_cpu_retention_deinit());
+#endif // SOC_PM_SUPPORT_CPU_PD
+}
+
+#undef TEST_PM_PUBLIC_API_GROUP
+
+#endif // CONFIG_TINYUSB_PM
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/test_apps/power_management/pytest_remote_wake.py
+++ b/device/esp_tinyusb/test_apps/power_management/pytest_remote_wake.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+from time import sleep
+import pytest
+from pytest_embedded_idf.dut import IdfDut
+
+# Mainly for a local run, as there is no error when pyusb is not installed and the pytest silently fails
+try:
+    import usb.core
+    import usb.util
+except ImportError as e:
+    raise RuntimeError("pyusb is not installed. Install it with: pip install pyusb") from e
+
+# Standard USB requests (USB 2.0 spec, Table 9-4)
+USB_B_REQUEST_SET_FEATURE       = 0x03
+
+# Standard feature selectors (USB 2.0 spec, Table 9-6)
+USB_FEAT_DEVICE_REMOTE_WAKEUP   = 0x01
+
+# Bit mask belonging to the bmAttributes field of a configuration descriptor
+USB_BM_ATTRIBUTES_WAKEUP        = 0x20
+
+# Device Under Test VID:PID
+DUT_VID = 0x303A
+DUT_PID = 0x4002
+
+# Tinyusb device events from device event handler
+TINYUSB_EVENTS = {
+    "attached":                         "TINYUSB_EVENT_ATTACHED",
+    "detached":                         "TINYUSB_EVENT_DETACHED",
+    "resumed":                          "TINYUSB_EVENT_RESUMED",
+    "suspended_remote_wake_dis":        "TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_DIS",
+    "suspended_remote_wake_en":         "TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_EN",
+}
+
+
+def set_remote_wake_on_device(VID: int, PID: int) -> None:
+    '''
+    Resume the device by opening it
+    Set remote wakeup on device by sending SET_FEATURE ctrl transfer to the device
+
+    :param VID: VID of the device
+    :param PID: PID of the device
+    '''
+
+    # Device is currently suspended, we must open it to resume it and send the ctrl transfer
+    dev = usb.core.find(idVendor=VID, idProduct=PID)
+    if dev is None:
+        raise ValueError("Device not found")
+
+    bmRequestType = usb.util.build_request_type(
+                    usb.util.CTRL_OUT,
+                    usb.util.CTRL_TYPE_STANDARD,
+                    usb.util.CTRL_RECIPIENT_DEVICE)
+
+    try:
+        dev.ctrl_transfer(
+            bmRequestType=bmRequestType,
+            bRequest=USB_B_REQUEST_SET_FEATURE,
+            wValue=USB_FEAT_DEVICE_REMOTE_WAKEUP,
+            wIndex=0,
+        )
+    except usb.core.USBError as e:
+        raise RuntimeError("Control transfer not sent") from e
+
+    print("CTRL transfer sent")
+
+    try:
+        usb.util.dispose_resources(dev)
+    except usb.core.USBError as e:
+        raise RuntimeError("Device resources not released") from e
+
+
+def check_remote_wake_feature(VID: int, PID: int, has_remote_wake: bool) -> None:
+    '''
+    Check if the device reports remote wakeup feature from it's configuration descriptor
+
+    :param VID: VID of the device
+    :param PID: PID of the device
+    :param has_remote_wake: Expect the device to does/does not feature with remote wakeup
+    '''
+
+    sleep(2)  # Some time for the OS to enumerate our USB device
+    dev = usb.core.find(idVendor=VID, idProduct=PID)
+    if dev is None:
+        raise ValueError("Device not found")
+
+    cfg = dev.get_active_configuration()
+    remote_wake_supported = bool(cfg.bmAttributes & USB_BM_ATTRIBUTES_WAKEUP)
+
+    if remote_wake_supported:
+        print("Device advertises remote wakeup feature in it's descriptor")
+    else:
+        print("Device does not advertise remote wakeup feature in it's descriptor")
+
+    # Assertion to fail on mismatch
+    assert remote_wake_supported == has_remote_wake, (
+        f"Remote wakeup capability mismatch: "
+        f"expected {has_remote_wake}, "
+        f"device reports {remote_wake_supported}"
+    )
+
+    try:
+        usb.util.dispose_resources(dev)
+    except usb.core.USBError as e:
+        raise RuntimeError("Device resources not released") from e
+
+
+@pytest.mark.usb_device
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
+@pytest.mark.parametrize(
+    'config, target',
+    [
+        pytest.param('default', 'esp32s2'),
+        pytest.param('default', 'esp32s3'),
+        pytest.param('default', 'esp32h4'),
+        pytest.param('default', 'esp32p4', marks=[pytest.mark.eco_default]),
+        pytest.param('esp32p4_eco4', 'esp32p4', marks=[pytest.mark.esp32p4_eco4]),
+        pytest.param('default', 'esp32s31'),
+    ],
+    indirect=['target'],
+)
+def test_usb_device_remote_wakeup_en(dut: IdfDut) -> None:
+    '''
+    Running the test locally:
+    1. Build the test app for your USB-OTG capable DUT
+    2. Connect you DUT to your test runner (local machine) with USB port and flashing port
+    3. Run `pytest --target <target>`
+
+    Test procedure:
+    1. Run the test on the DUT
+    2. Expect one COM Port in the system
+    3. Check the device's configuration descriptor, if it reports remote wakeup functionality
+    4. Enable the remote wakeup by sending a ctrl transfer
+    '''
+    sleep(5)
+    dut.expect_exact('Press ENTER to see the list of tests.')
+    dut.write('[tinyusb_remote_wakeup_reporting]')
+    dut.expect_exact('TinyUSB: TinyUSB Driver installed')
+    sleep(2)
+
+    # Wait for device attach event
+    dut.expect_exact(TINYUSB_EVENTS['attached'])
+    # Check if the device reports remote wakeup feature
+    check_remote_wake_feature(DUT_VID, DUT_PID, has_remote_wake=True)
+
+    # Expect device suspend event (auto suspend) with remote wakeup disabled
+    dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_dis'])
+
+    # Enable remote wakeup on the device
+    set_remote_wake_on_device(DUT_VID, DUT_PID)
+
+    # Expect device to resume (ctrl transfer sent)
+    dut.expect_exact(TINYUSB_EVENTS['resumed'])
+    # Expect device suspend event (auto suspend) with remote wakeup enabled
+    dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
+
+    # Device called remote wakeup
+
+    # Expect device to resume (remote wakeup)
+    dut.expect_exact(TINYUSB_EVENTS['resumed'])
+
+    # Wait for the test app to finish
+    dut.expect_exact('PM_Device_main_app: Cleanup')
+    dut.expect_exact(TINYUSB_EVENTS['detached'])
+    sleep(1)

--- a/device/esp_tinyusb/test_apps/power_management/pytest_usb_pm.py
+++ b/device/esp_tinyusb/test_apps/power_management/pytest_usb_pm.py
@@ -7,36 +7,124 @@ from serial import Serial, SerialException
 from serial.tools.list_ports import comports
 from pytest_embedded_idf.dut import IdfDut
 
-# Mainly for a local run, as there is no error when pyusb is not installed and the pytest silently fails
-try:
-    import usb.core
-    import usb.util
-except ImportError as e:
-    raise RuntimeError("pyusb is not installed. Install it with: pip install pyusb") from e
-
-# Standard USB requests (USB 2.0 spec, Table 9-4)
-USB_B_REQUEST_SET_FEATURE       = 0x03
-
-# Standard feature selectors (USB 2.0 spec, Table 9-6)
-USB_FEAT_DEVICE_REMOTE_WAKEUP   = 0x01
-
-# Bit mask belonging to the bmAttributes field of a configuration descriptor
-USB_BM_ATTRIBUTES_WAKEUP        = 0x20
-
 # Device Under Test VID:PID
 DUT_VID = 0x303A
 DUT_PID = 0x4002
 
 # Tinyusb device events from device event handler
 TINYUSB_EVENTS = {
-    "attached":                     "TINYUSB_EVENT_ATTACHED",
-    "resumed":                      "TINYUSB_EVENT_RESUMED",
-    "suspended_remote_wake_dis":    "TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_DIS",
-    "suspended_remote_wake_en":     "TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_EN",
+    "attached":                         "TINYUSB_EVENT_ATTACHED",
+    "detached":                         "TINYUSB_EVENT_DETACHED",
+    "resumed":                          "TINYUSB_EVENT_RESUMED",
+    "suspended_remote_wake_dis":        "TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_DIS",
+    "suspended_remote_wake_en":         "TINYUSB_EVENT_SUSPENDED_REMOTE_WAKE_EN",
+    "light_sleep_enter":                "LIGHT_SLEEP_ENTER",
+    "light_sleep_data_rx":              "LIGHT_SLEEP_DATA_RX",
 }
 
+def find_dut_cdc_ports() -> list[str]:
+    '''Return serial port paths for the TinyUSB CDC device.'''
+    ports = []
+    for p in comports():
+        if (p.vid == DUT_VID and p.pid == DUT_PID):
+            ports.append(p.device)
+    return ports
+
+def run_suspend_resume_cdc_test(
+    dut: IdfDut,
+    *,
+    resumed_event: str,
+    suspended_event: str,
+) -> None:
+    '''Run the write/read cycle test body'''
+    dut.expect_exact('TinyUSB: TinyUSB Driver installed')
+    sleep(2)  # Some time for the OS to enumerate our USB device
+
+    # Find device with Espressif TinyUSB VID/PID
+    ports = find_dut_cdc_ports()
+
+    if len(ports) == 0:
+        raise Exception('TinyUSB COM port not found')
+
+    try:
+        with Serial(ports[0], timeout=5, write_timeout=5) as cdc:
+            dut.expect_exact(TINYUSB_EVENTS['attached'])
+
+            # Wait for auto suspend (set to 3 seconds)
+            # This expect_exact is ignored by pytest when running second rerun of flaky test (unknown reason),
+            # making the test fail in further steps, adding explicit sleep(3) to wait for the suspend events
+            sleep(3)
+            dut.expect_exact(suspended_event, timeout=10)
+            sleep(1)
+
+            for i in range(5):
+                print(f"Power cycle iteration {i}.")
+
+                # Resume the device by accessing it
+                cdc.reset_input_buffer()
+                cdc.write(b'Time to resume\r\n')
+                cdc.flush()
+
+                res = cdc.readline()
+                assert b'Time to suspend\r\n' in res
+
+                dut.expect_exact(resumed_event, timeout=10)
+
+                # Wait for auto suspend (set to 3 seconds)
+                dut.expect_exact(suspended_event, timeout=10)
+
+                # Stay suspended for a while
+                sleep(1)
+
+    except SerialException as e:
+        raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
+
+    # Wait for the test app to finish
+    dut.expect_exact('PM_Device_main_app: Cleanup')
+    dut.expect_exact(TINYUSB_EVENTS['detached'])
+    sleep(1)
+
+def run_pm_light_sleep_suspend_resume_test(
+    dut: IdfDut,
+    *,
+    resumed_event: str,
+    suspended_event: str,
+) -> None:
+    '''Run PM-only suspend/resume test without host CDC resume.
+
+    On FS targets the host cannot wake the SoC from light sleep. The DUT wakes itself
+    with a sleep timer, signals USB remote wakeup, and pytest only observes events.
+    '''
+    dut.expect_exact('TinyUSB: TinyUSB Driver installed')
+    sleep(2)  # Some time for the OS to enumerate our USB device
+
+    ports = find_dut_cdc_ports()
+    if len(ports) == 0:
+        raise Exception('TinyUSB COM port not found')
+
+    try:
+        # Open the CDC port so the host enables remote wakeup, but do not write to it
+        with Serial(ports[0], timeout=2):
+            dut.expect_exact(TINYUSB_EVENTS['attached'])
+
+            for i in range(5):
+                print(f"PM light sleep iteration {i}.")
+
+                # Auto-suspend
+                dut.expect_exact(suspended_event)
+
+                # Wait for the timer to wake the SoC from light sleep and call the remote wakeup
+                dut.expect_exact(resumed_event)
+
+    except SerialException as e:
+        raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
+
+    dut.expect_exact('PM_Device_main_app: Cleanup')
+    dut.expect_exact(TINYUSB_EVENTS['detached'])
+    sleep(1)
+
 @pytest.mark.usb_device
-@pytest.mark.flaky(reruns=1, reruns_delay=10)
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
 @pytest.mark.parametrize(
     'config, target',
     [
@@ -46,10 +134,18 @@ TINYUSB_EVENTS = {
         pytest.param('default', 'esp32p4', marks=[pytest.mark.eco_default]),
         pytest.param('esp32p4_eco4', 'esp32p4', marks=[pytest.mark.esp32p4_eco4]),
         pytest.param('default', 'esp32s31'),
+        pytest.param('pm', 'esp32s2'),
+        pytest.param('pm', 'esp32s3'),
+        pytest.param('pm', 'esp32h4'),
+        pytest.param('pm', 'esp32p4', marks=[pytest.mark.eco_default]),
+        pytest.param('pm', 'esp32s31'),
+        # Only HS targets for otg wake
+        pytest.param('pm_otg_wake', 'esp32p4', marks=[pytest.mark.eco_default]),
+        pytest.param('pm_otg_wake', 'esp32s31'),
     ],
     indirect=['target'],
 )
-def test_usb_device_suspend_resume(dut: IdfDut) -> None:
+def test_usb_device_suspend_resume_signaling(config: str, dut: IdfDut) -> None:
     '''
     Running the test locally:
     1. Build the test app for your USB-OTG capable DUT
@@ -65,181 +161,32 @@ def test_usb_device_suspend_resume(dut: IdfDut) -> None:
     '''
     sleep(5) # When rerunning flaky test, to re-initialize the device
     dut.expect_exact('Press ENTER to see the list of tests.')
-    dut.write('[device_pm_suspend_resume]')
-    dut.expect_exact('TinyUSB: TinyUSB Driver installed')
-    sleep(2)  # Some time for the OS to enumerate our USB device
 
-    # Find device with Espressif TinyUSB VID/PID
-    ports = []
-    for p in comports():
-        if (p.vid == DUT_VID and p.pid == DUT_PID):
-            ports.append(p.device)
+    resumed_event=TINYUSB_EVENTS['resumed']
+    suspended_event=TINYUSB_EVENTS['suspended_remote_wake_en']
 
-    if len(ports) == 0:
-        raise Exception('TinyUSB COM port not found')
+    if config == 'default' or config == 'esp32p4_eco4':
+        dut.write('[tinyusb_suspend_resume_events]')
+    elif config == 'pm':
+        dut.write('[tinyusb_pm]')
+    elif config == 'pm_otg_wake':
+        dut.write('[tinyusb_pm_otg_wake]')
 
-    try:
-        with Serial(ports[0], timeout=2) as cdc:
-            dut.expect_exact(TINYUSB_EVENTS['attached'])
-
-            # Wait for auto suspend (set to 3 seconds)
-            # This expect_exact is ignored by pytest when running second rerun of flaky test (unknown reason),
-            # making the test fail in further steps, adding explicit sleep(3) to wait for the suspend events
-            sleep(3)
-            dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
-
-            for i in range(5):
-                print(f"Power cycle iteration {i}.")
-
-                # Resume the device by accessing it
-                cdc.write(b'Time to resume\r\n')
-                res = cdc.readline()
-                assert b'Time to suspend\r\n' in res
-
-                dut.expect_exact(TINYUSB_EVENTS['resumed'])
-
-                # Wait for auto suspend (set to 3 seconds)
-                dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
-
-                # Stay suspended for a while
-                sleep(2)
-
-    except SerialException as e:
-        raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
-
-    # Wait for the test app to finish
-    dut.expect_exact('PM_Device_main_app: Cleanup')
-
-def set_remote_wake_on_device(VID: int, PID: int) -> None:
-    '''
-    Resume the device by opening it
-    Set remote wakeup on device by sending SET_FEATURE ctrl transfer to the device
-
-    :param VID: VID of the device
-    :param PID: PID of the device
-    '''
-
-    # Device is currently suspended, we must open it to resume it and send the ctrl transfer
-    dev = usb.core.find(idVendor=VID, idProduct=PID)
-    if dev is None:
-        raise ValueError("Device not found")
-
-    bmRequestType = usb.util.build_request_type(
-                    usb.util.CTRL_OUT,
-                    usb.util.CTRL_TYPE_STANDARD,
-                    usb.util.CTRL_RECIPIENT_DEVICE)
-
-    try:
-        dev.ctrl_transfer(
-            bmRequestType=bmRequestType,
-            bRequest=USB_B_REQUEST_SET_FEATURE,
-            wValue=USB_FEAT_DEVICE_REMOTE_WAKEUP,
-            wIndex=0,
+    if config == 'pm':
+        run_pm_light_sleep_suspend_resume_test(
+            dut,
+            resumed_event=resumed_event,
+            suspended_event=suspended_event,
         )
-    except usb.core.USBError as e:
-        raise RuntimeError("Control transfer not sent") from e
-
-    print("CTRL transfer sent")
-
-    try:
-        usb.util.dispose_resources(dev)
-    except usb.core.USBError as e:
-        raise RuntimeError("Device resources not released") from e
-
-
-def check_remote_wake_feature(VID: int, PID: int, has_remote_wake: bool) -> None:
-    '''
-    Check if the device reports remote wakeup feature from it's configuration descriptor
-
-    :param VID: VID of the device
-    :param PID: PID of the device
-    :param has_remote_wake: Expect the device to does/does not feature with remote wakeup
-    '''
-
-    sleep(2)  # Some time for the OS to enumerate our USB device
-    dev = usb.core.find(idVendor=VID, idProduct=PID)
-    if dev is None:
-        raise ValueError("Device not found")
-
-    cfg = dev.get_active_configuration()
-    remote_wake_supported = bool(cfg.bmAttributes & USB_BM_ATTRIBUTES_WAKEUP)
-
-    if remote_wake_supported:
-        print("Device advertises remote wakeup feature in it's descriptor")
     else:
-        print("Device does not advertise remote wakeup feature in it's descriptor")
-
-    # Assertion to fail on mismatch
-    assert remote_wake_supported == has_remote_wake, (
-        f"Remote wakeup capability mismatch: "
-        f"expected {has_remote_wake}, "
-        f"device reports {remote_wake_supported}"
-    )
-
-    try:
-        usb.util.dispose_resources(dev)
-    except usb.core.USBError as e:
-        raise RuntimeError("Device resources not released") from e
+        run_suspend_resume_cdc_test(
+            dut,
+            resumed_event=resumed_event,
+            suspended_event=suspended_event,
+        )
 
 @pytest.mark.usb_device
-@pytest.mark.flaky(reruns=1, reruns_delay=10)
-@pytest.mark.parametrize(
-    'config, target',
-    [
-        pytest.param('default', 'esp32s2'),
-        pytest.param('default', 'esp32s3'),
-        pytest.param('default', 'esp32h4'),
-        pytest.param('default', 'esp32p4', marks=[pytest.mark.eco_default]),
-        pytest.param('esp32p4_eco4', 'esp32p4', marks=[pytest.mark.esp32p4_eco4]),
-        pytest.param('default', 'esp32s31'),
-    ],
-    indirect=['target'],
-)
-def test_usb_device_remote_wakeup_en(dut: IdfDut) -> None:
-    '''
-    Running the test locally:
-    1. Build the test app for your USB-OTG capable DUT
-    2. Connect you DUT to your test runner (local machine) with USB port and flashing port
-    3. Run `pytest --target <target>`
-
-    Test procedure:
-    1. Run the test on the DUT
-    2. Expect one COM Port in the system
-    3. Check the device's configuration descriptor, if it reports remote wakeup functionality
-    4. Enable the remote wakeup by sending a ctrl transfer
-    '''
-    sleep(5)
-    dut.expect_exact('Press ENTER to see the list of tests.')
-    dut.write('[device_pm_remote_wake]')
-    dut.expect_exact('TinyUSB: TinyUSB Driver installed')
-    sleep(2)
-
-    # Wait for device attach event
-    dut.expect_exact(TINYUSB_EVENTS['attached'])
-    # Check if the device reports remote wakeup feature
-    check_remote_wake_feature(DUT_VID, DUT_PID, has_remote_wake=True)
-
-    # Expect device suspend event (auto suspend) with remote wakeup disabled
-    dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_dis'])
-
-    # Enable remote wakeup on the device
-    set_remote_wake_on_device(DUT_VID, DUT_PID)
-
-    # Expect device to resume (ctrl transfer sent)
-    dut.expect_exact(TINYUSB_EVENTS['resumed'])
-    # Expect device suspend event (auto suspend) with remote wakeup enabled
-    dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
-
-    # Device called remote wakeup
-
-    # Expect device to resume (remote wakeup)
-    dut.expect_exact(TINYUSB_EVENTS['resumed'])
-
-    # Wait for the test app to finish
-    dut.expect_exact('PM_Device_main_app: Cleanup')
-    sleep(1)
-
-@pytest.mark.usb_device
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
 @pytest.mark.parametrize(
     'config, target',
     [
@@ -314,6 +261,63 @@ def test_usb_cdc_device_pm_public_api(dut: IdfDut) -> None:
     sleep(1)
 
 @pytest.mark.usb_device
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
+@pytest.mark.parametrize(
+    'config, target',
+    [
+        # Only HS port targets
+        pytest.param('otg_wake', 'esp32p4', marks=[pytest.mark.eco_default]),
+        pytest.param('otg_wake', 'esp32s31'),
+    ],
+    indirect=['target'],
+)
+def test_usb_device_light_sleep_usb_wakeup(dut: IdfDut) -> None:
+    '''
+    Running the test locally:
+    1. Build the test app for your USB-OTG capable DUT
+    2. Connect you DUT to your test runner (local machine) with USB port and flashing port
+    3. Run `pytest --target <target>`
+
+    Test procedure:
+    1. Run the light-sleep wakeup Unity test on the DUT
+    2. Wait for USB attach and auto suspend
+    3. After the DUT enters light sleep, access the CDC port to wake the SoC
+    4. Send data to the device and verify the echoed reply
+    5. Expect USB wakeup, bus resume, and data reception markers from the DUT
+    '''
+    sleep(5)
+    dut.expect_exact('Press ENTER to see the list of tests.')
+    dut.write('[tinyusb_light_sleep_otg_wake]')
+    dut.expect_exact('TinyUSB: TinyUSB Driver installed')
+    sleep(2)
+
+    ports = find_dut_cdc_ports()
+    if len(ports) == 0:
+        raise Exception('TinyUSB COM port not found')
+
+    try:
+        with Serial(ports[0], timeout=2) as cdc:
+
+            dut.expect_exact(TINYUSB_EVENTS['attached'])
+            dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
+            dut.expect_exact(TINYUSB_EVENTS['light_sleep_enter'])
+            # Stay in light sleep for some time
+            sleep(3)
+            cdc.write(b'Light sleep wake\r\n')
+            res = cdc.readline()
+            assert b'Light sleep ok\r\n' in res
+    except SerialException as e:
+        raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
+
+    dut.expect_exact(TINYUSB_EVENTS['resumed'])
+    dut.expect_exact(TINYUSB_EVENTS['light_sleep_data_rx'])
+    # Wait for the test app to finish
+    dut.expect_exact('PM_Device_main_app: Cleanup')
+    dut.expect_exact(TINYUSB_EVENTS['detached'])
+    sleep(1)
+
+@pytest.mark.usb_device
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
 @pytest.mark.parametrize(
     'config, target',
     [
@@ -323,8 +327,20 @@ def test_usb_cdc_device_pm_public_api(dut: IdfDut) -> None:
         pytest.param('default', 'esp32p4', marks=[pytest.mark.eco_default]),
         pytest.param('esp32p4_eco4', 'esp32p4', marks=[pytest.mark.esp32p4_eco4]),
         pytest.param('default', 'esp32s31'),
+        pytest.param('pm', 'esp32s2'),
+        pytest.param('pm', 'esp32s3'),
+        pytest.param('pm', 'esp32h4'),
+        pytest.param('pm', 'esp32p4', marks=[pytest.mark.eco_default]),
+        pytest.param('pm', 'esp32s31'),
+        pytest.param('pm_otg_wake', 'esp32p4', marks=[pytest.mark.eco_default]),
+        pytest.param('pm_otg_wake', 'esp32s31'),
     ],
     indirect=['target'],
 )
-def test_usb_device_pm(dut: IdfDut) -> None:
-    dut.run_all_single_board_cases(group='device_pm')
+def test_usb_pm_public_api(config: str, dut: IdfDut) -> None:
+    '''Testing tinyusb public API with basic configs'''
+
+    if config == 'default' or config == 'esp32p4_eco4':
+        dut.run_all_single_board_cases(group='driver_init_deinit')
+    else:
+        dut.run_all_single_board_cases(group='public_api_tinyusb_pm')

--- a/device/esp_tinyusb/test_apps/power_management/sdkconfig.ci.otg_wake
+++ b/device/esp_tinyusb/test_apps/power_management/sdkconfig.ci.otg_wake
@@ -1,0 +1,7 @@
+# Enable USB Peripheral as a light sleep wake-up source (Target dependent)
+CONFIG_PM_ENABLE=y
+CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+CONFIG_ESP_SLEEP_EVENT_CALLBACKS=y
+CONFIG_TINYUSB_USB_OTG_WAKEUP=y
+
+# Tinyusb Suspend/Resume events are registered internally in sdkconfig.defaults

--- a/device/esp_tinyusb/test_apps/power_management/sdkconfig.ci.pm
+++ b/device/esp_tinyusb/test_apps/power_management/sdkconfig.ci.pm
@@ -1,0 +1,6 @@
+# Enable Tinyusb power management
+CONFIG_PM_ENABLE=y
+CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+CONFIG_TINYUSB_PM=y
+
+# Tinyusb Suspend/Resume events are registered internally in sdkconfig.defaults

--- a/device/esp_tinyusb/test_apps/power_management/sdkconfig.ci.pm_otg_wake
+++ b/device/esp_tinyusb/test_apps/power_management/sdkconfig.ci.pm_otg_wake
@@ -1,0 +1,10 @@
+# Enable USB Peripheral as a light sleep wake-up source (Target dependent)
+CONFIG_PM_ENABLE=y
+CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+CONFIG_ESP_SLEEP_EVENT_CALLBACKS=y
+CONFIG_TINYUSB_USB_OTG_WAKEUP=y
+
+# Enable Tinyusb power management
+CONFIG_TINYUSB_PM=y
+
+# Tinyusb Suspend/Resume events are registered internally in sdkconfig.defaults

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_app_main.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_app_main.c
@@ -65,6 +65,6 @@ void app_main(void)
     printf("  \\_/ \\____/\\____/  \\_/                            \n");
 
     unity_utils_setup_heap_record(80);
-    unity_utils_set_leak_level(128);
+    unity_utils_set_leak_level(160);
     unity_run_menu();
 }

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_config.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_config.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -68,6 +68,7 @@ TEST_CASE("Config: Full-speed default (Full-speed)", "[runtime_config][full_spee
 #else
     TEST_ASSERT_EQUAL_MESSAGE(1, tusb_cfg.task.xCoreID, "Wrong default task affinity, should be 1 on multicore");
 #endif // CONFIG_FREERTOS_UNICORE
+    TEST_ASSERT_EQUAL_MESSAGE(false, tusb_cfg.pm_lock_enable, "Wrong default PM lock, should be disabled");
 }
 
 #else
@@ -88,6 +89,7 @@ TEST_CASE("Config: Full-speed (High-speed)", "[runtime_config][full_speed]")
     TEST_ASSERT_EQUAL_MESSAGE(TINYUSB_DEFAULT_TASK_SIZE, tusb_cfg.task.size, "Wrong default task size");
     TEST_ASSERT_EQUAL_MESSAGE(TINYUSB_DEFAULT_TASK_PRIO, tusb_cfg.task.priority, "Wrong default task priority");
     TEST_ASSERT_EQUAL_MESSAGE(1, tusb_cfg.task.xCoreID, "Wrong default task affinity, should be 1 on multicore");
+    TEST_ASSERT_EQUAL_MESSAGE(false, tusb_cfg.pm_lock_enable, "Wrong default PM lock, should be disabled");
 }
 
 /**
@@ -107,6 +109,7 @@ TEST_CASE("Config: High-speed default (High-speed)", "[runtime_config][high_spee
     TEST_ASSERT_EQUAL_MESSAGE(TINYUSB_DEFAULT_TASK_SIZE, tusb_cfg.task.size, "Wrong default task size");
     TEST_ASSERT_EQUAL_MESSAGE(TINYUSB_DEFAULT_TASK_PRIO, tusb_cfg.task.priority, "Wrong default task priority");
     TEST_ASSERT_EQUAL_MESSAGE(1, tusb_cfg.task.xCoreID, "Wrong default task affinity, should be 1 on multicore");
+    TEST_ASSERT_EQUAL_MESSAGE(false, tusb_cfg.pm_lock_enable, "Wrong default PM lock, should be disabled");
 }
 #endif // SOC_USB_OTG_PERIPH_NUM > 1
 

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_pm.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_pm.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_USB_OTG_SUPPORTED
+
+#include "esp_err.h"
+#include "unity.h"
+#include "tinyusb.h"
+#include "tinyusb_default_config.h"
+#include "device_handling.h"
+
+/**
+ * @brief TinyUSB PM specific testcase
+ *
+ * Scenario: Install and uninstall with default PM configuration (lock disabled)
+ * Awaiting: Install returns ESP_OK, device is enumerated, uninstall returns ESP_OK
+ */
+TEST_CASE("PM: install succeeds with lock disabled", "[runtime_config][full_speed][high_speed]")
+{
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
+    TEST_ASSERT_FALSE(tusb_cfg.pm_lock_enable);
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+    test_device_wait();
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+}
+
+/**
+ * @brief TinyUSB PM specific testcase
+ *
+ * Scenario: Install and uninstall with default PM configuration (lock enabled in config struct but not in sdkconfig)
+ * Awaiting: Install returns ESP_OK, device is enumerated, uninstall returns ESP_OK
+ */
+TEST_CASE("PM: install succeeds with lock enabled", "[runtime_config][full_speed][high_speed]")
+{
+    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG(test_device_event_handler);
+    tusb_cfg.pm_lock_enable = true;
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_install(&tusb_cfg));
+    test_device_wait();
+    TEST_ASSERT_EQUAL(ESP_OK, tinyusb_driver_uninstall());
+}
+
+#endif // SOC_USB_OTG_SUPPORTED

--- a/device/esp_tinyusb/tinyusb.c
+++ b/device/esp_tinyusb/tinyusb.c
@@ -19,6 +19,15 @@
 #include "msc_storage.h"
 #endif // CONFIG_TINYUSB_MSC_ENABLED
 
+#if (CONFIG_TINYUSB_PM)
+#include "tinyusb_pm.h"
+#endif // CONFIG_TINYUSB_PM
+
+#if (CONFIG_TINYUSB_USB_OTG_WAKEUP)
+#include "tinyusb_usb_wakeup.h"
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+
 const static char *TAG = "TinyUSB";
 
 /**
@@ -33,6 +42,8 @@ typedef struct {
 } tinyusb_ctx_t;
 
 static tinyusb_ctx_t s_ctx; // TinyUSB context
+
+static inline void pm_event(tinyusb_event_t *event);
 
 // ==================================================================================
 // ============================= TinyUSB Callbacks ==================================
@@ -57,6 +68,7 @@ void tud_mount_cb(void)
         .id = TINYUSB_EVENT_ATTACHED,
         .rhport = s_ctx.port,
     };
+    pm_event(&event);
 
     if (s_ctx.event_cb) {
         s_ctx.event_cb(&event, s_ctx.event_arg);
@@ -80,6 +92,7 @@ void tud_umount_cb(void)
         .id = TINYUSB_EVENT_DETACHED,
         .rhport = s_ctx.port,
     };
+    pm_event(&event);
 
     if (s_ctx.event_cb) {
         s_ctx.event_cb(&event, s_ctx.event_arg);
@@ -105,6 +118,7 @@ void tud_suspend_cb(bool remote_wakeup_en)
             .remote_wakeup = remote_wakeup_en,
         },
     };
+    pm_event(&event);
 
     // Save the remote wakeup enabled flag
     s_ctx.remote_wakeup_en = remote_wakeup_en;
@@ -129,6 +143,7 @@ void tud_resume_cb(void)
         .id = TINYUSB_EVENT_RESUMED,
         .rhport = s_ctx.port,
     };
+    pm_event(&event);
 
     if (s_ctx.event_cb) {
         s_ctx.event_cb(&event, s_ctx.event_arg);
@@ -137,11 +152,110 @@ void tud_resume_cb(void)
 #endif // CONFIG_TINYUSB_RESUME_CALLBACK
 
 // ==================================================================================
+// ============================== Power management ==================================
+// ==================================================================================
+
+#if CONFIG_TINYUSB_PM
+
+esp_err_t tinyusb_pm_get_lock_status(bool *acquired)
+{
+    ESP_RETURN_ON_FALSE(acquired, ESP_ERR_INVALID_ARG, TAG, "acquired can't be NULL");
+    ESP_RETURN_ON_FALSE(tud_inited(), ESP_ERR_INVALID_STATE, TAG, "TinyUSB driver is not installed");
+    ESP_RETURN_ON_ERROR(tinyusb_pm_lock_get(acquired), TAG, "Error getting tinyusb's PM status");
+    return ESP_OK;
+}
+#endif // CONFIG_TINYUSB_PM
+
+/**
+ * @brief Forward TinyUSB device events to the PM lock handler
+ *
+ * Dispatches attach, detach, suspend, and resume events to tinyusb power management
+ * when `CONFIG_TINYUSB_PM` is enabled.
+ *
+ * @param[in] event TinyUSB device event
+ */
+static inline void pm_event(tinyusb_event_t *event)
+{
+#if CONFIG_TINYUSB_PM
+    tinyusb_pm_on_event(event);
+#else
+    (void)event;
+#endif // CONFIG_TINYUSB_PM
+}
+
+/**
+ * @brief Install enabled TinyUSB power-management submodules
+ *
+ * Initializes USB Device light-sleep wakeup (`CONFIG_TINYUSB_USB_OTG_WAKEUP`) and/or
+ * PM lock management (`CONFIG_TINYUSB_PM`) according to Kconfig.
+ *
+ * @param[in] config Driver configuration passed to `tinyusb_driver_install()`
+ *
+ * @return
+ *      - ESP_OK on success or when no PM submodule is enabled in Kconfig
+ *      - Other error codes from USB wakeup or PM lock initialization
+ */
+static esp_err_t tinyusb_power_management_install(const tinyusb_config_t *config)
+{
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+    ESP_RETURN_ON_ERROR(tinyusb_usb_wakeup_init(config->port), TAG, "USB wakeup initialization failed");
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+#if CONFIG_TINYUSB_PM
+    const tinyusb_pm_config_t pm_cfg = {
+        .lock_enable = config->pm_lock_enable,
+    };
+    esp_err_t err = tinyusb_pm_init(&pm_cfg);
+    if (err != ESP_OK) {
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+        ESP_ERROR_CHECK(tinyusb_usb_wakeup_deinit());
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+        ESP_LOGE(TAG, "TinyUSB PM initialization failed");
+        return err;
+    }
+#else
+    if (config->pm_lock_enable) {
+        ESP_LOGW(TAG, "Tinyusb Power management is allowed in the configuration, but disabled in menuconfig");
+    }
+#endif // CONFIG_TINYUSB_PM
+    return ESP_OK;
+}
+
+/**
+ * @brief Uninstall enabled TinyUSB power-management submodules
+ *
+ * USB wakeup is torn down before PM lock deletion when both are enabled so light-sleep
+ * event callbacks cannot run while the PM lock is being released or deleted.
+ *
+ * @return
+ *      - ESP_OK on success or when no PM submodule is enabled in Kconfig
+ *      - Other error codes from PM lock or USB wakeup deinitialization
+ */
+static esp_err_t tinyusb_power_management_uninstall(void)
+{
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+    ESP_ERROR_CHECK(tinyusb_usb_wakeup_deinit());
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+#if CONFIG_TINYUSB_PM
+    ESP_ERROR_CHECK(tinyusb_pm_deinit());
+#endif // CONFIG_TINYUSB_PM
+
+    return ESP_OK;
+}
+
+
+// ==================================================================================
 // ============================= ESP TinyUSB Driver =================================
 // ==================================================================================
 
 /**
- * @brief Check the TinyUSB configuration
+ * @brief Validate the TinyUSB driver configuration before installation
+ *
+ * @param[in] config Driver configuration to validate
+ *
+ * @return
+ *      - ESP_OK if the configuration is valid
+ *      - ESP_ERR_INVALID_ARG if the input argument is NULL, the port is out of range, or the
+ *        selected port is not supported on the current target
  */
 static esp_err_t tinyusb_check_config(const tinyusb_config_t *config)
 {
@@ -160,7 +274,7 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     ESP_RETURN_ON_ERROR(tinyusb_check_config(config), TAG, "TinyUSB configuration check failed");
     ESP_RETURN_ON_ERROR(tinyusb_task_check_config(&config->task), TAG, "TinyUSB task configuration check failed");
 
-    esp_err_t ret;
+    esp_err_t ret = ESP_OK;
     usb_phy_handle_t phy_hdl = NULL;
     if (!config->phy.skip_setup) {
         // Configure USB PHY
@@ -192,6 +306,8 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     }
     // Init TinyUSB stack in task
     ESP_GOTO_ON_ERROR(tinyusb_task_start(config->port, &config->task, &config->descriptor), del_phy, TAG, "Init TinyUSB task failed");
+    // Install PM after PHY and task are up
+    ESP_GOTO_ON_ERROR(tinyusb_power_management_install(config), del_task, TAG, "TinyUSB power management install failed");
 
 #if (CONFIG_IDF_TARGET_ESP32P4) || (CONFIG_IDF_TARGET_ESP32S31)
     // Due to hardware limitations, VBUS cannot be monitored automatically by the High-Speed USB-OTG peripheral,
@@ -208,7 +324,8 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
             .port = (int)config->port,
         };
         ret = tinyusb_vbus_monitor_init(&vbus_cfg);
-        if (ESP_OK != ret) {
+        if (ret != ESP_OK) {
+            tinyusb_power_management_uninstall();
             tinyusb_task_stop();
             goto del_phy;
         }
@@ -224,8 +341,10 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     ESP_LOGI(TAG, "TinyUSB Driver installed on port %d", config->port);
     return ESP_OK;
 
+del_task:
+    tinyusb_task_stop();
 del_phy:
-    if (!config->phy.skip_setup) {
+    if (!config->phy.skip_setup && phy_hdl) {
         usb_del_phy(phy_hdl);
     }
     return ret;
@@ -234,6 +353,7 @@ del_phy:
 esp_err_t tinyusb_driver_uninstall(void)
 {
     ESP_RETURN_ON_ERROR(tinyusb_task_stop(), TAG, "Deinit TinyUSB task failed");
+    ESP_RETURN_ON_ERROR(tinyusb_power_management_uninstall(), TAG, "Deinit TinyUSB power management failed");
     if (s_ctx.phy_hdl) {
         ESP_RETURN_ON_ERROR(usb_del_phy(s_ctx.phy_hdl), TAG, "Unable to delete PHY");
         s_ctx.phy_hdl = NULL;
@@ -250,12 +370,17 @@ esp_err_t tinyusb_driver_uninstall(void)
 
 esp_err_t tinyusb_remote_wakeup(void)
 {
+    ESP_RETURN_ON_FALSE(tud_inited(), ESP_ERR_INVALID_STATE, TAG, "TinyUSB driver is not installed");
+    ESP_RETURN_ON_FALSE(tud_suspended(), ESP_ERR_NOT_ALLOWED, TAG, "USB device is not suspended");
     // Check if the remote wakeup flag was set by the esp_tinyusb's suspend callback
     // In case of user-defined suspend callback, user manages remote wakeup capability on it's own
 #ifdef CONFIG_TINYUSB_SUSPEND_CALLBACK
     ESP_RETURN_ON_FALSE(s_ctx.remote_wakeup_en, ESP_ERR_INVALID_STATE, TAG, "Remote wakeup is not enabled by the host");
 #endif // CONFIG_TINYUSB_SUSPEND_CALLBACK
 
+#ifdef CONFIG_TINYUSB_PM
+    ESP_RETURN_ON_ERROR(tinyusb_pm_remote_wake(), TAG, "Remote wakeup request to tinyusb PM failed");
+#endif // CONFIG_TINYUSB_PM
     ESP_RETURN_ON_FALSE(tud_remote_wakeup(), ESP_FAIL, TAG, "Remote wakeup request failed");
 
 #ifdef CONFIG_TINYUSB_SUSPEND_CALLBACK

--- a/device/esp_tinyusb/tinyusb_pm.c
+++ b/device/esp_tinyusb/tinyusb_pm.c
@@ -1,0 +1,390 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "freertos/FreeRTOS.h"
+#include "sdkconfig.h"
+#include "esp_idf_version.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_pm.h"
+#include "tinyusb_pm.h"
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+#include "tinyusb_usb_wakeup.h"
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+static const char *TAG = "TinyUSB-PM";
+
+static portMUX_TYPE tinyusb_pm_spinlock = portMUX_INITIALIZER_UNLOCKED;
+#define TINYUSB_PM_ENTER_CRITICAL()    portENTER_CRITICAL(&tinyusb_pm_spinlock)
+#define TINYUSB_PM_EXIT_CRITICAL()     portEXIT_CRITICAL(&tinyusb_pm_spinlock)
+
+/**
+ * Macro used in switch-case branch, to break off the case when error is returned
+ */
+#define PM_BREAK_ON_ERROR(x, fail_msg) do {     \
+        esp_err_t err_rc_ = (x);                \
+        if (unlikely(err_rc_ != ESP_OK)) {      \
+            ESP_LOGW(TAG, fail_msg);            \
+            break;                              \
+        }                                       \
+    } while (0)
+
+#define PM_CHECK(cond, ret_val) ({              \
+            if (!(cond)) {                      \
+                return (ret_val);               \
+            }                                   \
+})
+
+#define PM_CHECK_FROM_CRIT(cond, ret_val) ({    \
+            if (!(cond)) {                      \
+                TINYUSB_PM_EXIT_CRITICAL();     \
+                return (ret_val);               \
+            }                                   \
+})
+
+/**
+ * @brief TinyUSB power management context
+ */
+typedef struct {
+    struct {
+        // Dynamic members require a critical section
+        bool mounted;                   /*!< USB device configured by the host; required to enter suspend PM state */
+        bool suspended;                 /*!< USB Device suspended with PM lock released */
+        bool lock_acquired;             /*!< PM lock currently acquired */
+    } dynamic;
+    struct {
+        // Constant members do not change after registration thus do not require a critical section
+        bool lock_enabled;              /*!< PM lock enabled/disabled by user */
+        esp_pm_lock_handle_t lock;      /*!< PM lock object */
+    } constant;
+} tinyusb_pm_ctx_t;
+
+static tinyusb_pm_ctx_t s_pm_ctx;
+
+// ------------------------------------------------ PM lock management -------------------------------------------------
+
+/**
+ * @brief Sync tracked PM lock state with esp_pm_lock_get_stats()
+ * @note esp_pm_lock_get_stats() is available only in IDF 6.0 and newer
+ *
+ * @TODO: Get stats should be preferred over the flag tracking, once the IDF 5.5 is EOL
+ */
+static void tinyusb_pm_lock_sync(void)
+{
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    esp_pm_lock_instance_stats_t stats;
+
+    if (s_pm_ctx.constant.lock == NULL) {
+        return;
+    }
+    if (esp_pm_lock_get_stats(s_pm_ctx.constant.lock, &stats) != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to read PM lock stats for sync");
+        return;
+    }
+
+    // Lock acquired status from esp_pm instance
+    const bool stats_acquired = (stats.acquired != 0);
+
+    // Lock acquired status from the pm_context
+    bool pm_context_lock_acquired = false;
+    TINYUSB_PM_ENTER_CRITICAL();
+    pm_context_lock_acquired = s_pm_ctx.dynamic.lock_acquired;
+    TINYUSB_PM_EXIT_CRITICAL();
+
+    // Compare the esp_pm instance lock status and pm_context lock status if they are synced
+    if (stats_acquired != pm_context_lock_acquired) {
+        ESP_LOGW(TAG, "PM lock state mismatch: tracked=%d, stats=%d", pm_context_lock_acquired, stats_acquired);
+    }
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+}
+
+/**
+ * @brief Acquire the TinyUSB PM lock
+ *
+ * The spinlock is held across the flag check/update and lock acquire to prevent double-acquire of the PM lock
+ *
+ * @return
+ *      - ESP_OK on success or if the lock is already acquired
+ *      - Other error codes from called functions
+ */
+static esp_err_t tinyusb_pm_lock_acquire(void)
+{
+    esp_err_t err = ESP_OK;
+
+    TINYUSB_PM_ENTER_CRITICAL();
+    PM_CHECK_FROM_CRIT(!s_pm_ctx.dynamic.lock_acquired, ESP_OK);
+    err = esp_pm_lock_acquire(s_pm_ctx.constant.lock);
+    if (err == ESP_OK) {
+        s_pm_ctx.dynamic.lock_acquired = true;
+    }
+    TINYUSB_PM_EXIT_CRITICAL();
+    // Using ISR version, because the function could be called from the Light sleep exit callback's critical section
+    ESP_RETURN_ON_ERROR_ISR(err, TAG, "Lock acquire error");
+
+    tinyusb_pm_lock_sync();
+    ESP_EARLY_LOGD(TAG, "PM lock acquired");
+    return ESP_OK;
+}
+
+/**
+ * @brief Release the TinyUSB PM lock
+ *
+ * The spinlock is held across the flag check/update and lock release to prevent double-release of the PM lock
+ *
+ * @return
+ *      - ESP_OK on success or if the lock is not acquired
+ *      - Other error codes from called functions
+ */
+static esp_err_t tinyusb_pm_lock_release(void)
+{
+    esp_err_t err = ESP_OK;
+
+    TINYUSB_PM_ENTER_CRITICAL();
+    PM_CHECK_FROM_CRIT(s_pm_ctx.dynamic.lock_acquired, ESP_OK);
+    err = esp_pm_lock_release(s_pm_ctx.constant.lock);
+    if (err == ESP_OK) {
+        s_pm_ctx.dynamic.lock_acquired = false;
+    }
+    TINYUSB_PM_EXIT_CRITICAL();
+    ESP_RETURN_ON_ERROR(err, TAG, "Lock release error");
+
+    tinyusb_pm_lock_sync();
+    ESP_LOGD(TAG, "PM lock released");
+    return ESP_OK;
+}
+
+/**
+ * @brief Enter USB suspend PM state and release the PM lock
+ *
+ * Sets `suspended` before releasing the lock so the USB wakeup enter path can
+ * observe suspend state as soon as automatic light sleep becomes allowed.
+ *
+ * @return
+ *      - ESP_OK on success or when the PM lock is not enabled
+ *      - ESP_ERR_NOT_ALLOWED if the USB device is not mounted
+ *      - Other error codes from lock release
+ */
+static esp_err_t tinyusb_pm_enter_suspend(void)
+{
+    // Check if the PM lock is used
+    PM_CHECK(s_pm_ctx.constant.lock_enabled, ESP_OK);
+
+    TINYUSB_PM_ENTER_CRITICAL();
+    PM_CHECK_FROM_CRIT(s_pm_ctx.dynamic.mounted, ESP_ERR_NOT_ALLOWED);
+
+    // Mark as suspended first, before releasing the lock for safety
+    // Another core might query the suspended flag right after tinyusb_pm_lock_release() with the suspended flag still false
+    s_pm_ctx.dynamic.suspended = true;
+    TINYUSB_PM_EXIT_CRITICAL();
+
+    // Release PM lock to allow automatic light sleep when USB peripheral is in suspended state
+    const esp_err_t err = tinyusb_pm_lock_release();
+    if (err != ESP_OK) {
+        // Roll back to false
+        TINYUSB_PM_ENTER_CRITICAL();
+        s_pm_ctx.dynamic.suspended = false;
+        TINYUSB_PM_EXIT_CRITICAL();
+    }
+    return err;
+}
+
+/**
+ * @brief Leave USB suspend PM state and acquire the PM lock
+ *
+ * @return
+ *      - ESP_OK on success or when the PM lock is not enabled
+ *      - ESP_ERR_NOT_ALLOWED if the USB device is not mounted while in USB suspend PM state
+ *      - Other error codes from lock acquire
+ */
+static esp_err_t tinyusb_pm_leave_suspend(void)
+{
+    // Check if the PM lock is used
+    PM_CHECK(s_pm_ctx.constant.lock_enabled, ESP_OK);
+
+    TINYUSB_PM_ENTER_CRITICAL();
+    const bool in_suspend_pm = s_pm_ctx.dynamic.suspended;
+    if (in_suspend_pm) {
+        PM_CHECK_FROM_CRIT(s_pm_ctx.dynamic.mounted, ESP_ERR_NOT_ALLOWED);
+    }
+    TINYUSB_PM_EXIT_CRITICAL();
+
+    // Acquire PM lock to restrict automatic light sleep when USB peripheral is in resumed state
+    const esp_err_t err = tinyusb_pm_lock_acquire();
+    if (err == ESP_OK) {
+        TINYUSB_PM_ENTER_CRITICAL();
+        s_pm_ctx.dynamic.suspended = false;
+        TINYUSB_PM_EXIT_CRITICAL();
+    }
+    return err;
+}
+
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+/**
+ * @brief Read the synchronized USB suspend PM state
+ *
+ * @return True when the device is in USB suspend PM state
+ */
+static bool tinyusb_pm_get_pm_state(void)
+{
+    TINYUSB_PM_ENTER_CRITICAL();
+    const bool suspended = s_pm_ctx.dynamic.suspended;
+    TINYUSB_PM_EXIT_CRITICAL();
+    return suspended;
+}
+
+/**
+ * @brief Re-acquire the PM lock immediately after waking from light sleep on USB activity
+ *
+ * @note The PM lock would have normally been acquired by the resume callback some time later,
+ *       but it's necessary to acquire it immediately after waking from light sleep, to prevent light sleep re-entry
+ *
+ * Registered as a callback from `tinyusb_usb_wakeup.c`. Only acquires the lock
+ * while the device remains in USB suspend PM state.
+ *
+ * @return
+ *      - ESP_OK on success, when the PM lock is not enabled, or when the device is not in USB suspend PM state
+ *      - Other error codes from lock acquire
+ */
+static esp_err_t tinyusb_pm_on_light_sleep_usb_wakeup(void)
+{
+    PM_CHECK(s_pm_ctx.constant.lock_enabled, ESP_OK);
+    if (!tinyusb_pm_get_pm_state()) {
+        return ESP_OK;
+    }
+    return tinyusb_pm_lock_acquire();
+}
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+// --------------------------------------------------- Public API ------------------------------------------------------
+
+esp_err_t tinyusb_pm_init(const tinyusb_pm_config_t *config)
+{
+    esp_err_t ret = ESP_FAIL;
+    PM_CHECK(config != NULL, ESP_ERR_INVALID_ARG);
+
+    // Check if the user enabled the lock
+    if (!config->lock_enable) {
+        s_pm_ctx.constant.lock_enabled = false;
+        ESP_LOGD(TAG, "PM lock disabled in configuration");
+        return ESP_OK;
+    }
+
+    // Check if PM has been initialized and automatic light sleep has been enabled by user
+    esp_pm_config_t pm_config;
+    if (esp_pm_get_configuration(&pm_config) == ESP_OK && !pm_config.light_sleep_enable) {
+        ESP_LOGW(TAG, "pm_lock_enable is set but automatic light sleep is disabled. "
+                 "Configure esp_pm_configure() with light_sleep_enable=true to allow automatic light sleep "
+                 "when the USB PM lock is released");
+    }
+
+    // Initialize and acquire the lock
+    esp_pm_lock_handle_t pm_lock;
+    ESP_RETURN_ON_FALSE(s_pm_ctx.constant.lock == NULL, ESP_ERR_INVALID_STATE, TAG, "PM module already initialized");
+    ESP_RETURN_ON_ERROR(esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "usb_device", &pm_lock), TAG, "Failed to create PM lock");
+
+    s_pm_ctx.dynamic.mounted = false;
+    s_pm_ctx.dynamic.suspended = false;
+    s_pm_ctx.dynamic.lock_acquired = false;
+    s_pm_ctx.constant.lock_enabled = true;
+    s_pm_ctx.constant.lock = pm_lock;
+    ESP_GOTO_ON_ERROR(tinyusb_pm_lock_acquire(), acquire_err, TAG, "Failed to acquire PM lock on init");
+
+    // Register callbacks to tinyusb_usb_wakeup.c
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+    const tinyusb_usb_wakeup_pm_cbs_t pm_cbs = {
+        .pm_state = tinyusb_pm_get_pm_state,
+        .acquire_pm_lock = tinyusb_pm_on_light_sleep_usb_wakeup,
+    };
+    tinyusb_usb_wakeup_register_pm_cbs(&pm_cbs);
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+    ESP_LOGI(TAG, "PM lock initialized and acquired");
+    ret = ESP_OK;
+    return ret;
+
+acquire_err:
+    ESP_ERROR_CHECK(esp_pm_lock_delete(pm_lock));
+    s_pm_ctx.dynamic.lock_acquired = false;
+    s_pm_ctx.constant.lock = NULL;
+    s_pm_ctx.constant.lock_enabled = false;
+    return ret;
+}
+
+esp_err_t tinyusb_pm_deinit(void)
+{
+    // Unregister usb wakeup callbacks
+#if CONFIG_TINYUSB_USB_OTG_WAKEUP
+    tinyusb_usb_wakeup_register_pm_cbs(NULL);
+#endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
+
+    // Release and delete PM lock
+    if (s_pm_ctx.constant.lock != NULL) {
+        if (s_pm_ctx.constant.lock_enabled) {
+            ESP_RETURN_ON_ERROR(tinyusb_pm_lock_release(), TAG, "Failed to release PM lock");
+        }
+        ESP_RETURN_ON_ERROR(esp_pm_lock_delete(s_pm_ctx.constant.lock), TAG, "Failed to delete PM lock");
+        s_pm_ctx.constant.lock = NULL;
+    }
+
+    s_pm_ctx.dynamic.mounted = false;
+    s_pm_ctx.dynamic.suspended = false;
+    s_pm_ctx.dynamic.lock_acquired = false;
+    s_pm_ctx.constant.lock_enabled = false;
+    return ESP_OK;
+}
+
+void tinyusb_pm_on_event(tinyusb_event_t *event)
+{
+    switch (event->id) {
+    case TINYUSB_EVENT_ATTACHED:
+        if (!s_pm_ctx.constant.lock_enabled) {
+            break;
+        }
+        PM_BREAK_ON_ERROR(tinyusb_pm_lock_acquire(), "Failed to acquire PM lock on attach");
+        TINYUSB_PM_ENTER_CRITICAL();
+        s_pm_ctx.dynamic.mounted = true;
+        TINYUSB_PM_EXIT_CRITICAL();
+        break;
+    case TINYUSB_EVENT_DETACHED:
+        if (!s_pm_ctx.constant.lock_enabled) {
+            break;
+        }
+        PM_BREAK_ON_ERROR(tinyusb_pm_lock_acquire(), "Failed to acquire PM lock on detach");
+        TINYUSB_PM_ENTER_CRITICAL();
+        s_pm_ctx.dynamic.mounted = false;
+        s_pm_ctx.dynamic.suspended = false;
+        TINYUSB_PM_EXIT_CRITICAL();
+        break;
+    case TINYUSB_EVENT_SUSPENDED:
+        PM_BREAK_ON_ERROR(tinyusb_pm_enter_suspend(), "Failed to enter USB suspend PM state");
+        break;
+    case TINYUSB_EVENT_RESUMED:
+        PM_BREAK_ON_ERROR(tinyusb_pm_leave_suspend(), "Failed to leave USB suspend PM state");
+        break;
+    default:
+        ESP_LOGW(TAG, "Unhandled event %d", event->id);
+        return;
+    }
+}
+
+esp_err_t tinyusb_pm_remote_wake(void)
+{
+    PM_CHECK(s_pm_ctx.constant.lock_enabled, ESP_OK);
+    ESP_RETURN_ON_ERROR(tinyusb_pm_lock_acquire(), TAG, "Failed to acquire PM lock on remote wake");
+    return ESP_OK;
+}
+
+esp_err_t tinyusb_pm_lock_get(bool *lock_taken)
+{
+    PM_CHECK(lock_taken != NULL, ESP_ERR_INVALID_ARG);
+    ESP_RETURN_ON_FALSE(s_pm_ctx.constant.lock_enabled && s_pm_ctx.constant.lock != NULL, ESP_ERR_INVALID_STATE, TAG, "PM lock is not enabled");
+
+    tinyusb_pm_lock_sync();
+    TINYUSB_PM_ENTER_CRITICAL();
+    *lock_taken = s_pm_ctx.dynamic.lock_acquired;
+    TINYUSB_PM_EXIT_CRITICAL();
+    ESP_LOGD(TAG, "PM lock taken: %d", *lock_taken);
+    return ESP_OK;
+}

--- a/device/esp_tinyusb/tinyusb_usb_wakeup.c
+++ b/device/esp_tinyusb/tinyusb_usb_wakeup.c
@@ -1,0 +1,217 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_private/usb_phy.h"
+#include "esp_private/sleep_event.h"
+#include "tinyusb_usb_wakeup.h"
+#include "tusb.h"
+
+#include "esp_sleep.h"
+
+static const char *TAG = "TinyUSB-WAKE";
+
+#define USB_WAKE_CHECK(cond, ret_val) ({        \
+            if (!(cond)) {                      \
+                return (ret_val);               \
+            }                                   \
+})
+
+// ------------------------------------------- USB Device light-sleep wakeup -------------------------------------------
+
+typedef struct {
+    tinyusb_port_t port;                        /*!< USB port used by the driver */
+    bool port_configured;                       /*!< Port was configured during init */
+    bool otg_prepared_for_light_sleep;          /*!< UTMI OTG suspend state was set on light sleep enter */
+    tinyusb_usb_wakeup_pm_cbs_t pm_cbs;         /*!< Optional PM integration callbacks */
+} tinyusb_usb_wakeup_ctx_t;
+
+static tinyusb_usb_wakeup_ctx_t s_usb_wakeup_ctx;
+
+/**
+ * @brief Check whether the configured port supports USB light-sleep wakeup
+ *
+ * @param[in] port USB port used by the driver
+ *
+ * @return True when the port supports UTMI OTG wakeup preparation
+ */
+static bool port_supports_usb_wakeup(tinyusb_port_t port)
+{
+#if (SOC_USB_OTG_PERIPH_NUM > 1)
+    return port == TINYUSB_PORT_HIGH_SPEED_0;
+#else
+    (void)port;
+    return true;
+#endif // (SOC_USB_OTG_PERIPH_NUM > 1)
+}
+
+/**
+ * @brief Query whether the USB bus is suspended for light-sleep enter handling
+ *
+ * Uses the registered `pm_state` callback when available, otherwise falls back to
+ * `tud_suspended()`.
+ *
+ * @return True when the bus is considered suspended
+ */
+static bool usb_wakeup_is_bus_suspended(void)
+{
+    if (s_usb_wakeup_ctx.pm_cbs.pm_state != NULL) {
+        return s_usb_wakeup_ctx.pm_cbs.pm_state();
+    }
+    return tud_suspended();
+}
+
+/**
+ * @brief Restore UTMI OTG state after light sleep or driver deinitialization
+ */
+static void usb_wakeup_restore_otg_state(void)
+{
+    if (!s_usb_wakeup_ctx.otg_prepared_for_light_sleep) {
+        return;
+    }
+
+    s_usb_wakeup_ctx.otg_prepared_for_light_sleep = false;
+    usb_phy_set_otg_suspend_state(false);
+    usb_phy_clear_otg_wakeup_status();
+    ESP_LOGD(TAG, "USB OTG light-sleep state restored");
+}
+
+/**
+ * @brief Prepare UTMI OTG for USB wakeup before entering light sleep
+ *
+ * Only applies when the USB bus is suspended and the configured port supports wakeup.
+ *
+ * @param[in] user_arg Unused sleep event callback argument
+ * @param[in] ext_arg  Unused sleep event callback argument
+ *
+ * @return
+ *      - ESP_OK always; skips UTMI preparation when prerequisites are not met
+ */
+static esp_err_t usb_wakeup_enter_light_sleep(void *user_arg, void *ext_arg)
+{
+    (void)user_arg;
+    (void)ext_arg;
+
+    // UTMI PHY must not be already prepared for the light sleep
+    USB_WAKE_CHECK(!s_usb_wakeup_ctx.otg_prepared_for_light_sleep, ESP_OK);
+    // Port must support USB Wakeup (relevant only to P4 with 2 separate root ports)
+    USB_WAKE_CHECK(s_usb_wakeup_ctx.port_configured && port_supports_usb_wakeup(s_usb_wakeup_ctx.port), ESP_OK);
+    // Bus must be suspended (PM suspend state when registered, otherwise TinyUSB stack state)
+    USB_WAKE_CHECK(usb_wakeup_is_bus_suspended(), ESP_OK);
+
+    // Prepare PHY for light sleep
+    usb_phy_set_otg_suspend_state(true);
+
+    s_usb_wakeup_ctx.otg_prepared_for_light_sleep = true;
+    ESP_EARLY_LOGD(TAG, "USB OTG prepared for light sleep");
+    return ESP_OK;
+}
+
+/**
+ * @brief Restore UTMI OTG state after exiting light sleep
+ *
+ * @param[in] user_arg Unused sleep event callback argument
+ * @param[in] ext_arg  Unused sleep event callback argument
+ *
+ * @return
+ *      - ESP_OK on success or when UTMI OTG was not prepared for light sleep
+ *      - ESP_FAIL if the registered PM `acquire_pm_lock` callback fails
+ */
+static esp_err_t usb_wakeup_exit_light_sleep(void *user_arg, void *ext_arg)
+{
+    (void)user_arg;
+    (void)ext_arg;
+
+    // UTMI PHY must be already prepared for the light sleep
+    USB_WAKE_CHECK(s_usb_wakeup_ctx.otg_prepared_for_light_sleep, ESP_OK);
+
+    // Un-prepare PHY for light sleep
+    usb_phy_set_otg_suspend_state(false);
+    usb_phy_clear_otg_wakeup_status();
+
+    // Clear before PM acquire so a failed acquire cannot leave enter_light_sleep permanently skipped
+    s_usb_wakeup_ctx.otg_prepared_for_light_sleep = false;
+
+    // Acquire tinyusb PM lock, if PM is used
+    // It was observed, that the esp32p4 automatically re-enters light sleep after exiting it in case the PM lock
+    // is not acquired immediately after exiting light sleep. The esp32p4 light sleep exit sequence takes longer than
+    // on other targets and it also toggles PCLK of the UTMI PHY which forces the PHY into an undefined state
+    // and forces disconnection event. Acquiring PM lock immediately after light sleep exit removes this limitation.
+    if (s_usb_wakeup_ctx.pm_cbs.acquire_pm_lock != NULL) {
+        USB_WAKE_CHECK(s_usb_wakeup_ctx.pm_cbs.acquire_pm_lock() == ESP_OK, ESP_FAIL);
+    }
+    // Using _EARLY_ variant, because we are in a light sleep critical section
+    ESP_EARLY_LOGD(TAG, "USB OTG light-sleep state restored");
+    return ESP_OK;
+}
+
+/**
+ * @brief Callback configuration for enter light sleep event
+ */
+static const esp_sleep_event_cb_config_t enter_light_sleep_cb = {
+    .cb = usb_wakeup_enter_light_sleep,
+    .user_arg = NULL,
+    .prior = 2,
+    .next = NULL,
+};
+
+/**
+ * @brief Callback configuration for exit light sleep event
+ */
+static const esp_sleep_event_cb_config_t exit_light_sleep_cb = {
+    .cb = usb_wakeup_exit_light_sleep,
+    .user_arg = NULL,
+    .prior = 2,
+    .next = NULL,
+};
+
+void tinyusb_usb_wakeup_register_pm_cbs(const tinyusb_usb_wakeup_pm_cbs_t *cbs)
+{
+    if (cbs == NULL) {
+        s_usb_wakeup_ctx.pm_cbs.pm_state = NULL;
+        s_usb_wakeup_ctx.pm_cbs.acquire_pm_lock = NULL;
+    } else {
+        s_usb_wakeup_ctx.pm_cbs = *cbs;
+    }
+}
+
+esp_err_t tinyusb_usb_wakeup_init(tinyusb_port_t port)
+{
+    esp_err_t ret;
+    ESP_RETURN_ON_ERROR(esp_sleep_register_event_callback(SLEEP_EVENT_SW_GOTO_SLEEP, &enter_light_sleep_cb), TAG, "Failed to register goto light sleep callback");
+    ESP_GOTO_ON_ERROR(esp_sleep_register_event_callback(SLEEP_EVENT_SW_EXIT_SLEEP, &exit_light_sleep_cb), err, TAG, "Failed to register exit light sleep callback");
+    // Enable USB Wakeup should never fail, as long as the SOC_PM_SUPPORT_USB_WAKEUP is supported for a target
+    // Since this whole file is guarded by the same SOC cap, we just defensively check for error
+    ESP_ERROR_CHECK(esp_sleep_enable_usb_wakeup());
+
+    s_usb_wakeup_ctx.port = port;
+    s_usb_wakeup_ctx.port_configured = true;
+    s_usb_wakeup_ctx.otg_prepared_for_light_sleep = false;
+
+    ret = ESP_OK;
+    return ret;
+err:
+    // This should not fail, as long as light callback function pointer is not NULL, or sleep event ID is out of range
+    ESP_ERROR_CHECK(esp_sleep_unregister_event_callback(SLEEP_EVENT_SW_GOTO_SLEEP, usb_wakeup_enter_light_sleep));
+    return ret;
+}
+
+esp_err_t tinyusb_usb_wakeup_deinit(void)
+{
+    // This should not fail, as long as light callback function pointer is not NULL, or sleep event ID is out of range
+    ESP_ERROR_CHECK(esp_sleep_unregister_event_callback(SLEEP_EVENT_SW_GOTO_SLEEP, usb_wakeup_enter_light_sleep));
+    ESP_ERROR_CHECK(esp_sleep_unregister_event_callback(SLEEP_EVENT_SW_EXIT_SLEEP, usb_wakeup_exit_light_sleep));
+    // Disable USB Wakeup should never fail, as long as the SOC_PM_SUPPORT_USB_WAKEUP is supported for a target
+    // Since this whole file is guarded by the same SOC cap, we just defensively check for error
+    ESP_ERROR_CHECK(esp_sleep_disable_usb_wakeup());
+
+    // Deregister callbacks to PM module
+    tinyusb_usb_wakeup_register_pm_cbs(NULL);
+    usb_wakeup_restore_otg_state();
+    s_usb_wakeup_ctx.port_configured = false;
+    return ESP_OK;
+}


### PR DESCRIPTION
## Summary

Adds **power management (PM) lock support** to `esp_tinyusb`, enabling USB device applications to use automatic light sleep. While the USB bus is active, esp_tinyusb holds an `ESP_PM_NO_LIGHT_SLEEP` lock; on host suspend it releases the lock so the SoC can enter light sleep. On resume, attach, or remote wakeup, the lock is re-acquired.

Also adds optional **USB OTG light-sleep wakeup** for high-speed ports (ESP32-P4, ESP32-S31), preparing/restoring UTMI PHY state so the device can wake from light sleep on USB activity while the bus is suspended.

---

### Key changes

| Area | Details |
|------|---------|
| **Kconfig** | New *Power management* menu: `CONFIG_TINYUSB_PM`, `CONFIG_TINYUSB_USB_OTG_WAKEUP`|
| **Public API** | `tinyusb_config_t.pm_lock_enable`; `tinyusb_pm_get_lock_status()`; |
| **Implementation** | New `tinyusb_pm.c` (lock lifecycle tied to USB events) and `tinyusb_usb_wakeup.c` (light-sleep enter/exit UTMI OTG handling) |
| **Driver integration** | `tinyusb_driver_install()` / `uninstall()` initialize/teardown PM and wakeup; `tinyusb_remote_wakeup()` coordinates with PM lock during remote wakeup |

---

### PM lock behavior

Applies when `CONFIG_TINYUSB_PM=y` and `tinyusb_config_t.pm_lock_enable = true`. The lock is also **acquired on driver install** and **released on driver uninstall**. Otherwise, the USB Device would never be attached to the host as it will be automatically suspended by the time the install sequence finishes.

| Device event | PM lock action | Notes |
|--------------|----------------|-------|
| **Attach** (`TINYUSB_EVENT_ATTACHED`) | **Acquire** | Host has enumerated the device; prevent automatic light sleep while the bus is active |
| **Detach** (`TINYUSB_EVENT_DETACHED`) | **Acquire** | Device disconnected; lock stays held so the SoC does not enter light sleep while the driver remains installed |
| **Suspend** (`TINYUSB_EVENT_SUSPENDED`) | **Release** | Host suspended the bus; allows automatic light sleep while the USB peripheral is idle |
| **Resume** (`TINYUSB_EVENT_RESUMED`) | **Acquire** | Host resumed the bus; block automatic light sleep again while USB is active |
| **Remote wakeup** (`tinyusb_remote_wakeup()`) | **Acquire** | Called while the device is still suspended; holds the lock until the host completes resume so the SoC does not re-enter light sleep during the remote-wakeup handshake |

Additional notes:

- **Custom callbacks:** `CONFIG_TINYUSB_SUSPEND_CALLBACK` / `CONFIG_TINYUSB_RESUME_CALLBACK` are mandatory for this feature, thus the suspend/resume callbacks must be registered inside the `esp_tinyusb` to drive the suspend/resume.

### USB light-sleep wakeup (HS targets only)

- Enabled via `CONFIG_TINYUSB_USB_OTG_WAKEUP`
- Requires `esp_sleep_enable_usb_wakeup()`, `esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_ON)`, and related sleep setup
- **Independent of PM locks** — works with manual `esp_light_sleep_start()`, automatic light sleep via PM locks, or both
- **Not available on FS/LS-only ports** due to PHY limitations

## Tests added

### Unity tests (`test_apps/power_management`)

- **`sdkconfig.default`** - Only USB Peripheral suspend/resume events
- **`sdkconfig.ci.pm`** — PM locks enabled 
- **`sdkconfig.ci.pm_otg_wake`** — PM locks + USB OTG wakeup on ESP32-P4 / ESP32-S31
- **`sdkconfig.ci.otg_wake`** — USB wakeup without PM locks
---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes driver install/teardown, sleep/wake, and PM lock timing on USB suspend/resume; regressions could affect enumeration, remote wakeup, or light sleep on multiple SoCs, though behavior is gated by Kconfig and runtime flags.
> 
> **Overview**
> Adds **optional power management** to `esp_tinyusb` so USB device apps can use automatic light sleep without fighting an active USB bus.
> 
> With **`CONFIG_TINYUSB_PM`** and `tinyusb_config_t.pm_lock_enable`, the driver holds an **`ESP_PM_NO_LIGHT_SLEEP`** lock while the bus is active, **releases it on host suspend**, and re-acquires it on resume, attach, detach, and during **`tinyusb_remote_wakeup()`**. New **`tinyusb_pm_get_lock_status()`** exposes lock state; install/uninstall now initializes and tears down PM (with rollback on failure).
> 
> Adds **`CONFIG_TINYUSB_USB_OTG_WAKEUP`** (HS / UTMI targets such as ESP32-P4 and ESP32-S31): light-sleep enter/exit hooks prepare and restore OTG suspend state, **`esp_sleep_enable_usb_wakeup()`** runs at install, and PM can register callbacks so the lock is re-held immediately after USB wake.
> 
> **Kconfig**, **README**, and **CHANGELOG** document the options; **`esp_pm`** is always a private dependency. The **power_management** test app gains shared helpers, Unity cases for PM API and light-sleep USB wake, CI sdkconfigs (`pm`, `otg_wake`, `pm_otg_wake`), and expanded pytest coverage; CI rules skip OTG-wake configs on non-HS targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0d4afd9177024fbcb1faf4a9206a74b3d3dab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->