### PR TITLE
release(cdc): Release usb_host_cdc_acm version 2.4.1

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
+++ b/host/class/cdc/usb_host_cdc_acm/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.4.1] - 2026-08-25
 
 ### Fixed
 

--- a/host/class/cdc/usb_host_cdc_acm/idf_component.yml
+++ b/host/class/cdc/usb_host_cdc_acm/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.4.0"
+version: "2.4.1"
 description: USB Host CDC-ACM driver
 tags:
   - usb


### PR DESCRIPTION
Let's release before upcoming refactoring changes in #533 

Closes milestone https://github.com/espressif/esp-usb/milestone/39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version and changelog metadata change; no runtime code is modified in this PR.
> 
> **Overview**
> **Publishes `usb_host_cdc_acm` 2.4.1** as a component-manager release with no driver source changes in this diff.
> 
> `idf_component.yml` bumps the published version from **2.4.0** to **2.4.1**. The changelog moves the pending **Fixed** notes out of **Unreleased** and stamps them under **\[2.4.1\] - 2026-08-25** (transfer submit/poll race fix from PR #518 and bounding **SERIAL_STATE** notification parsing by `actual_num_bytes`).
> 
> This is a release cut ahead of larger refactoring work in #533.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b31c39125fcd4d98e31600e7980e376617c2a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->