### PR TITLE
ci: Remove IDF 5.2 from CI

### DIFF
--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -43,7 +43,6 @@ jobs:
       matrix:
         idf_ver:
           [
-            "release-v5.2",
             "release-v5.3",
             "release-v5.4",
             "release-v5.5",

--- a/.github/workflows/build_and_run_main_ci.yml
+++ b/.github/workflows/build_and_run_main_ci.yml
@@ -61,8 +61,7 @@ jobs:
     needs: get-changed-files
     uses: ./.github/workflows/build_and_run_test_app_usb.yml
     with:
-      idf_releases: '["release-v5.2",
-                      "release-v5.3",
+      idf_releases: '["release-v5.3",
                       "release-v5.4",
                       "release-v5.5",
                       "release-v6.0",

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -46,8 +46,6 @@ jobs:
         exclude:
           # Exclude using managed usb component for older releases, only with service releases
           - test_app: host_managed
-            idf_ver: "release-v5.2"
-          - test_app: host_managed
             idf_ver: "release-v5.3"
           - test_app: host_managed
             idf_ver: "release-v5.4"
@@ -146,12 +144,7 @@ jobs:
             runner_tag: usb_host_flash_disk
           - test_app: host_managed
             runner_tag: usb_device
-          # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
-          - idf_ver: "release-v5.2"
-            idf_target: "esp32p4"
           # Exclude using managed usb component for older releases, only with service releases
-          - test_app: host_managed
-            idf_ver: "release-v5.2"
           - test_app: host_managed
             idf_ver: "release-v5.3"
           - test_app: host_managed


### PR DESCRIPTION
IDF version 5.2 reached End of Life on 16.8.2026

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only matrix and exclude cleanup with no application or library code changes.
> 
> **Overview**
> **Removes ESP-IDF `release-v5.2` from CI** now that IDF 5.2 reached end of life (per PR description).
> 
> The **IDF examples** workflow no longer builds against 5.2. The **main CI** workflow stops passing 5.2 into the reusable USB test-app workflow. That reusable workflow drops 5.2-specific matrix **exclude** rules that only existed for `host_managed` builds and **esp32p4** on 5.2 (p4 support starts at 5.3).
> 
> Supported IDF versions in these pipelines are now **5.3 through latest** (5.3, 5.4, 5.5, 6.0, 6.1, latest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572bf457e864f531e9f386ebe9972161ebab50ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->