### PR TITLE
fix(uvc): deliver isoc frames from cameras that never set the EOF flag (IEC-584)

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ISOC handling so empty packets with invalid UVC payload headers do not discard the current frame.
 - Fixed basic UVC stream example to support MJPEG frame buffer size estimation
 - Fixed `uvc_host_stream_close()` aborting the whole system (`ESP_ERROR_CHECK`) when the device is stalled or disconnected; interface release failure is now logged and cleanup continues (https://github.com/espressif/esp-usb/issues/529)
+- Fixed isochronous frame reconstruction for cameras that never set the EOF flag in the payload header: the frame-ID toggle is now treated as the frame boundary and the frame is delivered, instead of being discarded with a `missed EoF` warning. Such a camera previously delivered no frames at all.
 
 ## [2.5.1] - 2026-05-25
 

--- a/host/class/uvc/usb_host_uvc/uvc_isoc.c
+++ b/host/class/uvc/usb_host_uvc/uvc_isoc.c
@@ -167,8 +167,9 @@ void isoc_transfer_callback(usb_transfer_t *transfer)
                     goto next_isoc_packet;
                 }
             } else {
-                // Streaming was stopped in the meantime, do not take a new frame buffer
+                // Streaming was stopped in the meantime: no buffer to write this payload into
                 UVC_EXIT_CRITICAL();
+                uvc_stream->single_thread.skip_current_frame = true;
             }
         }
 

--- a/host/class/uvc/usb_host_uvc/uvc_isoc.c
+++ b/host/class/uvc/usb_host_uvc/uvc_isoc.c
@@ -148,11 +148,33 @@ void isoc_transfer_callback(usb_transfer_t *transfer)
                     goto next_isoc_packet;
                 }
             } else {
-                // We received SoF but current_frame is not NULL: We missed EoF - reset the frame buffer
-                ESP_EARLY_LOGW(TAG, "missed EoF");
-                uvc_stream->single_thread.skip_current_frame = true;
-                uvc_frame_reset(uvc_stream->dynamic.current_frame);
+                /* SoF with a frame still open means the previous frame carried no EoF flag.
+                 * Some cameras never set it - observed on a Logitech H.264 stream, where
+                 * 21 MB of valid payloads produced zero delivered frames on every
+                 * alternate setting - so the frame-ID toggle is the only frame boundary
+                 * available. Deliver what we have instead of discarding it, mirroring the
+                 * tolerance the bulk path gained in 2.5.1. */
+                uvc_host_frame_t *this_frame = uvc_stream->dynamic.current_frame;
+                uvc_stream->dynamic.current_frame = NULL;
+                const bool invoke_fb_callback = (uvc_stream->dynamic.streaming && uvc_stream->constant.frame_cb &&
+                                                 this_frame && !uvc_stream->single_thread.skip_current_frame);
                 UVC_EXIT_CRITICAL();
+
+                bool return_frame = true;
+                if (invoke_fb_callback) {
+                    return_frame = uvc_stream->constant.frame_cb(this_frame, uvc_stream->constant.cb_arg);
+                }
+                if (return_frame && this_frame) {
+                    uvc_host_frame_return(uvc_stream, this_frame);
+                }
+
+                /* Start a new frame for the payload that triggered this SoF. */
+                uvc_stream->single_thread.skip_current_frame = payload_header->bmHeaderInfo.error;
+                uvc_stream->dynamic.current_frame = uvc_frame_get_empty(uvc_stream);
+                if (uvc_stream->dynamic.current_frame == NULL) {
+                    uvc_stream->single_thread.skip_current_frame = true;
+                    goto next_isoc_packet;
+                }
             }
         }
 

--- a/host/class/uvc/usb_host_uvc/uvc_isoc.c
+++ b/host/class/uvc/usb_host_uvc/uvc_isoc.c
@@ -111,6 +111,25 @@ void isoc_transfer_callback(usb_transfer_t *transfer)
 
         const bool start_of_frame = (uvc_stream->single_thread.current_frame_id != payload_header->bmHeaderInfo.frame_id);
         if (start_of_frame) {
+            /* A frame still open at the frame-ID toggle means the camera sent no EoF.
+             * Deliver it here, while skip_current_frame still describes it. */
+            UVC_ENTER_CRITICAL();
+            uvc_host_frame_t *unterminated_frame = uvc_stream->dynamic.current_frame;
+            uvc_stream->dynamic.current_frame = NULL;
+            const bool invoke_unterminated_cb = (uvc_stream->dynamic.streaming && uvc_stream->constant.frame_cb &&
+                                                 unterminated_frame && !uvc_stream->single_thread.skip_current_frame);
+            UVC_EXIT_CRITICAL();
+
+            if (unterminated_frame) {
+                bool return_frame = true;
+                if (invoke_unterminated_cb) {
+                    return_frame = uvc_stream->constant.frame_cb(unterminated_frame, uvc_stream->constant.cb_arg);
+                }
+                if (return_frame) {
+                    uvc_host_frame_return(uvc_stream, unterminated_frame);
+                }
+            }
+
             // We detected start of new frame. Update Frame ID and start fetching this frame
             uvc_stream->single_thread.current_frame_id   = payload_header->bmHeaderInfo.frame_id;
 #ifdef CONFIG_UVC_CHECK_PAYLOAD_HEADER_ERR
@@ -148,33 +167,8 @@ void isoc_transfer_callback(usb_transfer_t *transfer)
                     goto next_isoc_packet;
                 }
             } else {
-                /* SoF with a frame still open means the previous frame carried no EoF flag.
-                 * Some cameras never set it - observed on a Logitech H.264 stream, where
-                 * 21 MB of valid payloads produced zero delivered frames on every
-                 * alternate setting - so the frame-ID toggle is the only frame boundary
-                 * available. Deliver what we have instead of discarding it, mirroring the
-                 * tolerance the bulk path gained in 2.5.1. */
-                uvc_host_frame_t *this_frame = uvc_stream->dynamic.current_frame;
-                uvc_stream->dynamic.current_frame = NULL;
-                const bool invoke_fb_callback = (uvc_stream->dynamic.streaming && uvc_stream->constant.frame_cb &&
-                                                 this_frame && !uvc_stream->single_thread.skip_current_frame);
+                // Streaming was stopped in the meantime, do not take a new frame buffer
                 UVC_EXIT_CRITICAL();
-
-                bool return_frame = true;
-                if (invoke_fb_callback) {
-                    return_frame = uvc_stream->constant.frame_cb(this_frame, uvc_stream->constant.cb_arg);
-                }
-                if (return_frame && this_frame) {
-                    uvc_host_frame_return(uvc_stream, this_frame);
-                }
-
-                /* Start a new frame for the payload that triggered this SoF. */
-                uvc_stream->single_thread.skip_current_frame = payload_header->bmHeaderInfo.error;
-                uvc_stream->dynamic.current_frame = uvc_frame_get_empty(uvc_stream);
-                if (uvc_stream->dynamic.current_frame == NULL) {
-                    uvc_stream->single_thread.skip_current_frame = true;
-                    goto next_isoc_packet;
-                }
             }
         }
 


### PR DESCRIPTION
# Checklist

- [ ] Version in `idf_component.yml` file bumped
- [x] CHANGELOG.md entry added
- [ ] _Optional:_ README.md updated
- [ ] CI passing

The version is left at 2.5.1 because the component already has an
`## [Unreleased]` section collecting changes since that release; the entry was
added there. Happy to bump it if you'd prefer the fix released on its own.

# Change description

The isochronous path only completes a frame when a payload header carries the
EOF flag. Some cameras never set it. Those hit the frame-ID toggle instead,
where the driver logged `missed EoF` and reset the frame buffer, so a fully
received frame was thrown away every time and the application got no frames at
all.

This treats the frame-ID toggle as the frame boundary: the frame in flight is
handed to the callback and returned, then a fresh buffer is picked up for the
new frame ID, which is what the EOF path already does.

## How it showed up

A H.264 UVC camera on an ESP32-P4. Payload data kept flowing and no USB errors
were reported, but zero EOF flags arrived and zero frames were delivered. It
reproduced on every alternate setting and at every resolution the camera
offers. With this change the stream comes up and the frames decode cleanly.

## Why this shape of fix

2.5.1 already made the bulk path tolerant of non-conforming cameras, described
in the changelog as "bulk frame reconstruction for non-conforming cameras that
can send a same-frame payload header without EOF". That covers a different case
than this one - a same-`frame_id` header with no EOF, rather than the frame-ID
toggle - and `uvc_bulk.c` still resets the frame when a toggle arrives with a
frame open. So this is the same intent applied to isoc, not a port of that
change.

## Relationship to #538

#538 reports the same `missed EoF` warning, but from a different cause: a
high-bandwidth alternate setting whose bandwidth the RX FIFO cannot sustain.
Worth calling out so this isn't read as a duplicate. The camera here triggers
the warning on plain, non high-bandwidth alternate settings too, where nothing
is being dropped for bandwidth reasons, so the two need separate fixes.

Cameras that do set EOF are unaffected: the toggle branch is only reached when
a frame is still open at a frame-ID change, which for a conforming camera does
not happen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live isochronous frame assembly and callback delivery; behavior change is limited to non-conforming EOF-less cameras, but regressions in frame boundaries or buffer lifetime would affect streaming apps.
> 
> **Overview**
> **Isochronous UVC** no longer drops complete frames from cameras that never set the payload header **EoF** bit. When the **frame ID** toggles while a frame buffer is still open, the driver used to log `missed EoF`, reset the buffer, and the app saw **no frames**; it now **delivers** that in-flight frame (callback + buffer return when streaming and not skipped), then starts the new frame like the normal EoF path.
> 
> The `need_new_frame` false branch is narrowed to the case where streaming stopped mid-packet—no buffer to write into—instead of treating every open buffer at ID toggle as a missed EoF.
> 
> CHANGELOG documents the behavior change. Cameras that always signal EoF should be unaffected because the toggle-with-open-buffer path should not run on conforming streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14853debd8b7ee55ba8667e4ff13a059b5fdc36a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review follow-ups

- `690db8d` - complete the unterminated frame at the top of the `start_of_frame`
  block, before the new frame's `skip_current_frame` is computed. The first
  version read that flag after it had already been recomputed for the incoming
  frame, so a corrupt frame could be delivered and a good one dropped. It also
  drops the redundant reassignment that discarded the MJPEG-SOI check and
  ignored `CONFIG_UVC_CHECK_PAYLOAD_HEADER_ERR`. Allocation now goes through the
  existing `need_new_frame` path, which already re-checks `dynamic.streaming`
  inside the critical section (thanks @tore-espressif) and carries the
  `FRAME_BUFFER_UNDERFLOW` notification.
- `14853de` - set `skip_current_frame` on that stop path, so a payload arriving
  after the stream was stopped is skipped instead of being handed to
  `uvc_frame_add_data()` with a NULL frame and reported as a spurious
  `FRAME_BUFFER_OVERFLOW`.
