### PR TITLE
release(hid): Release usb_host_hid version 1.2.1

### DIFF
--- a/host/class/hid/usb_host_hid/CHANGELOG.md
+++ b/host/class/hid/usb_host_hid/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.1] - 2026-08-26
 
 ### Fixed
 

--- a/host/class/hid/usb_host_hid/idf_component.yml
+++ b/host/class/hid/usb_host_hid/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.2.0"
+version: "1.2.1"
 description: USB Host HID driver
 url: https://github.com/espressif/esp-usb/tree/master/host/class/hid/usb_host_hid
 issues: "https://github.com/espressif/esp-usb/issues"


### PR DESCRIPTION
Bugfix release

Closes https://github.com/espressif/esp-usb/milestone/34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only changes to version and changelog; runtime behavior is unchanged by this PR itself.
> 
> **Overview**
> **Packages the USB Host HID driver as version 1.2.1** by bumping `version` in `idf_component.yml` from `1.2.0` to `1.2.1` and turning the prior **Unreleased** changelog entry into a dated **1.2.1** release (2026-08-26).
> 
> There are **no source changes in this diff**—only release metadata. The documented fix is the disconnect cleanup bug (#470): strict close APIs stay unchanged, while disconnect teardown uses best-effort helpers so `hid_host_uninstall_device()` always runs and device context cannot remain stuck after unplug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec72ecfd14e09c14ee499c52a14c559837cbe4c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->