### PR TITLE
release(uvc): Release usb_host_uvc version 2.5.2

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.2] - 2026-09-01
 
 ### Added
 

--- a/host/class/uvc/usb_host_uvc/idf_component.yml
+++ b/host/class/uvc/usb_host_uvc/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "2.5.1"
+version: "2.5.2"
 description: USB Host UVC driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/uvc/usb_host_uvc
 dependencies:


### PR DESCRIPTION
Bugfix release

## Related

* Blocked by #545 
* Closes https://github.com/espressif/esp-usb/milestone/42


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release PR (version and changelog); no driver or runtime code changes in the diff.
> 
> **Overview**
> **Publishes `usb_host_uvc` 2.5.2** by bumping the IDF component manifest from **2.5.1** to **2.5.2** and replacing the **Unreleased** changelog section with a dated **[2.5.2] - 2026-09-01** entry.
> 
> The new release notes record the bugfix work shipped in this milestone: optional **`CONFIG_UVC_CHECK_PAYLOAD_HEADER_ERR`**, safer ISOC handling for invalid/empty payload headers, MJPEG buffer sizing in the basic stream example, non-fatal cleanup in **`uvc_host_stream_close()`** when the device is stalled or disconnected (issue #529), plus additional fixes already listed under 2.5.2 in the changelog (EOF-less camera frame boundaries, VC header NULL checks / frame-interval clamping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1220fbca614fee3a00e0f3777c6759792d4faa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->