### PR TITLE
feat(host): Support suspend/resume in dual host configuration

### DIFF
--- a/docs/en/usb_host.rst
+++ b/docs/en/usb_host.rst
@@ -397,6 +397,15 @@ USB Host library supports global Suspend/Resume, which suspends and resumes the 
 
 Note that the global Suspend/Resume also suspends/resumes the USB-OTG peripheral (not the whole SoC) on the USB Host side, and therefore reduces power consumption on the host controller itself. The global suspend/resume implements power saving by the DWC-OTG internal clock gating.
 
+.. only:: esp32p4
+
+    Global Suspend/Resume in dual host configuration
+    """"""""""""""""""""""""""""""""""""""""""""""""
+
+    When both USB-OTG controllers are enabled as USB hosts, they share a single power management state. :cpp:func:`usb_host_lib_root_port_suspend` suspends every root port that has a device connected, and :cpp:func:`usb_host_lib_root_port_resume` resumes every suspended root port. Root ports without a connected device are not affected.
+
+    Because both buses are always kept in the same power management state, anything that makes one bus active resumes the other one as well. This includes a device attach on a root port that was empty, a remote wakeup, and the automatic resume by transfer submit. Consequently, :cpp:member:`usb_host_lib_info_t::root_port_suspended` reports ``true`` only when no root port has an active device.
+
 Events
 ^^^^^^
 
@@ -429,7 +438,7 @@ Important considerations for the auto suspend timer:
 - When the timer expires, the USB Host library event is delivered only if:
 
     - A device is currently connected to the root port, and
-    - The root port is not already in a suspended state
+    - No root port with a connected device is already in a suspended state
 
 The auto suspend timer can be configured in the following modes:
 
@@ -545,6 +554,10 @@ The registered light sleep callbacks are:
   - the library does **not** automatically resume the root port. It only schedules the deferred suspend notification created by the pre-sleep callback, if that callback suspended the root port.
 
 After the SoC exits light sleep, the root port is kept suspended until the application is ready to communicate with the device again. Users can resume it explicitly with :cpp:func:`usb_host_lib_root_port_resume`, or submit a transfer to a suspended device and let the automatic resume-by-transfer path described in `Auto Resume by Transfer Submit`_ start the resume sequence.
+
+.. only:: esp32p4
+
+    In dual host configuration, all the root ports with a connected device enter and exit light sleep together. The state of every root port is validated before any of them is suspended, so the SoC never enters light sleep with one bus suspended and the other one still sending SOFs. If any root port is busy (for example executing a reset or a recovery sequence), the pre-sleep suspend is skipped entirely.
 
 Kconfig prerequisites
 """""""""""""""""""""

--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Global suspend/resume and the automatic suspend before light sleep now cover all the root ports. In dual host configuration on ESP32-P4 only the first root port used to be suspended, leaving the second USB-OTG controller sending SOFs. All the root ports are now kept in the same power management state: a device attach, a remote wakeup, or a transfer submission on one root port resumes the other one as well.
+
 ## [1.5.0] - 2026-06-16
 
 ### Changed

--- a/host/usb/include/usb/usb_host.h
+++ b/host/usb/include/usb/usb_host.h
@@ -96,7 +96,8 @@ typedef struct {
 typedef struct {
     int num_devices;            /**< Current number of connected (and enumerated) devices */
     int num_clients;            /**< Current number of registered clients */
-    bool root_port_suspended;   /**< Current status of the root port (suspended/resumed) */
+    bool root_port_suspended;   /**< Current status of the root ports (suspended/resumed). In dual host configuration,
+                                     this is true only if all the root ports with a connected device are suspended */
 } usb_host_lib_info_t;
 
 // ---------------------- Callbacks ------------------------
@@ -267,35 +268,41 @@ esp_err_t usb_host_lib_info(usb_host_lib_info_t *info_ret);
 esp_err_t usb_host_lib_set_root_port_power(bool enable);
 
 /**
- * @brief Suspend the root port
+ * @brief Suspend the root ports
  *
  * - The function checks, if a device is connected and if a transfer is submitted
- * - Then halts and flushes all endpoints of all the connected devices and suspends the root port
+ * - Then halts and flushes all endpoints of all the connected devices and suspends the root ports
  * - Finally, it notifies all the clients which opened the device, that the device is now suspended
  *
  * @note Remote wakeup from device is not implemented yet
- * @note The root port and the devices are not suspended immediately after returning from this function, this function
- *       only sets actions for devices and root port, which are handled by the usb_host_lib_handle_events() in separate task.
+ * @note The root ports and the devices are not suspended immediately after returning from this function, this function
+ *       only sets actions for devices and root ports, which are handled by the usb_host_lib_handle_events() in separate task.
+ * @note This is a global suspend. In dual host configuration, all the root ports with a connected device are suspended.
+ *       Root ports without a device are not affected. Selective suspend of a single device or a single root port is
+ *       not supported.
  * @return
- *    - ESP_OK: Root port marked to be suspended, or already issuing a suspend sequence
+ *    - ESP_OK: Root ports marked to be suspended, or already issuing a suspend sequence
  *    - ESP_ERR_NOT_FOUND: No device is connected
- *    - ESP_ERR_INVALID_STATE: Root port is not in correct state to be suspended
+ *    - ESP_ERR_INVALID_STATE: No root port is in correct state to be suspended
  */
 esp_err_t usb_host_lib_root_port_suspend(void);
 
 /**
- * @brief Resume the root port from suspended state
+ * @brief Resume the root ports from suspended state
  *
- * - The function resumes the root port from suspended state
+ * - The function resumes the root ports from suspended state
  * - Then resumes all the endpoints of all the connected devices
  * - Finally, it notifies all the clients which opened the device, that the device is now resumed
  *
- * @note The root port and the devices are not resumed immediately after returning from this function, this function
- *       only sets actions for devices and root port, which are handled by the usb_host_lib_handle_events() in separate task.
+ * @note The root ports and the devices are not resumed immediately after returning from this function, this function
+ *       only sets actions for devices and root ports, which are handled by the usb_host_lib_handle_events() in separate task.
+ * @note This is a global resume. In dual host configuration, all the suspended root ports are resumed, so that all
+ *       the root ports always end up in the same power management state. A device attach, a remote wakeup, or a
+ *       transfer submission on one root port therefore resumes the other root port as well.
  * @return
- *    - ESP_OK: Root port marked to be resumed, or already issuing a resume sequence
+ *    - ESP_OK: Root ports marked to be resumed, or already issuing a resume sequence
  *    - ESP_ERR_NOT_FOUND: No device is connected
- *    - ESP_ERR_INVALID_STATE: Root port is not in correct state to be resumed
+ *    - ESP_ERR_INVALID_STATE: No root port is in correct state to be resumed
  */
 esp_err_t usb_host_lib_root_port_resume(void);
 

--- a/host/usb/include/usb/usb_host.h
+++ b/host/usb/include/usb/usb_host.h
@@ -274,7 +274,6 @@ esp_err_t usb_host_lib_set_root_port_power(bool enable);
  * - Then halts and flushes all endpoints of all the connected devices and suspends the root ports
  * - Finally, it notifies all the clients which opened the device, that the device is now suspended
  *
- * @note Remote wakeup from device is not implemented yet
  * @note The root ports and the devices are not suspended immediately after returning from this function, this function
  *       only sets actions for devices and root ports, which are handled by the usb_host_lib_handle_events() in separate task.
  * @note This is a global suspend. In dual host configuration, all the root ports with a connected device are suspended.

--- a/host/usb/private_include/hub.h
+++ b/host/usb/private_include/hub.h
@@ -199,11 +199,12 @@ esp_err_t hub_root_mark_resume(void);
 /**
  * @brief Mark the Hub driver's root ports as ready to exit the light sleep
  *
- * This will mark all the suspended root ports as ready to exit light sleep and will be processed by the hub
+ * This will mark each auto-suspended root port as ready to exit light sleep and will be processed by the hub
  * processing loop. All the root ports enter and exit light sleep together.
  * @note This function:
  *   - Delivers deferred suspend notification (as the root ports had entered the light sleep before) to the clients
- *   - Treats potential device disconnect in the light sleep, if that happened no suspend notification will be delivered
+ *   - Treats potential device disconnect in the light sleep per root port: a disconnected port does not get a
+ *     suspend notification, but sibling root ports that stayed connected still do
  *
  * @return
  *    - ESP_OK: Hub driver marked to exit light sleep successfully

--- a/host/usb/private_include/hub.h
+++ b/host/usb/private_include/hub.h
@@ -128,102 +128,105 @@ esp_err_t hub_root_start(void);
 esp_err_t hub_root_stop(void);
 
 /**
- * @brief Check if a root port is in suspended state
+ * @brief Check if the Hub driver's root ports are in suspended state
  *
- * This will check root port state. In multi-port configurations, this currently
- * checks the first enabled root port only.
+ * All the enabled root ports share a single power management state, thus the Hub driver is considered suspended
+ * only if no root port has an active (enabled) device. Root ports without a device are not taken into account.
  *
  * @return
- *    - true: Root port is in suspended state
- *    - false: Root port is in any other state
+ *    - true: At least one root port is suspended and no root port is active
+ *    - false: Any root port is active, or no root port is suspended
  */
 bool hub_root_is_suspended(void);
 
 /**
- * @brief Check if the Hub driver's root port can be suspended
+ * @brief Check if the Hub driver's root ports can be suspended
  *
- * This will check if all HCD pipes are idle and which state the root port is in.
- * In multi-port configurations, this currently checks the first enabled root port only.
+ * This will check if all HCD pipes are idle and which state the root ports are in.
+ * All the root ports with an active device are checked, root ports without a device are skipped.
  *
  * @return
- *    - ESP_OK: Hub driver's root port can be suspended
+ *    - ESP_OK: Hub driver's root ports can be suspended
  *    - ESP_ERR_INVALID_STATE: Hub driver is not installed
- *    - ESP_ERR_NOT_FINISHED: HCD pipes routed through this port are still executing
- *    - ESP_ERR_TIMEOUT: Root port is already issuing a suspend command and is within a SUSPEND_ENTRY_MS timeout
- *    - ESP_ERR_NOT_ALLOWED: Root port is in other than enabled state
+ *    - ESP_ERR_NOT_FINISHED: HCD pipes routed through any of the root ports are still executing
+ *    - ESP_ERR_TIMEOUT: All the root ports are already issuing a suspend command and are within a SUSPEND_ENTRY_MS timeout
+ *    - ESP_ERR_NOT_ALLOWED: No root port is in enabled state
  */
 esp_err_t hub_root_can_suspend(void);
 
 /**
- * @brief Check if the Hub driver's root port can be resumed
+ * @brief Check if the Hub driver's root ports can be resumed
  *
- * In multi-port configurations, this currently checks the first enabled root port only.
+ * All the suspended root ports are checked.
  *
  * @return
- *    - ESP_OK: Hub driver's root port can be resumed
+ *    - ESP_OK: At least one root port can be resumed
  *    - ESP_ERR_INVALID_STATE: Hub driver is not installed
- *    - ESP_ERR_TIMEOUT: Root port is already issuing a resume command and is within a RESUME_RECOVERY_MS,
+ *    - ESP_ERR_TIMEOUT: The root ports are already issuing a resume command and are within a RESUME_RECOVERY_MS,
  *      or a RESUME_HOLD_MS timeout
- *    - ESP_ERR_NOT_ALLOWED: Root port is in other than suspended state, or HCD port is in incorrect state
+ *    - ESP_ERR_NOT_ALLOWED: No root port is in suspended state, or all HCD ports are in incorrect state
  */
 esp_err_t hub_root_can_resume(void);
 
 /**
- * @brief Mark the Hub driver's root port as ready for suspend
+ * @brief Mark the Hub driver's root ports as ready for suspend
  *
- * This will mark the root port as ready to be suspended and will be processed by the hub processing loop.
- * In multi-port configurations, this currently targets the first enabled root port only.
+ * This will mark all the root ports with an active device as ready to be suspended and will be processed by the hub
+ * processing loop. Root ports without a device are left untouched.
  *
  * @return
- *    - ESP_OK: Hub driver suspended successfully
+ *    - ESP_OK: At least one root port marked to be suspended
  *    - ESP_ERR_INVALID_STATE: Hub driver is not installed
- *    - ESP_ERR_NOT_ALLOWED: Root port is in other than enabled state
+ *    - ESP_ERR_NOT_ALLOWED: No root port is in enabled state
  */
 esp_err_t hub_root_mark_suspend(void);
 
 /**
- * @brief Mark the Hub driver's root port as ready for resume
+ * @brief Mark the Hub driver's root ports as ready for resume
  *
- * This will mark the root port as ready to be resumed and will be processed by the hub processing loop.
- * In multi-port configurations, this currently targets the first enabled root port only.
+ * This will mark all the suspended root ports as ready to be resumed and will be processed by the hub processing loop.
+ * All the root ports are resumed together, so that they always end up in the same power management state.
  *
  * @return
- *    - ESP_OK: Hub driver resumed successfully
+ *    - ESP_OK: At least one root port marked to be resumed
  *    - ESP_ERR_INVALID_STATE: Hub driver is not installed
- *    - ESP_ERR_NOT_ALLOWED: Root port is in other than suspended state
+ *    - ESP_ERR_NOT_ALLOWED: No root port is in suspended state
  */
 esp_err_t hub_root_mark_resume(void);
 
 #ifdef AUTO_PM_LIGHT_SLEEP
 
 /**
- * @brief Mark the Hub driver's root port as ready to exit the light sleep
+ * @brief Mark the Hub driver's root ports as ready to exit the light sleep
  *
- * This will mark the root port as ready to exit light sleep and will be processed by the hub processing loop.
- * In multi-port configurations, this currently targets the first enabled root port only.
+ * This will mark all the suspended root ports as ready to exit light sleep and will be processed by the hub
+ * processing loop. All the root ports enter and exit light sleep together.
  * @note This function:
- *   - Delivers deferred suspend notification (as the root port had entered the light sleep before) to the clients
+ *   - Delivers deferred suspend notification (as the root ports had entered the light sleep before) to the clients
  *   - Treats potential device disconnect in the light sleep, if that happened no suspend notification will be delivered
  *
  * @return
  *    - ESP_OK: Hub driver marked to exit light sleep successfully
  *    - ESP_ERR_INVALID_STATE: Hub driver is not installed
- *    - ESP_ERR_NOT_ALLOWED: Root port is in other than suspended state
+ *    - ESP_ERR_NOT_ALLOWED: No root port is in suspended state
  */
 esp_err_t hub_root_mark_exit_light_sleep(void);
 
 /**
  * @brief Minimal root suspend for automatic light sleep (synchronous)
  *
- * Halt and flush all device endpoints, issue HCD_PORT_CMD_SUSPEND_LIGHT_SLEEP on the root port, mark the root hub
- * suspended, and update USBH device suspended state without client-visible suspend events (those follow on resume).
+ * Halt and flush all device endpoints, issue HCD_PORT_CMD_SUSPEND_LIGHT_SLEEP on every root port with an active
+ * device, mark the root hub suspended, and update USBH device suspended state without client-visible suspend events
+ * (those follow on resume).
  *
  * @note The device actions are done synchronously to decrease enter light sleep latency
+ * @note The state of all the root ports is validated before any of them is suspended, so that the SoC never enters
+ *       light sleep with one bus suspended and another one active
  *
  * @return
- *   - ESP_OK: Root port successfully suspended, already suspended, powered off, or no device connected
+ *   - ESP_OK: Root ports successfully suspended, already suspended, powered off, or no device connected
  *   - ESP_ERR_INVALID_STATE: Hub driver is in invalid state
- *   - ESP_ERR_NOT_FINISHED: HCD port is not in a correct state to be suspended (executing reset, recovery, resume sequence..)
+ *   - ESP_ERR_NOT_FINISHED: Any HCD port is not in a correct state to be suspended (executing reset, recovery, resume sequence..)
  *   - Other errors from calling functions
  */
 esp_err_t hub_root_light_sleep_suspend_bus(void);

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -96,6 +96,9 @@ typedef struct {
     struct {
         unsigned int reqs;
         root_port_state_t state;                    /**< Root port state */
+#ifdef AUTO_PM_LIGHT_SLEEP
+        uint32_t light_sleep_auto_pm: 1;            /**< This root port was automatically suspended from the light sleep callback */
+#endif // AUTO_PM_LIGHT_SLEEP
     } dynamic;
 } root_hub_port_t;
 
@@ -104,8 +107,7 @@ typedef struct {
         union {
             struct {
                 hub_flag_action_t actions: 8;       /**< Hub actions */
-                uint32_t light_sleep_auto_pm: 1;    /**< Root port was automatically suspended from light sleep callback, when entering light sleep */
-                uint32_t reserved23: 23;            /**< Reserved */
+                uint32_t reserved24: 24;            /**< Reserved */
             };
             uint32_t val;                           /**< Hub flag action value */
         } flags;                                    /**< Hub flags */
@@ -495,7 +497,7 @@ static void root_port_handle_events(root_hub_port_t *root_hub_port)
     case HCD_PORT_EVENT_CONNECTION: {
         if (hcd_port_command(root_port_hdl, HCD_PORT_CMD_RESET) != ESP_OK) {
             ESP_LOGE(HUB_DRIVER_TAG, "Root port reset failed");
-            goto reset_err;
+            break;
         }
         ESP_LOGD(HUB_DRIVER_TAG, "Root port reset");
         usb_speed_t speed;
@@ -523,13 +525,15 @@ static void root_port_handle_events(root_hub_port_t *root_hub_port)
         // All root ports share a single PM state. A device attaching to one bus makes the whole Host active,
         // so any bus that is still suspended must be resumed together with this connection.
         if (sibling_suspended) {
-            hub_root_mark_resume();
+            esp_err_t ret = hub_root_mark_resume();
+            if (ret != ESP_OK) {
+                ESP_LOGE(HUB_DRIVER_TAG, "Root hub resume err: %s", esp_err_to_name(ret));
+            }
         }
         break;
 new_dev_err:
         // We allow this to fail in case a disconnect/port error happens while disabling.
         hcd_port_command(root_port_hdl, HCD_PORT_CMD_DISABLE);
-reset_err:
         break;
     }
     case HCD_PORT_EVENT_DISCONNECTION:
@@ -551,7 +555,9 @@ reset_err:
             // Clear stale suspended state so resume-by-transfer is not attempted on a recovery port
             root_hub_port->dynamic.state = ROOT_PORT_STATE_ENABLED;
 #ifdef AUTO_PM_LIGHT_SLEEP
-            p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 0;
+            // Clear this port's auto-PM flag only. Sibling root ports that stayed connected must still
+            // receive the deferred suspend notification after wake-up
+            root_hub_port->dynamic.light_sleep_auto_pm = 0;
 #endif // AUTO_PM_LIGHT_SLEEP
             break;
         default:
@@ -1132,28 +1138,35 @@ esp_err_t hub_root_mark_resume(void)
 
 esp_err_t hub_root_mark_exit_light_sleep(void)
 {
+    int num_auto_pm = 0;
     int num_marked = 0;
 
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
-    // Return early, if the root ports were not suspended from the light sleep callback (suspend event already delivered)
-    HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm != 0, ESP_OK);
-    // Root ports suspended from the light sleep callback, deliver the suspend event
-    p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 0;
 
-    // All the root ports enter and exit light sleep together
+    // Each root port that was auto-suspended from the light sleep callback gets a deferred suspend event.
+    // A sibling port that disconnected during light sleep already cleared its own flag, so it is skipped
+    // and does not prevent the remaining ports from being marked.
     for (int i = 0; i < HCD_NUM_PORTS; i++) {
         root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[i];
+        if (!root_port_is_installed(root_hub_port) || root_hub_port->dynamic.light_sleep_auto_pm == 0) {
+            continue;
+        }
+        num_auto_pm++;
+        root_hub_port->dynamic.light_sleep_auto_pm = 0;
         // Root port must be in suspended state
         // This state is a stale state taken when entering light sleep, port might have undergone reset or error,
         // but the usb host lib has not have a chance to run, thus to update the port state
-        if (root_port_is_installed(root_hub_port) && root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED) {
+        if (root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED) {
             _root_port_set_req(root_hub_port, PORT_REQ_EXIT_LIGHT_SLEEP);
             num_marked++;
         }
     }
     HUB_DRIVER_EXIT_CRITICAL();
 
+    // Return early if no root port was auto-suspended from the light sleep callback
+    // (suspend event already delivered, or the auto-suspended port(s) disconnected during sleep)
+    HUB_DRIVER_CHECK(num_auto_pm > 0, ESP_OK);
     HUB_DRIVER_CHECK(num_marked > 0, ESP_ERR_NOT_ALLOWED);
 
     // Call processing callback
@@ -1210,7 +1223,7 @@ esp_err_t hub_root_light_sleep_suspend_bus(void)
         ESP_RETURN_ON_ERROR(hcd_port_command(ports_to_suspend[i]->constant.hdl, HCD_PORT_CMD_SUSPEND_LIGHT_SLEEP),
                             HUB_DRIVER_TAG, "Port suspend cmd failed");
         HUB_DRIVER_ENTER_CRITICAL();
-        p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 1;
+        ports_to_suspend[i]->dynamic.light_sleep_auto_pm = 1;
         ports_to_suspend[i]->dynamic.state = ROOT_PORT_STATE_SUSPENDED;
         HUB_DRIVER_EXIT_CRITICAL();
     }

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -168,6 +168,51 @@ static bool root_port_callback(hcd_port_handle_t port_hdl, hcd_port_event_t port
 
 // ---------------------- Internal Logic ------------------------
 
+/**
+ * @brief Check whether a root port was selected by the port map during Hub driver installation
+ *
+ * @param[in] root_hub_port Root port object
+ * @return
+ *    - true: Root port is installed and can be commanded
+ *    - false: Root port is not present in this configuration
+ */
+static inline bool root_port_is_installed(const root_hub_port_t *root_hub_port)
+{
+    return root_hub_port->constant.hdl != NULL;
+}
+
+/**
+ * @brief Get the Hub driver action flag that schedules processing of the root port's requests
+ *
+ * @param[in] root_hub_port Root port object
+ * @return Hub driver action flag of the root port
+ */
+static inline hub_flag_action_t root_port_req_action(const root_hub_port_t *root_hub_port)
+{
+#if HCD_NUM_PORTS > 1
+    if (root_hub_port->constant.index != 0) {
+        return HUB_DRIVER_ACTION_ROOT1_REQ;
+    }
+#endif // HCD_NUM_PORTS > 1
+    assert(root_hub_port->constant.index == 0);
+    return HUB_DRIVER_ACTION_ROOT0_REQ;
+}
+
+/**
+ * @brief Add a request to a root port and schedule the Hub driver to process it
+ *
+ * @note This function must be called from a critical section
+ * @note The caller is responsible for calling the processing request callback
+ *
+ * @param[in] root_hub_port Root port object
+ * @param[in] port_req Port request flag (PORT_REQ_*)
+ */
+static inline void _root_port_set_req(root_hub_port_t *root_hub_port, unsigned int port_req)
+{
+    root_hub_port->dynamic.reqs |= port_req;
+    p_hub_driver_obj->dynamic.flags.actions |= root_port_req_action(root_hub_port);
+}
+
 static dev_tree_node_t *dev_tree_node_get_by_uid(unsigned int node_uid)
 {
     dev_tree_node_t *dev_tree_node = NULL;
@@ -464,9 +509,22 @@ static void root_port_handle_events(root_hub_port_t *root_hub_port)
         }
 
         // Change Port state
+        bool sibling_suspended = false;
         HUB_DRIVER_ENTER_CRITICAL();
         root_hub_port->dynamic.state = ROOT_PORT_STATE_ENABLED;
+        for (int i = 0; i < HCD_NUM_PORTS; i++) {
+            if (p_hub_driver_obj->root_hub_ports[i].dynamic.state == ROOT_PORT_STATE_SUSPENDED) {
+                sibling_suspended = true;
+                break;
+            }
+        }
         HUB_DRIVER_EXIT_CRITICAL();
+
+        // All root ports share a single PM state. A device attaching to one bus makes the whole Host active,
+        // so any bus that is still suspended must be resumed together with this connection.
+        if (sibling_suspended) {
+            hub_root_mark_resume();
+        }
         break;
 new_dev_err:
         // We allow this to fail in case a disconnect/port error happens while disabling.
@@ -482,16 +540,7 @@ reset_err:
         switch (root_hub_port->dynamic.state) {
         case ROOT_PORT_STATE_POWERED: // This occurred before enumeration
             // Therefore, there's no device object to clean up, and we can go straight to port recovery
-            root_hub_port->dynamic.reqs |= PORT_REQ_RECOVER;
-            if (root_hub_port->constant.index == 0) {
-                p_hub_driver_obj->dynamic.flags.actions |= HUB_DRIVER_ACTION_ROOT0_REQ;
-            } else {
-#if HCD_NUM_PORTS > 1
-                p_hub_driver_obj->dynamic.flags.actions |= HUB_DRIVER_ACTION_ROOT1_REQ;
-#else
-                abort();    // Should never occur
-#endif // HCD_NUM_PORTS > 1
-            }
+            _root_port_set_req(root_hub_port, PORT_REQ_RECOVER);
             break;
         case ROOT_PORT_STATE_NOT_POWERED: // The user turned off ports' power. Indicate to USBH that the device is gone
         case ROOT_PORT_STATE_ENABLED: // There is an enabled (active) device. Indicate to USBH that the device is gone
@@ -536,9 +585,20 @@ reset_err:
     }
 }
 
-static void root_port_req(root_hub_port_t *root_hub_port)
+/**
+ * @brief Handle all pending requests of a single root port
+ *
+ * @note The power management device actions are not issued here, but returned to the caller. In dual host
+ *       configurations all root ports are suspended/resumed together, so the device actions (and the client
+ *       events they produce) must be issued only once for the whole transition.
+ *
+ * @param[in] root_hub_port Root port object
+ * @return Device control commands (usbh_dev_ctrl_t flags) that must be issued once all root ports are processed
+ */
+static uint32_t root_port_req(root_hub_port_t *root_hub_port)
 {
     unsigned int port_reqs;
+    uint32_t dev_ctrl = 0;
     hcd_port_handle_t root_port_hdl = root_hub_port->constant.hdl;
 
     HUB_DRIVER_ENTER_CRITICAL();
@@ -578,7 +638,7 @@ static void root_port_req(root_hub_port_t *root_hub_port)
         // In case the port's state changed (disconnection, reconnection) prior to issuing PORT_REQ_SUSPEND request,
         // we will not proceed with the resuming sequence
         if (root_state != ROOT_PORT_STATE_ENABLED) {
-            return;
+            return dev_ctrl;
         }
 
         const esp_err_t port_cmd_err = hcd_port_command(root_port_hdl, HCD_PORT_CMD_SUSPEND);
@@ -589,11 +649,11 @@ static void root_port_req(root_hub_port_t *root_hub_port)
         case ESP_ERR_INVALID_RESPONSE:
             // Root port's state machine changed it's state during suspend command execution (port disconnect)
             // The root port is already in recovery state, which was set by dconn event interrupt, no further action needed
-            return;
+            return dev_ctrl;
         default:
             // Fatal error occurred: Do ESP_ERROR_CHECK for backtrace
             ESP_ERROR_CHECK(port_cmd_err);
-            return;
+            return dev_ctrl;
         }
 
         // Suspend command executed successfully, finish the suspend procedure
@@ -603,7 +663,7 @@ static void root_port_req(root_hub_port_t *root_hub_port)
 
         // Root port, including all the connected devices were suspended (global suspend)
         // Propagate the suspended event to clients
-        usbh_devs_set_pm_actions_all(USBH_DEV_SUSPEND_EVT);
+        dev_ctrl |= USBH_DEV_SUSPEND_EVT;
     }
     if (port_reqs & PORT_REQ_RESUME) {
         ESP_LOGD(HUB_DRIVER_TAG, "Resuming root port %d",  root_hub_port->constant.index);
@@ -615,7 +675,7 @@ static void root_port_req(root_hub_port_t *root_hub_port)
         // In case the port's state changed (disconnection, reconnection) prior to issuing PORT_REQ_RESUME request,
         // we will not proceed with the resuming sequence
         if (root_state != ROOT_PORT_STATE_SUSPENDED) {
-            return;
+            return dev_ctrl;
         }
 
         const esp_err_t port_cmd_err = hcd_port_command(root_port_hdl, HCD_PORT_CMD_RESUME);
@@ -627,11 +687,11 @@ static void root_port_req(root_hub_port_t *root_hub_port)
         case ESP_ERR_INVALID_STATE:
             // Root port's state machine changed during resume (port disconnect or stale hub suspend state).
             // The root port is already in recovery state, which was set by dconn event interrupt, no further action needed
-            return;
+            return dev_ctrl;
         default:
             // Fatal error occurred: Do ESP_ERROR_CHECK for backtrace
             ESP_ERROR_CHECK(port_cmd_err);
-            return;
+            return dev_ctrl;
         }
 
         // Resume command executed successfully, finish the resume procedure
@@ -641,7 +701,7 @@ static void root_port_req(root_hub_port_t *root_hub_port)
 
         // Root port, including all the connected devices were resumed (global resume)
         // Clear all EPs and propagate the resumed event to clients
-        usbh_devs_set_pm_actions_all(USBH_DEV_RESUME | USBH_DEV_RESUME_EVT);    // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+        dev_ctrl |= (USBH_DEV_RESUME | USBH_DEV_RESUME_EVT);
     }
 #ifdef AUTO_PM_LIGHT_SLEEP
     if (port_reqs & PORT_REQ_EXIT_LIGHT_SLEEP) {
@@ -653,14 +713,15 @@ static void root_port_req(root_hub_port_t *root_hub_port)
             // That indicates, that the device has been disconnected during light sleep
             // Clock gating will be disabled by recovery routine, nothing to do here
             // Deferred suspend event will not be delivered
-            return;
+            return dev_ctrl;
         }
 
         // Root port, including all the connected devices were suspended (global suspend)
         // Propagate the suspended event to clients
-        usbh_devs_set_pm_actions_all(USBH_DEV_SUSPEND_EVT);
+        dev_ctrl |= USBH_DEV_SUSPEND_EVT;
     }
 #endif // AUTO_PM_LIGHT_SLEEP
+    return dev_ctrl;
 }
 
 static esp_err_t root_port_recycle(root_hub_port_t *root_hub_port)
@@ -672,23 +733,14 @@ static esp_err_t root_port_recycle(root_hub_port_t *root_hub_port)
     switch (port_state) {
     case HCD_PORT_STATE_ENABLED:
     case HCD_PORT_STATE_SUSPENDED:
-        root_hub_port->dynamic.reqs |= PORT_REQ_DISABLE;
+        _root_port_set_req(root_hub_port, PORT_REQ_DISABLE);
         break;
     case HCD_PORT_STATE_RECOVERY:
-        root_hub_port->dynamic.reqs |= PORT_REQ_RECOVER;
+        _root_port_set_req(root_hub_port, PORT_REQ_RECOVER);
         break;
     default:
         abort();    // Should never occur
         break;
-    }
-    if (root_hub_port->constant.index == 0) {
-        p_hub_driver_obj->dynamic.flags.actions |= HUB_DRIVER_ACTION_ROOT0_REQ;
-    } else {
-#if HCD_NUM_PORTS > 1
-        p_hub_driver_obj->dynamic.flags.actions |= HUB_DRIVER_ACTION_ROOT1_REQ;
-#else
-        abort();    // Should never occur
-#endif // HCD_NUM_PORTS > 1
     }
     HUB_DRIVER_EXIT_CRITICAL();
 
@@ -703,16 +755,7 @@ static esp_err_t root_port_disable(root_hub_port_t *root_hub_port)
     HUB_DRIVER_CHECK(port_state == HCD_PORT_STATE_ENABLED, ESP_ERR_INVALID_STATE);
 
     HUB_DRIVER_ENTER_CRITICAL();
-    root_hub_port->dynamic.reqs |= PORT_REQ_DISABLE;
-    if (root_hub_port->constant.index == 0) {
-        p_hub_driver_obj->dynamic.flags.actions |= HUB_DRIVER_ACTION_ROOT0_REQ;
-    } else {
-#if HCD_NUM_PORTS > 1
-        p_hub_driver_obj->dynamic.flags.actions |= HUB_DRIVER_ACTION_ROOT1_REQ;
-#else
-        abort();    // Should never occur
-#endif // HCD_NUM_PORTS > 1
-    }
+    _root_port_set_req(root_hub_port, PORT_REQ_DISABLE);
     HUB_DRIVER_EXIT_CRITICAL();
 
     p_hub_driver_obj->constant.proc_req_cb(USB_PROC_REQ_SOURCE_HUB, false, p_hub_driver_obj->constant.proc_req_cb_arg);
@@ -921,90 +964,119 @@ esp_err_t hub_root_stop(void)
 
 bool hub_root_is_suspended(void)
 {
+    hcd_port_handle_t suspended_hdls[HCD_NUM_PORTS];
+    int num_suspended = 0;
+
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, false);
-
-    // TODO: Suspend/Resume API is currently available only for single host configuration.
-    // Pick the first root port that is enabled
-    root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[0];
-#if HCD_NUM_PORTS > 1
-    if (!root_hub_port->constant.hdl) {
-        root_hub_port = &p_hub_driver_obj->root_hub_ports[1];
+    // All root ports share a single PM state: the Host is suspended only if no bus is active
+    for (int i = 0; i < HCD_NUM_PORTS; i++) {
+        root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[i];
+        if (!root_port_is_installed(root_hub_port)) {
+            continue;
+        }
+        // An enabled port has a device and is sending SOFs
+        HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state != ROOT_PORT_STATE_ENABLED, false);
+        if (root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED) {
+            suspended_hdls[num_suspended++] = root_hub_port->constant.hdl;
+        }
     }
-#endif
-    assert(root_hub_port->constant.hdl);
-    HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED, false);
-    hcd_port_handle_t root_port_hdl = root_hub_port->constant.hdl;
     HUB_DRIVER_EXIT_CRITICAL();
 
     // Hub suspend state can be stale if disconnect occurred before the hub event was processed
-    const hcd_port_state_t port_state = hcd_port_get_state(root_port_hdl);
-    if (port_state != HCD_PORT_STATE_SUSPENDED && port_state != HCD_PORT_STATE_SUSPENDING) {
-        return false;
+    for (int i = 0; i < num_suspended; i++) {
+        const hcd_port_state_t port_state = hcd_port_get_state(suspended_hdls[i]);
+        if (port_state == HCD_PORT_STATE_SUSPENDED || port_state == HCD_PORT_STATE_SUSPENDING) {
+            return true;
+        }
     }
 
-    return true;
+    // No root port is suspended, or all suspend states were stale
+    return false;
 }
 
 esp_err_t hub_root_can_suspend(void)
 {
+    hcd_port_handle_t enabled_hdls[HCD_NUM_PORTS];
+    int num_enabled = 0;
+
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
-
-    // TODO: Suspend/Resume API is currently available only for single host configuration.
-    // Pick the first root port that is enabled
-    root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[0];
-#if HCD_NUM_PORTS > 1
-    if (!root_hub_port->constant.hdl) {
-        root_hub_port = &p_hub_driver_obj->root_hub_ports[1];
+    for (int i = 0; i < HCD_NUM_PORTS; i++) {
+        root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[i];
+        if (root_port_is_installed(root_hub_port) && root_hub_port->dynamic.state == ROOT_PORT_STATE_ENABLED) {
+            enabled_hdls[num_enabled++] = root_hub_port->constant.hdl;
+        }
     }
-#endif
-    assert(root_hub_port->constant.hdl);
-    HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state == ROOT_PORT_STATE_ENABLED, ESP_ERR_NOT_ALLOWED);
     HUB_DRIVER_EXIT_CRITICAL();
 
-    const hcd_port_state_t port_state = hcd_port_get_state(root_hub_port->constant.hdl);
-    if (port_state == HCD_PORT_STATE_SUSPENDING) {
-        // Root port is already issuing suspend command and is within a SUSPEND_ENTRY_MS timeout,
-        // no need to issue the suspend command again
+    // Ports without a device (powered or not powered) are not suspended, so there must be at least one enabled port
+    HUB_DRIVER_CHECK(num_enabled > 0, ESP_ERR_NOT_ALLOWED);
+
+    int num_suspending = 0;
+    esp_err_t ret = ESP_OK;
+    for (int i = 0; i < num_enabled; i++) {
+        if (hcd_port_get_state(enabled_hdls[i]) == HCD_PORT_STATE_SUSPENDING) {
+            // Root port is already issuing suspend command and is within a SUSPEND_ENTRY_MS timeout,
+            // no need to issue the suspend command again
+            num_suspending++;
+            continue;
+        }
+        if (hcd_port_check_all_pipes_idle(enabled_hdls[i]) != ESP_OK) {
+            ret = ESP_ERR_NOT_FINISHED;
+        }
+    }
+
+    if (num_suspending == num_enabled) {
+        // Every enabled root port is already being suspended
         return ESP_ERR_TIMEOUT;
     }
 
-    return hcd_port_check_all_pipes_idle(root_hub_port->constant.hdl);
+    return ret;
 }
 
 esp_err_t hub_root_can_resume(void)
 {
+    hcd_port_handle_t suspended_hdls[HCD_NUM_PORTS];
+    int num_suspended = 0;
+
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
-
-    // TODO: Suspend/Resume API is currently available only for single host configuration.
-    // Pick the first root port that is enabled
-    root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[0];
-#if HCD_NUM_PORTS > 1
-    if (!root_hub_port->constant.hdl) {
-        root_hub_port = &p_hub_driver_obj->root_hub_ports[1];
+    for (int i = 0; i < HCD_NUM_PORTS; i++) {
+        root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[i];
+        if (root_port_is_installed(root_hub_port) && root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED) {
+            suspended_hdls[num_suspended++] = root_hub_port->constant.hdl;
+        }
     }
-#endif
-    assert(root_hub_port->constant.hdl);
-    HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED, ESP_ERR_NOT_ALLOWED);
     HUB_DRIVER_EXIT_CRITICAL();
 
-    const hcd_port_state_t port_state = hcd_port_get_state(root_hub_port->constant.hdl);
+    HUB_DRIVER_CHECK(num_suspended > 0, ESP_ERR_NOT_ALLOWED);
+
+    bool any_resumable = false;
+    bool any_resuming = false;
+    for (int i = 0; i < num_suspended; i++) {
+        switch (hcd_port_get_state(suspended_hdls[i])) {
+        case HCD_PORT_STATE_SUSPENDED:
+            any_resumable = true;
+            break;
+        case HCD_PORT_STATE_RESUMING:
+            // Root port is already issuing resume command and is within a RESUME_RECOVERY_MS or a RESUME_HOLD_MS timeout,
+            // no need to issue the resume command again
+            any_resuming = true;
+            break;
+        default:
+            // Port disconnected, in recovery, or otherwise not resumable
+            break;
+        }
+    }
+
     esp_err_t ret;
-    switch (port_state) {
-    case HCD_PORT_STATE_SUSPENDED:
+    if (any_resumable) {
         ret = ESP_OK;
-        break;
-    case HCD_PORT_STATE_RESUMING:
-        // Root port is already issuing resume command and is within a RESUME_RECOVERY_MS or a RESUME_HOLD_MS timeout,
-        // no need to issue the resume command again
+    } else if (any_resuming) {
         ret = ESP_ERR_TIMEOUT;
-        break;
-    default:
-        // Port disconnected, in recovery, or otherwise not resumable
+    } else {
         ret = ESP_ERR_NOT_ALLOWED;
-        break;
     }
 
     return ret;
@@ -1012,26 +1084,21 @@ esp_err_t hub_root_can_resume(void)
 
 esp_err_t hub_root_mark_suspend(void)
 {
+    int num_marked = 0;
+
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
-
-    // TODO: Suspend/Resume API is currently available only for single host configuration.
-    // Pick the first root port that is enabled
-    root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[0];
-    hub_flag_action_t action = HUB_DRIVER_ACTION_ROOT0_REQ;
-#if HCD_NUM_PORTS > 1
-    if (!root_hub_port->constant.hdl) {
-        root_hub_port = &p_hub_driver_obj->root_hub_ports[1];
-        action = HUB_DRIVER_ACTION_ROOT1_REQ;
+    // Mark every root port that has an active device. Root ports without a device are left untouched
+    for (int i = 0; i < HCD_NUM_PORTS; i++) {
+        root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[i];
+        if (root_port_is_installed(root_hub_port) && root_hub_port->dynamic.state == ROOT_PORT_STATE_ENABLED) {
+            _root_port_set_req(root_hub_port, PORT_REQ_SUSPEND);
+            num_marked++;
+        }
     }
-#endif
-    assert(root_hub_port->constant.hdl);
-    HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state == ROOT_PORT_STATE_ENABLED, ESP_ERR_NOT_ALLOWED);
-
-    // Set port request to suspend
-    root_hub_port->dynamic.reqs |= PORT_REQ_SUSPEND;
-    p_hub_driver_obj->dynamic.flags.actions |= action;
     HUB_DRIVER_EXIT_CRITICAL();
+
+    HUB_DRIVER_CHECK(num_marked > 0, ESP_ERR_NOT_ALLOWED);
 
     // Call processing callback
     p_hub_driver_obj->constant.proc_req_cb(USB_PROC_REQ_SOURCE_HUB, false, p_hub_driver_obj->constant.proc_req_cb_arg);
@@ -1040,26 +1107,21 @@ esp_err_t hub_root_mark_suspend(void)
 
 esp_err_t hub_root_mark_resume(void)
 {
+    int num_marked = 0;
+
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
-
-    // TODO: Suspend/Resume API is currently available only for single host configuration.
-    // Pick the first root port that is enabled
-    root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[0];
-    hub_flag_action_t action = HUB_DRIVER_ACTION_ROOT0_REQ;
-#if HCD_NUM_PORTS > 1
-    if (!root_hub_port->constant.hdl) {
-        root_hub_port = &p_hub_driver_obj->root_hub_ports[1];
-        action = HUB_DRIVER_ACTION_ROOT1_REQ;
+    // Resume every suspended root port, so all the buses end up in the same PM state
+    for (int i = 0; i < HCD_NUM_PORTS; i++) {
+        root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[i];
+        if (root_port_is_installed(root_hub_port) && root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED) {
+            _root_port_set_req(root_hub_port, PORT_REQ_RESUME);
+            num_marked++;
+        }
     }
-#endif
-    assert(root_hub_port->constant.hdl);
-    HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED, ESP_ERR_NOT_ALLOWED);
-
-    // Set port request to resume
-    root_hub_port->dynamic.reqs |= PORT_REQ_RESUME;
-    p_hub_driver_obj->dynamic.flags.actions |= action;
     HUB_DRIVER_EXIT_CRITICAL();
+
+    HUB_DRIVER_CHECK(num_marked > 0, ESP_ERR_NOT_ALLOWED);
 
     // Call processing callback
     p_hub_driver_obj->constant.proc_req_cb(USB_PROC_REQ_SOURCE_HUB, false, p_hub_driver_obj->constant.proc_req_cb_arg);
@@ -1070,33 +1132,29 @@ esp_err_t hub_root_mark_resume(void)
 
 esp_err_t hub_root_mark_exit_light_sleep(void)
 {
+    int num_marked = 0;
+
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
-    // Return early, if the root port was not suspended from the light sleep callback (suspend event already delivered)
+    // Return early, if the root ports were not suspended from the light sleep callback (suspend event already delivered)
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm != 0, ESP_OK);
-    // Root port suspended from the light sleep callback, deliver the suspend event
+    // Root ports suspended from the light sleep callback, deliver the suspend event
     p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 0;
 
-    // TODO: Suspend/Resume API is currently available only for single host configuration.
-    // Pick the first root port that is enabled
-    root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[0];
-    hub_flag_action_t action = HUB_DRIVER_ACTION_ROOT0_REQ;
-#if HCD_NUM_PORTS > 1
-    if (!root_hub_port->constant.hdl) {
-        root_hub_port = &p_hub_driver_obj->root_hub_ports[1];
-        action = HUB_DRIVER_ACTION_ROOT1_REQ;
+    // All the root ports enter and exit light sleep together
+    for (int i = 0; i < HCD_NUM_PORTS; i++) {
+        root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[i];
+        // Root port must be in suspended state
+        // This state is a stale state taken when entering light sleep, port might have undergone reset or error,
+        // but the usb host lib has not have a chance to run, thus to update the port state
+        if (root_port_is_installed(root_hub_port) && root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED) {
+            _root_port_set_req(root_hub_port, PORT_REQ_EXIT_LIGHT_SLEEP);
+            num_marked++;
+        }
     }
-#endif
-    assert(root_hub_port->constant.hdl);
-    // Root port must be in suspended state
-    // This state is a stale state taken when entering light sleep, port might have undergone reset or error,
-    // but the usb host lib has not have a chance to run, thus to update the port state
-    HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state == ROOT_PORT_STATE_SUSPENDED, ESP_ERR_NOT_ALLOWED);
-
-    // Set port request to exit light sleep
-    root_hub_port->dynamic.reqs |= PORT_REQ_EXIT_LIGHT_SLEEP;
-    p_hub_driver_obj->dynamic.flags.actions |= action;
     HUB_DRIVER_EXIT_CRITICAL();
+
+    HUB_DRIVER_CHECK(num_marked > 0, ESP_ERR_NOT_ALLOWED);
 
     // Call processing callback
     p_hub_driver_obj->constant.proc_req_cb(USB_PROC_REQ_SOURCE_HUB, false, p_hub_driver_obj->constant.proc_req_cb_arg);
@@ -1105,45 +1163,58 @@ esp_err_t hub_root_mark_exit_light_sleep(void)
 
 esp_err_t hub_root_light_sleep_suspend_bus(void)
 {
+    root_hub_port_t *ports_to_suspend[HCD_NUM_PORTS];
+    int num_to_suspend = 0;
+
     HUB_DRIVER_ENTER_CRITICAL();
     HUB_DRIVER_CHECK_FROM_CRIT(p_hub_driver_obj != NULL, ESP_ERR_INVALID_STATE);
-
-    root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[0];
-#if HCD_NUM_PORTS > 1
-    if (!root_hub_port->constant.hdl) {
-        root_hub_port = &p_hub_driver_obj->root_hub_ports[1];
+    // Collect the root ports with an active device; the others are already suspended, powered off or have no device
+    for (int i = 0; i < HCD_NUM_PORTS; i++) {
+        root_hub_port_t *root_hub_port = &p_hub_driver_obj->root_hub_ports[i];
+        if (root_port_is_installed(root_hub_port) && root_hub_port->dynamic.state == ROOT_PORT_STATE_ENABLED) {
+            ports_to_suspend[num_to_suspend++] = root_hub_port;
+        }
     }
-#endif
-    assert(root_hub_port->constant.hdl);
-    // Continue only when enabled; otherwise port is either already suspended, powered off or device not preset
-    HUB_DRIVER_CHECK_FROM_CRIT(root_hub_port->dynamic.state == ROOT_PORT_STATE_ENABLED, ESP_OK);
-    hcd_port_handle_t root_port_hdl = root_hub_port->constant.hdl;
     HUB_DRIVER_EXIT_CRITICAL();
 
-    // Check the port state
-    const hcd_port_state_t hcd_port_state = hcd_port_get_state(root_port_hdl);
-    switch (hcd_port_state) {
-    case HCD_PORT_STATE_SUSPENDED:      // Already suspended
-    case HCD_PORT_STATE_SUSPENDING:     // Inside suspend entry delay, already suspending
-    case HCD_PORT_STATE_NOT_POWERED:    // No suspend routine needed for not powered port
-        // no further actions
+    // Check the state of every port before issuing any command, so we never enter light sleep with one bus suspended
+    // and another one active
+    int num_pending = 0;
+    for (int i = 0; i < num_to_suspend; i++) {
+        const hcd_port_state_t hcd_port_state = hcd_port_get_state(ports_to_suspend[i]->constant.hdl);
+        switch (hcd_port_state) {
+        case HCD_PORT_STATE_SUSPENDED:      // Already suspended
+        case HCD_PORT_STATE_SUSPENDING:     // Inside suspend entry delay, already suspending
+        case HCD_PORT_STATE_NOT_POWERED:    // No suspend routine needed for not powered port
+            // no further actions
+            break;
+        case HCD_PORT_STATE_ENABLED:
+            // Continue with auto suspend from light sleep callback
+            ports_to_suspend[num_pending++] = ports_to_suspend[i];
+            break;
+        default:
+            // In other state (port resetting, in recovery, resuming..) it does not make sense to continue
+            // with the auto suspend sequence, the port state is not correct for the suspend
+            return ESP_ERR_NOT_FINISHED;
+        }
+    }
+
+    if (num_pending == 0) {
         return ESP_OK;
-    case HCD_PORT_STATE_ENABLED:
-        // Continue with auto suspend from light sleep callback
-        break;
-    default:
-        // In other state (port resetting, in recovery, resuming..) it does not make sense to continue
-        // with the auto suspend sequence, the port state is not correct for the suspend
-        return ESP_ERR_NOT_FINISHED;
     }
 
+    // Endpoints of all the devices are halted and flushed at once, regardless of the root port they hang off
     ESP_RETURN_ON_ERROR(usbh_devs_halt_flush_all_sync(), HUB_DRIVER_TAG, "Devs halt/flush failed");
-    ESP_RETURN_ON_ERROR(hcd_port_command(root_port_hdl, HCD_PORT_CMD_SUSPEND_LIGHT_SLEEP), HUB_DRIVER_TAG, "Port suspend cmd failed");
 
-    HUB_DRIVER_ENTER_CRITICAL();
-    p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 1;
-    root_hub_port->dynamic.state = ROOT_PORT_STATE_SUSPENDED;
-    HUB_DRIVER_EXIT_CRITICAL();
+    for (int i = 0; i < num_pending; i++) {
+        ESP_RETURN_ON_ERROR(hcd_port_command(ports_to_suspend[i]->constant.hdl, HCD_PORT_CMD_SUSPEND_LIGHT_SLEEP),
+                            HUB_DRIVER_TAG, "Port suspend cmd failed");
+        HUB_DRIVER_ENTER_CRITICAL();
+        p_hub_driver_obj->dynamic.flags.light_sleep_auto_pm = 1;
+        ports_to_suspend[i]->dynamic.state = ROOT_PORT_STATE_SUSPENDED;
+        HUB_DRIVER_EXIT_CRITICAL();
+    }
+
     return ESP_OK;
 }
 
@@ -1345,20 +1416,26 @@ esp_err_t hub_process(void)
             ESP_ERROR_CHECK(ext_hub_process());
         }
 #endif // ENABLE_USB_HUBS
+        uint32_t dev_ctrl = 0;
         if (action_flags & HUB_DRIVER_ACTION_ROOT0_EVENT) {
             root_port_handle_events(&p_hub_driver_obj->root_hub_ports[0]);
         }
         if (action_flags & HUB_DRIVER_ACTION_ROOT0_REQ) {
-            root_port_req(&p_hub_driver_obj->root_hub_ports[0]);
+            dev_ctrl |= root_port_req(&p_hub_driver_obj->root_hub_ports[0]);
         }
 #if HCD_NUM_PORTS > 1
         if (action_flags & HUB_DRIVER_ACTION_ROOT1_EVENT) {
             root_port_handle_events(&p_hub_driver_obj->root_hub_ports[1]);
         }
         if (action_flags & HUB_DRIVER_ACTION_ROOT1_REQ) {
-            root_port_req(&p_hub_driver_obj->root_hub_ports[1]);
+            dev_ctrl |= root_port_req(&p_hub_driver_obj->root_hub_ports[1]);
         }
 #endif // HCD_NUM_PORTS > 1
+        if (dev_ctrl != 0) {
+            // The whole USB Host (all the root ports) changed its power management state.
+            // Issue the device actions once, so that every client receives exactly one suspended/resumed event
+            usbh_devs_set_pm_actions_all((usbh_dev_ctrl_t)dev_ctrl);    // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+        }
         HUB_DRIVER_ENTER_CRITICAL();
         action_flags = p_hub_driver_obj->dynamic.flags.actions;
         p_hub_driver_obj->dynamic.flags.actions = HUB_DRIVER_ACTION_NONE;

--- a/host/usb/src/usb_host.c
+++ b/host/usb/src/usb_host.c
@@ -539,7 +539,7 @@ static void get_config_desc_transfer_cb(usb_transfer_t *transfer)
  * - Callback unblocks the usb_host_lib_handle_events() and delivers suspend USB Host lib event
  * - Event flag is dellivered, only if:
  *      - A device is connected to the the root port
- *      - The root port is not already in suspended state
+ *      - No root port with a connected device is already in suspended state
  * @param[in] xTimer Timer handle
  */
 static void auto_suspend_timer_cb(TimerHandle_t xTimer)

--- a/host/usb/src/usbh.c
+++ b/host/usb/src/usbh.c
@@ -1172,24 +1172,6 @@ unlock:
 
 void usbh_devs_set_pm_actions_all(usbh_dev_ctrl_t device_ctrl)
 {
-    // Decode the device_ctrl to dev_actions flags
-    uint32_t dev_actions_flags = 0;
-    if (device_ctrl & USBH_DEV_SUSPEND) {
-        dev_actions_flags |= (DEV_ACTION_EPn_HALT_FLUSH | DEV_ACTION_EP0_FLUSH);
-    }
-
-    if (device_ctrl & USBH_DEV_RESUME) {
-        dev_actions_flags |= (DEV_ACTION_EP0_CLEAR | DEV_ACTION_EPn_CLEAR);
-    }
-
-    if (device_ctrl & USBH_DEV_SUSPEND_EVT) {
-        dev_actions_flags |= DEV_ACTION_PROP_SUSPEND_EVT;
-    }
-
-    if (device_ctrl & USBH_DEV_RESUME_EVT) {
-        dev_actions_flags |= DEV_ACTION_PROP_RESUME_EVT;
-    }
-
     USBH_ENTER_CRITICAL();
     /*
     Go through the device list and mark each device with a device action.
@@ -1207,16 +1189,36 @@ void usbh_devs_set_pm_actions_all(usbh_dev_ctrl_t device_ctrl)
             dev_obj_cur = TAILQ_FIRST(&p_usbh_obj->dynamic.devs_idle_tailq);
         }
         while (dev_obj_cur != NULL) {
+            /*
+            Decode the device_ctrl to dev_actions flags for this particular device.
+            The suspend/resume events are only relevant for devices that are not/are suspended: In dual host
+            configuration a device can attach to one root port while another root port is still suspended. Resuming
+            that root port must not touch the freshly attached device, as restoring its last_state would take it out
+            of the DEFAULT state and abort its enumeration.
+            */
+            uint32_t dev_actions_flags = 0;
+            const bool dev_suspended = (dev_obj_cur->dynamic.state == USB_DEVICE_STATE_SUSPENDED);
 
-            // Update device state
-            if (device_ctrl & USBH_DEV_SUSPEND_EVT) {
+            if (device_ctrl & USBH_DEV_SUSPEND) {
+                dev_actions_flags |= (DEV_ACTION_EPn_HALT_FLUSH | DEV_ACTION_EP0_FLUSH);
+            }
+
+            if ((device_ctrl & USBH_DEV_SUSPEND_EVT) && !dev_suspended) {
                 // Change device state to suspended and backup the current device state for resuming
                 dev_obj_cur->dynamic.last_state = dev_obj_cur->dynamic.state;
                 dev_obj_cur->dynamic.state = USB_DEVICE_STATE_SUSPENDED;
+                dev_actions_flags |= DEV_ACTION_PROP_SUSPEND_EVT;
             }
-            if (device_ctrl & USBH_DEV_RESUME_EVT) {
-                // Set the device state, to the state in which it was before suspending
-                dev_obj_cur->dynamic.state = dev_obj_cur->dynamic.last_state;
+
+            if (dev_suspended) {
+                if (device_ctrl & USBH_DEV_RESUME) {
+                    dev_actions_flags |= (DEV_ACTION_EP0_CLEAR | DEV_ACTION_EPn_CLEAR);
+                }
+                if (device_ctrl & USBH_DEV_RESUME_EVT) {
+                    // Set the device state, to the state in which it was before suspending
+                    dev_obj_cur->dynamic.state = dev_obj_cur->dynamic.last_state;
+                    dev_actions_flags |= DEV_ACTION_PROP_RESUME_EVT;
+                }
             }
 
             // Keep a copy of the next item first in case we remove the current item
@@ -1229,8 +1231,7 @@ void usbh_devs_set_pm_actions_all(usbh_dev_ctrl_t device_ctrl)
 
     // As the last device is being marked, add DEV_ACTION_PROP_ALL_IDLE_EVT to event flags
     if (dev_obj_last != NULL && device_ctrl & USBH_DEV_SUSPEND) {
-        dev_actions_flags |= DEV_ACTION_PROP_ALL_IDLE_EVT;
-        _dev_set_actions(dev_obj_last, dev_actions_flags);
+        _dev_set_actions(dev_obj_last, DEV_ACTION_EPn_HALT_FLUSH | DEV_ACTION_EP0_FLUSH | DEV_ACTION_PROP_ALL_IDLE_EVT);
     }
     USBH_EXIT_CRITICAL();
 

--- a/host/usb/test/host_test/usbh_layer_test/main/CMakeLists.txt
+++ b/host/usb/test/host_test/usbh_layer_test/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(srcs)
 list(APPEND srcs "test_main.cpp"
                  "usbh_install_unit_test.cpp"
+                 "hub_root_pm_unit_test.cpp"
                  )
 
 idf_component_register(SRCS  ${srcs}

--- a/host/usb/test/host_test/usbh_layer_test/main/hub_root_pm_unit_test.cpp
+++ b/host/usb/test/host_test/usbh_layer_test/main/hub_root_pm_unit_test.cpp
@@ -1,0 +1,450 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <ostream>
+#include <vector>
+#include <catch2/catch_test_macros.hpp>
+
+#include "esp_bit_defs.h"
+#include "hub.h"    // Real implementation of hub.h
+#include "usbh.h"   // Real implementation of usbh.h
+
+// Test all the mocked headers defined for this mock
+extern "C" {
+#include "Mockhcd.h"
+#include "Mockusb_private.h"
+}
+
+/*
+These test cases cover the global (all root ports) power management of the Hub driver in a dual host configuration.
+The mock builds the USB component with SOC_USB_OTG_PERIPH_NUM set to 2, so the Hub driver has two root ports and both
+of them can hold a device at the same time, which is not reproducible on a target with a single USB-OTG peripheral.
+
+Instead of setting up CMock expectations, the HCD is replaced by a minimal fake below. The fake keeps the state of both
+ports and records every port command, so the test cases can assert which root ports were actually commanded.
+*/
+
+namespace {
+
+constexpr int NUM_ROOT_PORTS = 2;
+
+struct PortCommand {
+    int port_idx;
+    hcd_port_cmd_t cmd;
+
+    bool operator==(const PortCommand &other) const
+    {
+        return port_idx == other.port_idx && cmd == other.cmd;
+    }
+};
+
+const char *cmd_name(hcd_port_cmd_t cmd)
+{
+    switch (cmd) {
+    case HCD_PORT_CMD_POWER_ON:  return "POWER_ON";
+    case HCD_PORT_CMD_POWER_OFF: return "POWER_OFF";
+    case HCD_PORT_CMD_RESET:     return "RESET";
+    case HCD_PORT_CMD_SUSPEND:   return "SUSPEND";
+    case HCD_PORT_CMD_RESUME:    return "RESUME";
+    case HCD_PORT_CMD_DISABLE:   return "DISABLE";
+    default:                     return "OTHER";
+    }
+}
+
+/** Make the recorded port commands readable in the Catch2 output */
+std::ostream &operator<<(std::ostream &os, const PortCommand &port_command)
+{
+    return os << "port " << port_command.port_idx << ": " << cmd_name(port_command.cmd);
+}
+
+/** Minimal fake of the HCD, shared by all the stubs below */
+struct {
+    hcd_port_state_t state[NUM_ROOT_PORTS];
+    hcd_port_event_t pending_event[NUM_ROOT_PORTS];
+    hcd_port_callback_t cb[NUM_ROOT_PORTS];
+    void *cb_arg[NUM_ROOT_PORTS];
+    std::vector<PortCommand> commands;
+} s_hcd;
+
+int s_num_dev_suspend_events;
+int s_num_dev_resume_events;
+unsigned int s_last_connected_uid;
+
+hcd_port_handle_t port_hdl(int port_idx)
+{
+    // Non-null opaque handles, so that the Hub driver can distinguish the root ports
+    return reinterpret_cast<hcd_port_handle_t>(static_cast<uintptr_t>(0xB0510000 + port_idx));
+}
+
+int port_idx(hcd_port_handle_t hdl)
+{
+    for (int i = 0; i < NUM_ROOT_PORTS; i++) {
+        if (hdl == port_hdl(i)) {
+            return i;
+        }
+    }
+    FAIL("Unknown HCD port handle");
+    return 0;
+}
+
+// ------------------------------------------------- HCD stubs ---------------------------------------------------
+
+esp_err_t port_init_stub(int port_number, const hcd_port_config_t *port_config, hcd_port_handle_t *port_hdl_ret, int cmock_num_calls)
+{
+    s_hcd.cb[port_number] = port_config->callback;
+    s_hcd.cb_arg[port_number] = port_config->callback_arg;
+    *port_hdl_ret = port_hdl(port_number);
+    return ESP_OK;
+}
+
+esp_err_t port_deinit_stub(hcd_port_handle_t hdl, int cmock_num_calls)
+{
+    return ESP_OK;
+}
+
+esp_err_t port_command_stub(hcd_port_handle_t hdl, hcd_port_cmd_t command, int cmock_num_calls)
+{
+    const int idx = port_idx(hdl);
+    s_hcd.commands.push_back({idx, command});
+
+    switch (command) {
+    case HCD_PORT_CMD_POWER_ON:  s_hcd.state[idx] = HCD_PORT_STATE_DISCONNECTED; break;
+    case HCD_PORT_CMD_POWER_OFF: s_hcd.state[idx] = HCD_PORT_STATE_NOT_POWERED;  break;
+    case HCD_PORT_CMD_RESET:     s_hcd.state[idx] = HCD_PORT_STATE_ENABLED;      break;
+    case HCD_PORT_CMD_SUSPEND:   s_hcd.state[idx] = HCD_PORT_STATE_SUSPENDED;    break;
+    case HCD_PORT_CMD_RESUME:    s_hcd.state[idx] = HCD_PORT_STATE_ENABLED;      break;
+    case HCD_PORT_CMD_DISABLE:   s_hcd.state[idx] = HCD_PORT_STATE_DISABLED;     break;
+    default: break;
+    }
+    return ESP_OK;
+}
+
+hcd_port_state_t port_get_state_stub(hcd_port_handle_t hdl, int cmock_num_calls)
+{
+    return s_hcd.state[port_idx(hdl)];
+}
+
+hcd_port_event_t port_handle_event_stub(hcd_port_handle_t hdl, int cmock_num_calls)
+{
+    const int idx = port_idx(hdl);
+    const hcd_port_event_t event = s_hcd.pending_event[idx];
+    s_hcd.pending_event[idx] = HCD_PORT_EVENT_NONE;
+    return event;
+}
+
+esp_err_t port_get_speed_stub(hcd_port_handle_t hdl, usb_speed_t *speed, int cmock_num_calls)
+{
+    *speed = USB_SPEED_FULL;
+    return ESP_OK;
+}
+
+esp_err_t port_check_all_pipes_idle_stub(hcd_port_handle_t hdl, int cmock_num_calls)
+{
+    return ESP_OK;
+}
+
+esp_err_t port_recover_stub(hcd_port_handle_t hdl, int cmock_num_calls)
+{
+    s_hcd.state[port_idx(hdl)] = HCD_PORT_STATE_NOT_POWERED;
+    return ESP_OK;
+}
+
+void *port_get_context_stub(hcd_port_handle_t hdl, int cmock_num_calls)
+{
+    return s_hcd.cb_arg[port_idx(hdl)];
+}
+
+esp_err_t pipe_alloc_stub(hcd_port_handle_t hdl, const hcd_pipe_config_t *pipe_config, hcd_pipe_handle_t *pipe_hdl_ret, int cmock_num_calls)
+{
+    // A non-null unique handle per root port is enough, the pipe itself is never used
+    *pipe_hdl_ret = reinterpret_cast<hcd_pipe_handle_t>(static_cast<uintptr_t>(0xB1BE0000 + port_idx(hdl)));
+    return ESP_OK;
+}
+
+esp_err_t pipe_free_stub(hcd_pipe_handle_t hdl, int cmock_num_calls)
+{
+    return ESP_OK;
+}
+
+esp_err_t pipe_command_stub(hcd_pipe_handle_t hdl, hcd_pipe_cmd_t command, int cmock_num_calls)
+{
+    return ESP_OK;
+}
+
+esp_err_t pipe_update_mps_stub(hcd_pipe_handle_t hdl, int mps, int cmock_num_calls)
+{
+    return ESP_OK;
+}
+
+// ------------------------------------------- Upper layer callbacks ---------------------------------------------
+
+bool proc_req_cb(usb_proc_req_source_t source, bool in_isr, void *context)
+{
+    // The test drives hub_process() and usbh_process() explicitly, there is no host library task here
+    return false;
+}
+
+void hub_event_cb(hub_event_data_t *event_data, void *arg)
+{
+    // Mimic the USB Host library, minus the enumeration which is driven by the test cases themselves
+    switch (event_data->event) {
+    case HUB_EVENT_CONNECTED:
+        s_last_connected_uid = event_data->connected.uid;
+        break;
+    case HUB_EVENT_DISCONNECTED:
+        usbh_devs_remove(event_data->disconnected.uid);
+        break;
+    default:
+        break;
+    }
+}
+
+void usbh_event_cb(usbh_event_data_t *event_data, void *arg)
+{
+    switch (event_data->event) {
+    case USBH_EVENT_DEV_SUSPEND:
+        s_num_dev_suspend_events++;
+        break;
+    case USBH_EVENT_DEV_RESUME:
+        s_num_dev_resume_events++;
+        break;
+    case USBH_EVENT_DEV_FREE:
+        // Mimic the USB Host library, which lets the Hub driver recycle the device's port
+        hub_node_recycle(event_data->dev_free_data.dev_uid);
+        break;
+    default:
+        break;
+    }
+}
+
+// ------------------------------------------------ Test helpers -------------------------------------------------
+
+/**
+ * @brief Install USBH and the Hub driver with the given root ports enabled and powered ON
+ */
+void install_hub(unsigned port_map)
+{
+    s_hcd = {};
+    s_num_dev_suspend_events = 0;
+    s_num_dev_resume_events = 0;
+    s_last_connected_uid = 0;
+
+    hcd_port_init_Stub(port_init_stub);
+    hcd_port_deinit_Stub(port_deinit_stub);
+    hcd_port_command_Stub(port_command_stub);
+    hcd_port_get_state_Stub(port_get_state_stub);
+    hcd_port_handle_event_Stub(port_handle_event_stub);
+    hcd_port_get_speed_Stub(port_get_speed_stub);
+    hcd_port_check_all_pipes_idle_Stub(port_check_all_pipes_idle_stub);
+    hcd_port_recover_Stub(port_recover_stub);
+    hcd_port_get_context_Stub(port_get_context_stub);
+    hcd_pipe_alloc_Stub(pipe_alloc_stub);
+    hcd_pipe_free_Stub(pipe_free_stub);
+    hcd_pipe_command_Stub(pipe_command_stub);
+    hcd_pipe_update_mps_Stub(pipe_update_mps_stub);
+
+    usbh_config_t usbh_config = {
+        .proc_req_cb = proc_req_cb,
+        .proc_req_cb_arg = nullptr,
+        .event_cb = usbh_event_cb,
+        .event_cb_arg = nullptr,
+    };
+    REQUIRE(ESP_OK == usbh_install(&usbh_config));
+
+    hub_config_t hub_config = {
+        .port_map = port_map,
+        .proc_req_cb = proc_req_cb,
+        .proc_req_cb_arg = nullptr,
+        .event_cb = hub_event_cb,
+        .event_cb_arg = nullptr,
+        .intr_flags = 0,
+        .fifo_config = nullptr,
+    };
+    void *client_hdl;
+    REQUIRE(ESP_OK == hub_install(&hub_config, &client_hdl));
+    REQUIRE(ESP_OK == hub_root_start());
+    s_hcd.commands.clear();
+}
+
+/**
+ * @brief Inject an HCD port event and let the Hub driver and USBH handle it
+ */
+void port_event(int idx, hcd_port_event_t event)
+{
+    s_hcd.pending_event[idx] = event;
+    // The HCD calls the root port callback from an ISR, the Hub driver only defers the event to hub_process()
+    s_hcd.cb[idx](port_hdl(idx), event, s_hcd.cb_arg[idx], true);
+    REQUIRE(ESP_OK == hub_process());
+    REQUIRE(ESP_OK == usbh_process());
+}
+
+/**
+ * @brief Bring a root port to the enabled state by connecting a device to it
+ */
+void connect_device(int idx)
+{
+    port_event(idx, HCD_PORT_EVENT_CONNECTION);
+}
+
+void uninstall_hub(unsigned port_map)
+{
+    for (int i = 0; i < NUM_ROOT_PORTS; i++) {
+        if (port_map & BIT(i)) {
+            port_event(i, HCD_PORT_EVENT_DISCONNECTION);
+        }
+    }
+    // The recycle path spans both processing loops: device free -> node recycle -> port disable
+    REQUIRE(ESP_OK == hub_process());
+
+    REQUIRE(ESP_OK == hub_root_stop());
+    REQUIRE(ESP_OK == hub_uninstall());
+    REQUIRE(ESP_OK == usbh_uninstall());
+}
+
+} // namespace
+
+SCENARIO("Hub root PM: dual host global suspend and resume")
+{
+    GIVEN("Both root ports enabled with a connected device") {
+        install_hub(BIT0 | BIT1);
+        connect_device(0);
+        connect_device(1);
+        s_hcd.commands.clear();
+
+        WHEN("The Host is suspended") {
+            REQUIRE(ESP_OK == hub_root_can_suspend());
+            REQUIRE(ESP_OK == hub_root_mark_suspend());
+            REQUIRE(ESP_OK == hub_process());
+
+            THEN("Both root ports are commanded to suspend") {
+                const std::vector<PortCommand> expected = {
+                    {0, HCD_PORT_CMD_SUSPEND},
+                    {1, HCD_PORT_CMD_SUSPEND},
+                };
+                REQUIRE(s_hcd.commands == expected);
+                REQUIRE(hub_root_is_suspended());
+            }
+
+            THEN("Each device is suspended exactly once") {
+                REQUIRE(ESP_OK == usbh_process());
+                REQUIRE(s_num_dev_suspend_events == 2);
+            }
+
+            THEN("Both root ports are commanded to resume") {
+                s_hcd.commands.clear();
+                REQUIRE(ESP_OK == hub_root_can_resume());
+                REQUIRE(ESP_OK == hub_root_mark_resume());
+                REQUIRE(ESP_OK == hub_process());
+
+                const std::vector<PortCommand> expected = {
+                    {0, HCD_PORT_CMD_RESUME},
+                    {1, HCD_PORT_CMD_RESUME},
+                };
+                REQUIRE(s_hcd.commands == expected);
+                REQUIRE_FALSE(hub_root_is_suspended());
+
+                // Each device is resumed exactly once
+                REQUIRE(ESP_OK == usbh_process());
+                REQUIRE(s_num_dev_resume_events == 2);
+            }
+        }
+
+        uninstall_hub(BIT0 | BIT1);
+    }
+}
+
+SCENARIO("Hub root PM: root port without a device is not suspended")
+{
+    GIVEN("Both root ports enabled, a device connected to the second one only") {
+        install_hub(BIT0 | BIT1);
+        connect_device(1);
+        s_hcd.commands.clear();
+
+        WHEN("The Host is suspended") {
+            REQUIRE(ESP_OK == hub_root_can_suspend());
+            REQUIRE(ESP_OK == hub_root_mark_suspend());
+            REQUIRE(ESP_OK == hub_process());
+
+            THEN("Only the root port with a device is commanded to suspend") {
+                const std::vector<PortCommand> expected = {{1, HCD_PORT_CMD_SUSPEND}};
+                REQUIRE(s_hcd.commands == expected);
+
+                // The empty root port does not prevent the Host from being reported as suspended
+                REQUIRE(hub_root_is_suspended());
+            }
+        }
+
+        uninstall_hub(BIT1);
+    }
+}
+
+SCENARIO("Hub root PM: no root port has a device")
+{
+    GIVEN("Both root ports enabled without a connected device") {
+        install_hub(BIT0 | BIT1);
+
+        THEN("The Host can neither be suspended nor resumed") {
+            REQUIRE(ESP_ERR_NOT_ALLOWED == hub_root_can_suspend());
+            REQUIRE(ESP_ERR_NOT_ALLOWED == hub_root_mark_suspend());
+            REQUIRE(ESP_ERR_NOT_ALLOWED == hub_root_can_resume());
+            REQUIRE(ESP_ERR_NOT_ALLOWED == hub_root_mark_resume());
+            REQUIRE_FALSE(hub_root_is_suspended());
+            REQUIRE(s_hcd.commands.empty());
+        }
+
+        uninstall_hub(0);
+    }
+}
+
+SCENARIO("Hub root PM: attach on one root port resumes the other one")
+{
+    GIVEN("A suspended root port and an empty root port") {
+        install_hub(BIT0 | BIT1);
+        connect_device(0);
+        REQUIRE(ESP_OK == hub_root_mark_suspend());
+        REQUIRE(ESP_OK == hub_process());
+        REQUIRE(hub_root_is_suspended());
+        s_hcd.commands.clear();
+
+        WHEN("A device is attached to the empty root port") {
+            connect_device(1);
+
+            THEN("The suspended root port is resumed together with the attach") {
+                // The PM state of the root ports must stay symmetric
+                const std::vector<PortCommand> expected = {
+                    {1, HCD_PORT_CMD_RESET},
+                    {0, HCD_PORT_CMD_RESUME},
+                };
+                REQUIRE(s_hcd.commands == expected);
+                REQUIRE_FALSE(hub_root_is_suspended());
+            }
+
+            THEN("Only the previously suspended device is resumed") {
+                REQUIRE(ESP_OK == usbh_process());
+                // The freshly attached device was never suspended, so it must not get a resumed event either
+                REQUIRE(s_num_dev_resume_events == 1);
+            }
+
+            THEN("The freshly attached device can still be enumerated") {
+                /*
+                Mimic the beginning of the enumeration of the new device. The global resume must leave the device in
+                the DEFAULT state, otherwise the enumeration driver cannot set its EP0 MPS and the device never
+                enumerates.
+                */
+                usb_device_handle_t dev_hdl;
+                REQUIRE(ESP_OK == usbh_devs_open_uid(s_last_connected_uid, &dev_hdl));
+                REQUIRE(ESP_OK == usbh_dev_enum_lock(dev_hdl));
+                REQUIRE(ESP_OK == usbh_dev_set_ep0_mps(dev_hdl, 64));
+                REQUIRE(ESP_OK == usbh_dev_enum_unlock(dev_hdl));
+                REQUIRE(ESP_OK == usbh_dev_close(dev_hdl));
+            }
+        }
+
+        uninstall_hub(BIT0 | BIT1);
+    }
+}

--- a/host/usb/test/host_test/usbh_layer_test/main/hub_root_pm_unit_test.cpp
+++ b/host/usb/test/host_test/usbh_layer_test/main/hub_root_pm_unit_test.cpp
@@ -69,6 +69,12 @@ struct {
     hcd_port_callback_t cb[NUM_ROOT_PORTS];
     void *cb_arg[NUM_ROOT_PORTS];
     std::vector<PortCommand> commands;
+    // Error injection, armed by fail_next_command()
+    struct {
+        bool armed;
+        hcd_port_cmd_t cmd;
+        esp_err_t err;
+    } cmd_failure[NUM_ROOT_PORTS];
 } s_hcd;
 
 int s_num_dev_suspend_events;
@@ -111,6 +117,12 @@ esp_err_t port_command_stub(hcd_port_handle_t hdl, hcd_port_cmd_t command, int c
 {
     const int idx = port_idx(hdl);
     s_hcd.commands.push_back({idx, command});
+
+    if (s_hcd.cmd_failure[idx].armed && s_hcd.cmd_failure[idx].cmd == command) {
+        s_hcd.cmd_failure[idx].armed = false;
+        // A rejected command leaves the port in its previous state
+        return s_hcd.cmd_failure[idx].err;
+    }
 
     switch (command) {
     case HCD_PORT_CMD_POWER_ON:  s_hcd.state[idx] = HCD_PORT_STATE_DISCONNECTED; break;
@@ -284,6 +296,18 @@ void port_event(int idx, hcd_port_event_t event)
 }
 
 /**
+ * @brief Make the next occurrence of a port command on a root port fail
+ *
+ * @note A real HCD port rejects a command when its state machine changed underneath the command, which happens when
+ *       the device disconnects exactly while the command is being issued. Such a race is hardly reproducible on real
+ *       hardware, especially with two root ports involved.
+ */
+void fail_next_command(int idx, hcd_port_cmd_t cmd, esp_err_t err)
+{
+    s_hcd.cmd_failure[idx] = {true, cmd, err};
+}
+
+/**
  * @brief Bring a root port to the enabled state by connecting a device to it
  */
 void connect_device(int idx)
@@ -352,6 +376,25 @@ SCENARIO("Hub root PM: dual host global suspend and resume")
                 REQUIRE(ESP_OK == usbh_process());
                 REQUIRE(s_num_dev_resume_events == 2);
             }
+
+            THEN("A remote wakeup on one root port resumes both of them") {
+                REQUIRE(ESP_OK == usbh_process());
+                s_hcd.commands.clear();
+
+                // The device behind the second root port signals resume upstream
+                port_event(1, HCD_PORT_EVENT_REMOTE_WAKEUP);
+
+                // The remote wakeup makes the whole Host active, not just the root port that reported it
+                const std::vector<PortCommand> expected = {
+                    {0, HCD_PORT_CMD_RESUME},
+                    {1, HCD_PORT_CMD_RESUME},
+                };
+                REQUIRE(s_hcd.commands == expected);
+                REQUIRE_FALSE(hub_root_is_suspended());
+
+                // Each device is resumed exactly once
+                REQUIRE(s_num_dev_resume_events == 2);
+            }
         }
 
         uninstall_hub(BIT0 | BIT1);
@@ -379,7 +422,7 @@ SCENARIO("Hub root PM: root port without a device is not suspended")
             }
         }
 
-        uninstall_hub(BIT1);
+        uninstall_hub(BIT0 | BIT1);
     }
 }
 
@@ -397,9 +440,112 @@ SCENARIO("Hub root PM: no root port has a device")
             REQUIRE(s_hcd.commands.empty());
         }
 
-        uninstall_hub(0);
+        uninstall_hub(BIT0 | BIT1);
     }
 }
+
+/*
+@todo define reaction to these errors
+SCENARIO("Hub root PM: one root port fails to suspend")
+{
+    GIVEN("Both root ports enabled with a connected device") {
+        install_hub(BIT0 | BIT1);
+        connect_device(0);
+        connect_device(1);
+        s_hcd.commands.clear();
+
+        WHEN("The first root port rejects the suspend command") {
+            fail_next_command(0, HCD_PORT_CMD_SUSPEND, ESP_ERR_INVALID_RESPONSE);
+            REQUIRE(ESP_OK == hub_root_mark_suspend());
+            REQUIRE(ESP_OK == hub_process());
+
+            THEN("The other root port is suspended anyway") {
+                const std::vector<PortCommand> expected = {
+                    {0, HCD_PORT_CMD_SUSPEND},
+                    {1, HCD_PORT_CMD_SUSPEND},
+                };
+                REQUIRE(s_hcd.commands == expected);
+
+                // The failed root port keeps sending SOFs, so the Host as a whole is not suspended
+                REQUIRE_FALSE(hub_root_is_suspended());
+            }
+
+            THEN("Each device is still suspended exactly once") {
+                REQUIRE(ESP_OK == usbh_process());
+
+                // The client facing PM state is global, so the root port that did suspend propagates the event to every
+                // device. The device behind the failed root port is disconnecting (that is why the command was rejected),
+                // so it does not need a PM state of its own.
+                REQUIRE(s_num_dev_suspend_events == 2);
+            }
+
+            THEN("The failed root port can be suspended by a new attempt") {
+                s_hcd.commands.clear();
+                REQUIRE(ESP_OK == hub_root_can_suspend());
+                REQUIRE(ESP_OK == hub_root_mark_suspend());
+                REQUIRE(ESP_OK == hub_process());
+
+                // Only the root port that is still enabled is commanded again
+                const std::vector<PortCommand> expected = {{0, HCD_PORT_CMD_SUSPEND}};
+                REQUIRE(s_hcd.commands == expected);
+                REQUIRE(hub_root_is_suspended());
+            }
+        }
+
+        uninstall_hub(BIT0 | BIT1);
+    }
+}
+
+SCENARIO("Hub root PM: one root port fails to resume")
+{
+    GIVEN("Both root ports suspended with a connected device") {
+        install_hub(BIT0 | BIT1);
+        connect_device(0);
+        connect_device(1);
+        REQUIRE(ESP_OK == hub_root_mark_suspend());
+        REQUIRE(ESP_OK == hub_process());
+        REQUIRE(ESP_OK == usbh_process());
+        REQUIRE(hub_root_is_suspended());
+        s_hcd.commands.clear();
+
+        WHEN("The second root port rejects the resume command") {
+            fail_next_command(1, HCD_PORT_CMD_RESUME, ESP_ERR_INVALID_STATE);
+            REQUIRE(ESP_OK == hub_root_mark_resume());
+            REQUIRE(ESP_OK == hub_process());
+
+            THEN("The other root port is resumed anyway") {
+                const std::vector<PortCommand> expected = {
+                    {0, HCD_PORT_CMD_RESUME},
+                    {1, HCD_PORT_CMD_RESUME},
+                };
+                REQUIRE(s_hcd.commands == expected);
+
+                // One active root port is enough to make the Host active
+                REQUIRE_FALSE(hub_root_is_suspended());
+            }
+
+            THEN("Each device is still resumed exactly once") {
+                REQUIRE(ESP_OK == usbh_process());
+                REQUIRE(s_num_dev_resume_events == 2);
+            }
+
+            THEN("The failed root port can be resumed by a new attempt") {
+                s_hcd.commands.clear();
+                REQUIRE(ESP_OK == hub_root_can_resume());
+                REQUIRE(ESP_OK == hub_root_mark_resume());
+                REQUIRE(ESP_OK == hub_process());
+
+                // Only the root port that is still suspended is commanded again
+                const std::vector<PortCommand> expected = {{1, HCD_PORT_CMD_RESUME}};
+                REQUIRE(s_hcd.commands == expected);
+                REQUIRE_FALSE(hub_root_is_suspended());
+            }
+        }
+
+        uninstall_hub(BIT0 | BIT1);
+    }
+}
+*/
 
 SCENARIO("Hub root PM: attach on one root port resumes the other one")
 {

--- a/host/usb/test/mocks/usbh_layer_mock/usb/mock/mock_config.yaml
+++ b/host/usb/test/mocks/usbh_layer_mock/usb/mock/mock_config.yaml
@@ -5,3 +5,4 @@
     - return_thru_ptr
     - ignore
     - ignore_arg
+    - callback


### PR DESCRIPTION
Suspend/Resume both USB host ports in dual host configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core USB host power-management and light-sleep paths for dual-controller setups; incorrect per-device PM handling could affect enumeration or suspend notifications, though new unit tests cover the main scenarios.
> 
> **Overview**
> Fixes **ESP32-P4 dual-host** power management so global suspend, resume, auto-suspend, and pre–light-sleep suspend apply to **every root port with a device**, not only the first controller.
> 
> **Hub driver:** Root ports share one PM state—`hub_root_mark_suspend` / `hub_root_mark_resume`, light-sleep suspend, and `hub_root_is_suspended` iterate all installed ports. Suspend/resume client notifications are issued **once** after both ports are processed. A device attach on an idle port resumes a suspended sibling; light-sleep auto-PM is tracked **per port**.
> 
> **USBH:** `usbh_devs_set_pm_actions_all` only applies suspend/resume **events** to devices already in the matching state, so a new enumeration on one bus is not broken when the other bus resumes.
> 
> Docs, public API comments, changelog, and **Catch2 hub root PM unit tests** (dual-port fake HCD) document and lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11abaa723b284ff5e3674801ebbb77483a8aedb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->