### PR TITLE
fix(hcd_test): Better logging

### DIFF
--- a/host/usb/test/target_test/common/hcd_common.c
+++ b/host/usb/test/target_test/common/hcd_common.c
@@ -20,6 +20,7 @@
 #include "mock_msc.h"
 #include "phy_common.h"
 #include "unity.h"
+#include "esp_log.h"
 #include "sdkconfig.h"
 
 // ----------------------------------------------------- Macros --------------------------------------------------------
@@ -28,6 +29,8 @@
 #define ENUM_ADDR               1   // Device address to use for tests that enumerate the device
 #define ENUM_CONFIG             1   // Device configuration number to use for tests that enumerate the device
 #define TRANSFER_MAX_BYTES      256
+
+static const char *TAG = "HCD";
 
 typedef struct {
     hcd_port_handle_t port_hdl;
@@ -235,7 +238,7 @@ void test_hcd_expect_port_event_impl(hcd_port_handle_t port_hdl, hcd_port_event_
         snprintf(err_msg_buf, sizeof(err_msg_buf), "Unexpected port event at %s:%d\n %s expected, %s delivered", file, line, port_event_str(expected_event), port_event_str(msg.port_event));
         TEST_FAIL_MESSAGE(err_msg_buf);
     }
-    printf("\t-> Port event\n");
+    ESP_LOGD(TAG, "-> Port event");
 }
 
 void test_hcd_expect_pipe_event_impl(hcd_pipe_handle_t pipe_hdl, hcd_pipe_event_t expected_event, const char *file, int line)
@@ -359,19 +362,19 @@ usb_speed_t test_hcd_wait_for_conn(hcd_port_handle_t port_hdl)
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_POWER_ON));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_DISCONNECTED);
     // Wait for connection event
-    printf("Waiting for connection\n");
+    ESP_LOGI(TAG, "Waiting for connection");
     TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_CONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_CONNECTION, hcd_port_handle_event(port_hdl));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_DISABLED);
     // Reset newly connected device
-    printf("Resetting\n");
+    ESP_LOGI(TAG, "Resetting");
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESET));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
     // Get speed of connected
     usb_speed_t port_speed;
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_get_speed(port_hdl, &port_speed));
     TEST_ASSERT_LESS_OR_EQUAL_MESSAGE(USB_SPEED_HIGH, port_speed, "Invalid port speed");
-    printf("%s speed enabled\n", (char *[]) {
+    ESP_LOGI(TAG, "%s speed enabled", (char *[]) {
         "Low", "Full", "High"
     }[port_speed]);
     return port_speed;
@@ -381,11 +384,11 @@ void test_hcd_wait_for_disconn(hcd_port_handle_t port_hdl, bool already_disabled
 {
     if (!already_disabled) {
         // Disable the device
-        printf("Disabling\n");
+        ESP_LOGI(TAG, "Disabling");
         TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_DISABLE));
         TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_DISABLED);
     }
-    printf("Waiting for disconnection\n");
+    ESP_LOGI(TAG, "Waiting for disconnection");
     // Power-off the port to trigger a disconnection
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_POWER_OFF));
     // Wait for the port disconnection event
@@ -406,7 +409,7 @@ void test_hcd_root_port_suspend(hcd_port_handle_t port_hdl, hcd_pipe_handle_t pi
     // Suspend the root port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
-    printf("Root port suspended\n");
+    ESP_LOGI(TAG, "Root port suspended");
 }
 
 void test_hcd_root_port_suspend_multi_pipe(hcd_port_handle_t port_hdl, hcd_pipe_handle_t *pipe_list, int list_len)
@@ -422,7 +425,7 @@ void test_hcd_root_port_suspend_multi_pipe(hcd_port_handle_t port_hdl, hcd_pipe_
     // Suspend the root port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
-    printf("Root port suspended\n");
+    ESP_LOGI(TAG, "Root port suspended");
 }
 
 void test_hcd_root_port_resume(hcd_port_handle_t port_hdl, hcd_pipe_handle_t pipe_hdl)
@@ -433,7 +436,7 @@ void test_hcd_root_port_resume(hcd_port_handle_t port_hdl, hcd_pipe_handle_t pip
     // Clear the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(pipe_hdl, HCD_PIPE_CMD_CLEAR));
     TEST_HCD_EXPECT_PIPE_STATE(pipe_hdl, HCD_PIPE_STATE_ACTIVE);
-    printf("Root port resumed\n");
+    ESP_LOGI(TAG, "Root port resumed");
 }
 
 void test_hcd_root_port_resume_multi_pipe(hcd_port_handle_t port_hdl, hcd_pipe_handle_t *pipe_list, int list_len)
@@ -600,11 +603,11 @@ void test_hcd_remote_wake_enable(hcd_pipe_handle_t default_pipe, urb_t *feature_
     feature_urb->transfer.context = URB_CONTEXT_VAL;
 
     if (enable) {
-        printf("Enabling device remote wake-up\n");
+        ESP_LOGI(TAG, "Enabling device remote wake-up");
         // Initialize feature_urb with the set feature request to enable remote wakeup
         USB_SETUP_PACKET_INIT_SET_FEATURE((usb_setup_packet_t *)feature_urb->transfer.data_buffer, DEVICE_REMOTE_WAKEUP);
     } else {
-        printf("Disabling device remote wake-up\n");
+        ESP_LOGI(TAG, "Disabling device remote wake-up");
         // Initialize feature_urb with the clear feature request to disable remote wakeup
         USB_SETUP_PACKET_INIT_CLEAR_FEATURE((usb_setup_packet_t *)feature_urb->transfer.data_buffer, DEVICE_REMOTE_WAKEUP);
     }
@@ -646,6 +649,6 @@ bool test_hcd_remote_wake_check(hcd_pipe_handle_t default_pipe, urb_t *get_statu
     // Get the device status out of the data buffer
     usb_device_status_t *device_status = (usb_device_status_t *)(urb->transfer.data_buffer + sizeof(usb_setup_packet_t));
     const bool remote_wake_enabled = device_status->remote_wakeup;
-    printf("Remote wake-up is currently %s\n", ((remote_wake_enabled)) ? ("enabled") : ("disabled") );
+    ESP_LOGI(TAG, "Remote wake-up is currently %s", ((remote_wake_enabled)) ? ("enabled") : ("disabled") );
     return remote_wake_enabled;
 }

--- a/host/usb/test/target_test/common/hcd_common.c
+++ b/host/usb/test/target_test/common/hcd_common.c
@@ -41,6 +41,121 @@ typedef struct {
 
 hcd_port_handle_t port_hdl = NULL;
 
+// ----------------------------------------------------- Logging -------------------------------------------------------
+
+// Buffer for building Unity failure messages that include the caller's file and line
+static char err_msg_buf[128];
+
+// Human-readable names for HCD port events, indexed by hcd_port_event_t
+static const char *const port_event_names[] = {
+    [HCD_PORT_EVENT_NONE]           = "HCD_PORT_EVENT_NONE",
+    [HCD_PORT_EVENT_CONNECTION]     = "HCD_PORT_EVENT_CONNECTION",
+    [HCD_PORT_EVENT_DISCONNECTION]  = "HCD_PORT_EVENT_DISCONNECTION",
+    [HCD_PORT_EVENT_ERROR]          = "HCD_PORT_EVENT_ERROR",
+    [HCD_PORT_EVENT_OVERCURRENT]    = "HCD_PORT_EVENT_OVERCURRENT",
+    [HCD_PORT_EVENT_REMOTE_WAKEUP]  = "HCD_PORT_EVENT_REMOTE_WAKEUP",
+};
+
+// Human-readable names for HCD pipe events, indexed by hcd_pipe_event_t
+static const char *const pipe_event_names[] = {
+    [HCD_PIPE_EVENT_NONE]                   = "HCD_PIPE_EVENT_NONE",
+    [HCD_PIPE_EVENT_URB_DONE]               = "HCD_PIPE_EVENT_URB_DONE",
+    [HCD_PIPE_EVENT_ERROR_XFER]             = "HCD_PIPE_EVENT_ERROR_XFER",
+    [HCD_PIPE_EVENT_ERROR_URB_NOT_AVAIL]    = "HCD_PIPE_EVENT_ERROR_URB_NOT_AVAIL",
+    [HCD_PIPE_EVENT_ERROR_OVERFLOW]         = "HCD_PIPE_EVENT_ERROR_OVERFLOW",
+    [HCD_PIPE_EVENT_ERROR_STALL]            = "HCD_PIPE_EVENT_ERROR_STALL",
+};
+
+// Human-readable names for HCD port states, indexed by hcd_port_state_t
+static const char *const port_state_names[] = {
+    [HCD_PORT_STATE_NOT_POWERED]    = "HCD_PORT_STATE_NOT_POWERED",
+    [HCD_PORT_STATE_DISCONNECTED]   = "HCD_PORT_STATE_DISCONNECTED",
+    [HCD_PORT_STATE_DISABLED]       = "HCD_PORT_STATE_DISABLED",
+    [HCD_PORT_STATE_RESETTING]      = "HCD_PORT_STATE_RESETTING",
+    [HCD_PORT_STATE_SUSPENDING]     = "HCD_PORT_STATE_SUSPENDING",
+    [HCD_PORT_STATE_SUSPENDED]      = "HCD_PORT_STATE_SUSPENDED",
+    [HCD_PORT_STATE_RESUMING]       = "HCD_PORT_STATE_RESUMING",
+    [HCD_PORT_STATE_ENABLED]        = "HCD_PORT_STATE_ENABLED",
+    [HCD_PORT_STATE_RECOVERY]       = "HCD_PORT_STATE_RECOVERY",
+};
+
+// Human-readable names for HCD pipe states, indexed by hcd_pipe_state_t
+static const char *const pipe_state_names[] = {
+    [HCD_PIPE_STATE_ACTIVE]         = "HCD_PIPE_STATE_ACTIVE",
+    [HCD_PIPE_STATE_HALTED]         = "HCD_PIPE_STATE_HALTED",
+};
+
+// Human-readable names for USB transfer statuses, indexed by usb_transfer_status_t
+static const char *const transfer_status_names[] = {
+    [USB_TRANSFER_STATUS_COMPLETED] = "USB_TRANSFER_STATUS_COMPLETED",
+    [USB_TRANSFER_STATUS_ERROR]     = "USB_TRANSFER_STATUS_ERROR",
+    [USB_TRANSFER_STATUS_TIMED_OUT] = "USB_TRANSFER_STATUS_TIMED_OUT",
+    [USB_TRANSFER_STATUS_CANCELED]  = "USB_TRANSFER_STATUS_CANCELED",
+    [USB_TRANSFER_STATUS_STALL]     = "USB_TRANSFER_STATUS_STALL",
+    [USB_TRANSFER_STATUS_OVERFLOW]  = "USB_TRANSFER_STATUS_OVERFLOW",
+    [USB_TRANSFER_STATUS_SKIPPED]   = "USB_TRANSFER_STATUS_SKIPPED",
+    [USB_TRANSFER_STATUS_NO_DEVICE] = "USB_TRANSFER_STATUS_NO_DEVICE",
+};
+
+/**
+ * @brief Look up a name in a name table
+ *
+ * @param names Name table indexed by enum value
+ * @param count Number of entries in the name table
+ * @param value Enum value to resolve
+ * @return const char* Matching name, or "UNKNOWN" for out-of-range indices or gaps in the table
+ */
+static const char *enum_to_str(const char *const *names, size_t count, int value)
+{
+    if (value < 0 || (size_t)value >= count || names[value] == NULL) {
+        return "UNKNOWN";
+    }
+    return names[value];
+}
+
+// Resolve an enum value against its name table (which must be in scope)
+#define ENUM_TO_STR(names, value) enum_to_str((names), sizeof(names) / sizeof((names)[0]), (value))
+
+/**
+ * @brief Get the human-readable name of an HCD port event
+ */
+static const char *port_event_str(hcd_port_event_t event)
+{
+    return ENUM_TO_STR(port_event_names, event);
+}
+
+/**
+ * @brief Get the human-readable name of an HCD pipe event
+ */
+static const char *pipe_event_str(hcd_pipe_event_t event)
+{
+    return ENUM_TO_STR(pipe_event_names, event);
+}
+
+/**
+ * @brief Get the human-readable name of an HCD port state
+ */
+static const char *port_state_str(hcd_port_state_t state)
+{
+    return ENUM_TO_STR(port_state_names, state);
+}
+
+/**
+ * @brief Get the human-readable name of an HCD pipe state
+ */
+static const char *pipe_state_str(hcd_pipe_state_t state)
+{
+    return ENUM_TO_STR(pipe_state_names, state);
+}
+
+/**
+ * @brief Get the human-readable name of a USB transfer status
+ */
+static const char *transfer_status_str(usb_transfer_status_t status)
+{
+    return ENUM_TO_STR(transfer_status_names, status);
+}
+
 // ---------------------------------------------------- Private --------------------------------------------------------
 
 /**
@@ -64,7 +179,9 @@ static bool port_callback(hcd_port_handle_t port_hdl, hcd_port_event_t port_even
         .port_event = port_event,
     };
     BaseType_t xTaskWoken = pdFALSE;
-    xQueueSendFromISR(port_evt_queue, &msg, &xTaskWoken);
+    BaseType_t ret = xQueueSendFromISR(port_evt_queue, &msg, &xTaskWoken);
+    // Asserting in case of the queue being full instead of TEST_ASSERT which is not ISR safe function
+    configASSERT(ret == pdTRUE);
     return (xTaskWoken == pdTRUE);
 }
 
@@ -87,17 +204,20 @@ static bool pipe_callback(hcd_pipe_handle_t pipe_hdl, hcd_pipe_event_t pipe_even
     };
     if (in_isr) {
         BaseType_t xTaskWoken = pdFALSE;
-        xQueueSendFromISR(pipe_evt_queue, &msg, &xTaskWoken);
+        BaseType_t ret = xQueueSendFromISR(pipe_evt_queue, &msg, &xTaskWoken);
+        // Asserting in case of the queue being full instead of TEST_ASSERT which is not ISR safe function
+        configASSERT(ret == pdTRUE);
         return (xTaskWoken == pdTRUE);
     } else {
-        xQueueSend(pipe_evt_queue, &msg, portMAX_DELAY);
+        BaseType_t ret = xQueueSend(pipe_evt_queue, &msg, pdMS_TO_TICKS(10000));
+        TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, ret, "Pipe event queue full, event lost");
         return false;
     }
 }
 
 // ------------------------------------------------- HCD Event Test ----------------------------------------------------
 
-void test_hcd_expect_port_event(hcd_port_handle_t port_hdl, hcd_port_event_t expected_event)
+void test_hcd_expect_port_event_impl(hcd_port_handle_t port_hdl, hcd_port_event_t expected_event, const char *file, int line)
 {
     // Get the port event queue from the port's context variable
     QueueHandle_t port_evt_queue = (QueueHandle_t)hcd_port_get_context(port_hdl);
@@ -105,14 +225,20 @@ void test_hcd_expect_port_event(hcd_port_handle_t port_hdl, hcd_port_event_t exp
     // Wait for port callback to send an event message
     port_event_msg_t msg;
     BaseType_t ret = xQueueReceive(port_evt_queue, &msg, pdMS_TO_TICKS(5000));
-    TEST_ASSERT_EQUAL_MESSAGE(pdPASS, ret, "Port event not generated on time");
+    if (ret != pdPASS) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Port event %s not generated on time at %s:%d", port_event_str(expected_event), file, line);
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
     // Check the contents of that event message
     TEST_ASSERT_EQUAL(port_hdl, msg.port_hdl);
-    TEST_ASSERT_EQUAL_MESSAGE(expected_event, msg.port_event, "Unexpected port event");
+    if (expected_event != msg.port_event) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Unexpected port event at %s:%d\n %s expected, %s delivered", file, line, port_event_str(expected_event), port_event_str(msg.port_event));
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
     printf("\t-> Port event\n");
 }
 
-void test_hcd_expect_pipe_event(hcd_pipe_handle_t pipe_hdl, hcd_pipe_event_t expected_event)
+void test_hcd_expect_pipe_event_impl(hcd_pipe_handle_t pipe_hdl, hcd_pipe_event_t expected_event, const char *file, int line)
 {
     // Get the pipe's event queue from the pipe's context variable
     QueueHandle_t pipe_evt_queue = (QueueHandle_t)hcd_pipe_get_context(pipe_hdl);
@@ -120,13 +246,19 @@ void test_hcd_expect_pipe_event(hcd_pipe_handle_t pipe_hdl, hcd_pipe_event_t exp
     // Wait for pipe callback to send an event message
     pipe_event_msg_t msg;
     BaseType_t ret =  xQueueReceive(pipe_evt_queue, &msg, pdMS_TO_TICKS(5000));
-    TEST_ASSERT_EQUAL_MESSAGE(pdPASS, ret, "Pipe event not generated on time");
+    if (ret != pdPASS) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Pipe event %s not generated on time at %s:%d", pipe_event_str(expected_event), file, line);
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
     // Check the contents of that event message
     TEST_ASSERT_EQUAL(pipe_hdl, msg.pipe_hdl);
-    TEST_ASSERT_EQUAL_MESSAGE(expected_event, msg.pipe_event, "Unexpected pipe event");
+    if (expected_event != msg.pipe_event) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Unexpected pipe event at %s:%d\n %s expected, %s delivered", file, line, pipe_event_str(expected_event), pipe_event_str(msg.pipe_event));
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
 }
 
-void test_hcd_expect_no_pipe_event(hcd_pipe_handle_t pipe_hdl)
+void test_hcd_expect_no_pipe_event_impl(hcd_pipe_handle_t pipe_hdl, const char *file, int line)
 {
     // Get the pipe's event queue from the pipe's context variable
     QueueHandle_t pipe_evt_queue = (QueueHandle_t)hcd_pipe_get_context(pipe_hdl);
@@ -134,7 +266,37 @@ void test_hcd_expect_no_pipe_event(hcd_pipe_handle_t pipe_hdl)
     // Wait for pipe callback to send an event message
     pipe_event_msg_t msg;
     BaseType_t ret =  xQueueReceive(pipe_evt_queue, &msg, pdMS_TO_TICKS(2000));
-    TEST_ASSERT_EQUAL_MESSAGE(pdFALSE, ret, "Pipe event generated, but none expected");
+    if (ret != pdFALSE) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Expecting NO pipe event, but %s delivered at %s:%d", pipe_event_str(msg.pipe_event), file, line);
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
+}
+
+void test_hcd_expect_port_state_impl(hcd_port_handle_t port_hdl, hcd_port_state_t expected_state, const char *file, int line)
+{
+    hcd_port_state_t actual_state = hcd_port_get_state(port_hdl);
+    if (actual_state != expected_state) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Unexpected port state at %s:%d\n %s expected, %s actual", file, line, port_state_str(expected_state), port_state_str(actual_state));
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
+}
+
+void test_hcd_expect_pipe_state_impl(hcd_pipe_handle_t pipe_hdl, hcd_pipe_state_t expected_state, const char *file, int line)
+{
+    hcd_pipe_state_t actual_state = hcd_pipe_get_state(pipe_hdl);
+    if (actual_state != expected_state) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Unexpected pipe state at %s:%d\n %s expected, %s actual", file, line, pipe_state_str(expected_state), pipe_state_str(actual_state));
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
+}
+
+void test_hcd_expect_transfer_status_impl(const urb_t *urb, usb_transfer_status_t expected_status, const char *file, int line)
+{
+    TEST_ASSERT_NOT_NULL(urb);
+    if (urb->transfer.status != expected_status) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Unexpected transfer status at %s:%d\n %s expected, %s delivered", file, line, transfer_status_str(expected_status), transfer_status_str(urb->transfer.status));
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
 }
 
 int test_hcd_get_num_port_events(hcd_port_handle_t port_hdl)
@@ -195,16 +357,16 @@ usb_speed_t test_hcd_wait_for_conn(hcd_port_handle_t port_hdl)
 {
     // Power ON the port. This should allow for connections to occur
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_POWER_ON));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_DISCONNECTED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_DISCONNECTED);
     // Wait for connection event
     printf("Waiting for connection\n");
-    test_hcd_expect_port_event(port_hdl, HCD_PORT_EVENT_CONNECTION);
+    TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_CONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_CONNECTION, hcd_port_handle_event(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_DISABLED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_DISABLED);
     // Reset newly connected device
     printf("Resetting\n");
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESET));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_ENABLED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
     // Get speed of connected
     usb_speed_t port_speed;
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_get_speed(port_hdl, &port_speed));
@@ -221,18 +383,18 @@ void test_hcd_wait_for_disconn(hcd_port_handle_t port_hdl, bool already_disabled
         // Disable the device
         printf("Disabling\n");
         TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_DISABLE));
-        TEST_ASSERT_EQUAL(HCD_PORT_STATE_DISABLED, hcd_port_get_state(port_hdl));
+        TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_DISABLED);
     }
     printf("Waiting for disconnection\n");
     // Power-off the port to trigger a disconnection
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_POWER_OFF));
     // Wait for the port disconnection event
-    test_hcd_expect_port_event(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
+    TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_DISCONNECTION, hcd_port_handle_event(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_RECOVERY, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_RECOVERY);
     // Power down the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_POWER_OFF));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_NOT_POWERED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_NOT_POWERED);
 }
 
 void test_hcd_root_port_suspend(hcd_port_handle_t port_hdl, hcd_pipe_handle_t pipe_hdl)
@@ -240,10 +402,10 @@ void test_hcd_root_port_suspend(hcd_port_handle_t port_hdl, hcd_pipe_handle_t pi
     // Halt and flush the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(pipe_hdl, HCD_PIPE_CMD_HALT));
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(pipe_hdl, HCD_PIPE_CMD_FLUSH));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(pipe_hdl));
+    TEST_HCD_EXPECT_PIPE_STATE(pipe_hdl, HCD_PIPE_STATE_HALTED);
     // Suspend the root port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_SUSPENDED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
     printf("Root port suspended\n");
 }
 
@@ -254,12 +416,12 @@ void test_hcd_root_port_suspend_multi_pipe(hcd_port_handle_t port_hdl, hcd_pipe_
         // Halt and flush the pipe
         TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(pipe_hdl, HCD_PIPE_CMD_HALT));
         TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(pipe_hdl, HCD_PIPE_CMD_FLUSH));
-        TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(pipe_hdl));
+        TEST_HCD_EXPECT_PIPE_STATE(pipe_hdl, HCD_PIPE_STATE_HALTED);
     }
 
     // Suspend the root port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_SUSPENDED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
     printf("Root port suspended\n");
 }
 
@@ -267,10 +429,10 @@ void test_hcd_root_port_resume(hcd_port_handle_t port_hdl, hcd_pipe_handle_t pip
 {
     // Resume the root port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESUME));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_ENABLED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
     // Clear the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(pipe_hdl, HCD_PIPE_CMD_CLEAR));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(pipe_hdl));
+    TEST_HCD_EXPECT_PIPE_STATE(pipe_hdl, HCD_PIPE_STATE_ACTIVE);
     printf("Root port resumed\n");
 }
 
@@ -278,13 +440,13 @@ void test_hcd_root_port_resume_multi_pipe(hcd_port_handle_t port_hdl, hcd_pipe_h
 {
     // Resume the root port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESUME));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_ENABLED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
 
     for (int pipe_i = 0; pipe_i < list_len; pipe_i++) {
         hcd_pipe_handle_t pipe_hdl = pipe_list[pipe_i];
         // Clear the pipe
         TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(pipe_hdl, HCD_PIPE_CMD_CLEAR));
-        TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(pipe_hdl));
+        TEST_HCD_EXPECT_PIPE_STATE(pipe_hdl, HCD_PIPE_STATE_ACTIVE);
     }
 }
 
@@ -370,9 +532,9 @@ uint8_t test_hcd_enum_device(hcd_pipe_handle_t default_pipe)
     USB_SETUP_PACKET_INIT_GET_DEVICE_DESC(setup_pkt);
     urb->transfer.num_bytes = sizeof(usb_setup_packet_t) + sizeof(usb_device_desc_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(urb, hcd_urb_dequeue(default_pipe));
-    TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+    TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
 
     // Update the MPS of the default pipe
     usb_device_desc_t *device_desc = (usb_device_desc_t *)(urb->transfer.data_buffer + sizeof(usb_setup_packet_t));
@@ -382,9 +544,9 @@ uint8_t test_hcd_enum_device(hcd_pipe_handle_t default_pipe)
     USB_SETUP_PACKET_INIT_SET_ADDR(setup_pkt, ENUM_ADDR);    // We only support one device for now so use address 1
     urb->transfer.num_bytes = sizeof(usb_setup_packet_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(urb, hcd_urb_dequeue(default_pipe));
-    TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+    TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
 
     // Update address of default pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_update_dev_addr(default_pipe, ENUM_ADDR));
@@ -397,9 +559,9 @@ uint8_t test_hcd_enum_device(hcd_pipe_handle_t default_pipe)
     USB_SETUP_PACKET_INIT_SET_CONFIG(setup_pkt, ENUM_CONFIG);
     urb->transfer.num_bytes = sizeof(usb_setup_packet_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(urb, hcd_urb_dequeue(default_pipe));
-    TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+    TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
 
     // Free URB
     test_hcd_free_urb(urb);
@@ -417,12 +579,12 @@ void test_hcd_ping_device(hcd_pipe_handle_t default_pipe, urb_t *default_urb)
 
     // Enqueue urb, wait for the URB_DONE event and dequeue urb
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, default_urb));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     urb_t *urb = hcd_urb_dequeue(default_pipe);
 
     // Check the dequeued URB
     TEST_ASSERT_EQUAL_MESSAGE(default_urb, urb, "URB pointers not equal");
-    TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+    TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
     TEST_ASSERT_EQUAL_MESSAGE(URB_CONTEXT_VAL, urb->transfer.context, "URB context not equal");
 
     // We must have transmitted at least the setup packet, but device may return less bytes than bytes requested
@@ -449,12 +611,12 @@ void test_hcd_remote_wake_enable(hcd_pipe_handle_t default_pipe, urb_t *feature_
 
     // Enqueue urb, wait for the URB_DONE event and dequeue urb
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, feature_urb));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     urb_t *urb = hcd_urb_dequeue(default_pipe);
 
     // Check the dequeued URB
     TEST_ASSERT_EQUAL_MESSAGE(feature_urb, urb, "URB pointers not equal");
-    TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+    TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
     TEST_ASSERT_EQUAL_MESSAGE(URB_CONTEXT_VAL, urb->transfer.context, "URB context not equal");
 
     TEST_ASSERT_EQUAL(sizeof(usb_setup_packet_t), urb->transfer.actual_num_bytes);
@@ -470,12 +632,12 @@ bool test_hcd_remote_wake_check(hcd_pipe_handle_t default_pipe, urb_t *get_statu
 
     // Enqueue urb, wait for the URB_DONE event and dequeue urb
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, get_status_urb));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     urb_t *urb = hcd_urb_dequeue(default_pipe);
 
     // Check the dequeued URB
     TEST_ASSERT_EQUAL_MESSAGE(get_status_urb, urb, "URB pointers not equal");
-    TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+    TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
     TEST_ASSERT_EQUAL_MESSAGE(URB_CONTEXT_VAL, urb->transfer.context, "URB context not equal");
 
     TEST_ASSERT_EQUAL(sizeof(usb_setup_packet_t) + sizeof(usb_device_status_t), urb->transfer.actual_num_bytes);

--- a/host/usb/test/target_test/common/hcd_common.h
+++ b/host/usb/test/target_test/common/hcd_common.h
@@ -35,10 +35,34 @@ extern hcd_port_handle_t port_hdl;
 /**
  * @brief Expect (wait) for an HCD port event
  *
+ * @note Use the TEST_HCD_EXPECT_PORT_EVENT() macro, which automatically fills in the file and line.
+ *
+ * @param port_hdl Port handle to expect event from
+ * @param expected_event Port event to expect
+ * @param file File from which the function was called
+ * @param line Line from which the function was called
+ */
+void test_hcd_expect_port_event_impl(hcd_port_handle_t port_hdl, hcd_port_event_t expected_event, const char *file, int line);
+
+/**
+ * @brief Expect (wait) for an HCD port event
+ *
  * @param port_hdl Port handle to expect event from
  * @param expected_event Port event to expect
  */
-void test_hcd_expect_port_event(hcd_port_handle_t port_hdl, hcd_port_event_t expected_event);
+#define TEST_HCD_EXPECT_PORT_EVENT(port_hdl, expected_event) test_hcd_expect_port_event_impl((port_hdl), (expected_event), __FILE__, __LINE__)
+
+/**
+ * @brief Expect (wait) for an HCD pipe event
+ *
+ * @note Use the TEST_HCD_EXPECT_PIPE_EVENT() macro, which automatically fills in the file and line.
+ *
+ * @param pipe_hdl Pipe handle to expect event from
+ * @param expected_event Pipe event to expect
+ * @param file File from which the function was called
+ * @param line Line from which the function was called
+ */
+void test_hcd_expect_pipe_event_impl(hcd_pipe_handle_t pipe_hdl, hcd_pipe_event_t expected_event, const char *file, int line);
 
 /**
  * @brief Expect (wait) for an HCD pipe event
@@ -46,7 +70,20 @@ void test_hcd_expect_port_event(hcd_port_handle_t port_hdl, hcd_port_event_t exp
  * @param pipe_hdl Pipe handle to expect event from
  * @param expected_event Pipe event to expect
  */
-void test_hcd_expect_pipe_event(hcd_pipe_handle_t pipe_hdl, hcd_pipe_event_t expected_event);
+#define TEST_HCD_EXPECT_PIPE_EVENT(pipe_hdl, expected_event) test_hcd_expect_pipe_event_impl((pipe_hdl), (expected_event), __FILE__, __LINE__)
+
+/**
+ * @brief Expect (wait) for an HCD pipe event, but none should be delivered
+ *
+ * This function waits for an pipe event and makes sure, that none is delivered
+ *
+ * @note Use the TEST_HCD_EXPECT_NO_PIPE_EVENT() macro, which automatically fills in the file and line.
+ *
+ * @param pipe_hdl Pipe handle to expect event from
+ * @param file File from which the function was called
+ * @param line Line from which the function was called
+ */
+void test_hcd_expect_no_pipe_event_impl(hcd_pipe_handle_t pipe_hdl, const char *file, int line);
 
 /**
  * @brief Expect (wait) for an HCD pipe event, but none should be delivered
@@ -55,10 +92,70 @@ void test_hcd_expect_pipe_event(hcd_pipe_handle_t pipe_hdl, hcd_pipe_event_t exp
  *
  * @param pipe_hdl Pipe handle to expect event from
  */
-void test_hcd_expect_no_pipe_event(hcd_pipe_handle_t pipe_hdl);
+#define TEST_HCD_EXPECT_NO_PIPE_EVENT(pipe_hdl) test_hcd_expect_no_pipe_event_impl((pipe_hdl), __FILE__, __LINE__)
 
 /**
- * @brief Get the current number of queued port events (dequeued using test_hcd_expect_port_event())
+ * @brief Expect (assert) that an HCD port is in a given state
+ *
+ * @note Use the TEST_HCD_EXPECT_PORT_STATE() macro, which automatically fills in the file and line.
+ *
+ * @param port_hdl Port handle to check
+ * @param expected_state Port state to expect
+ * @param file File from which the function was called
+ * @param line Line from which the function was called
+ */
+void test_hcd_expect_port_state_impl(hcd_port_handle_t port_hdl, hcd_port_state_t expected_state, const char *file, int line);
+
+/**
+ * @brief Expect (assert) that an HCD port is in a given state
+ *
+ * @param port_hdl Port handle to check
+ * @param expected_state Port state to expect
+ */
+#define TEST_HCD_EXPECT_PORT_STATE(port_hdl, expected_state) test_hcd_expect_port_state_impl((port_hdl), (expected_state), __FILE__, __LINE__)
+
+/**
+ * @brief Expect (assert) that an HCD pipe is in a given state
+ *
+ * @note Use the TEST_HCD_EXPECT_PIPE_STATE() macro, which automatically fills in the file and line.
+ *
+ * @param pipe_hdl Pipe handle to check
+ * @param expected_state Pipe state to expect
+ * @param file File from which the function was called
+ * @param line Line from which the function was called
+ */
+void test_hcd_expect_pipe_state_impl(hcd_pipe_handle_t pipe_hdl, hcd_pipe_state_t expected_state, const char *file, int line);
+
+/**
+ * @brief Expect (assert) that an HCD pipe is in a given state
+ *
+ * @param pipe_hdl Pipe handle to check
+ * @param expected_state Pipe state to expect
+ */
+#define TEST_HCD_EXPECT_PIPE_STATE(pipe_hdl, expected_state) test_hcd_expect_pipe_state_impl((pipe_hdl), (expected_state), __FILE__, __LINE__)
+
+/**
+ * @brief Expect (assert) that a URB's transfer completed with a given status
+ *
+ * @note Use the TEST_HCD_EXPECT_TRANSFER_STATUS() macro, which automatically fills in the file and line.
+ *
+ * @param urb URB whose transfer status to check
+ * @param expected_status Transfer status to expect
+ * @param file File from which the function was called
+ * @param line Line from which the function was called
+ */
+void test_hcd_expect_transfer_status_impl(const urb_t *urb, usb_transfer_status_t expected_status, const char *file, int line);
+
+/**
+ * @brief Expect (assert) that a URB's transfer completed with a given status
+ *
+ * @param urb URB whose transfer status to check
+ * @param expected_status Transfer status to expect
+ */
+#define TEST_HCD_EXPECT_TRANSFER_STATUS(urb, expected_status) test_hcd_expect_transfer_status_impl((urb), (expected_status), __FILE__, __LINE__)
+
+/**
+ * @brief Get the current number of queued port events (dequeued using TEST_HCD_EXPECT_PORT_EVENT())
  *
  * @param port_hdl Port handle
  * @return int Number of port events currently queued
@@ -66,7 +163,7 @@ void test_hcd_expect_no_pipe_event(hcd_pipe_handle_t pipe_hdl);
 int test_hcd_get_num_port_events(hcd_port_handle_t port_hdl);
 
 /**
- * @brief Get the current number of queued pipe events (dequeued using test_hcd_expect_pipe_event())
+ * @brief Get the current number of queued pipe events (dequeued using TEST_HCD_EXPECT_PIPE_EVENT())
  *
  * @param pipe_hdl Pipe handle
  * @return int Number of pipe events currently queued

--- a/host/usb/test/target_test/common/mock_msc.c
+++ b/host/usb/test/target_test/common/mock_msc.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "usb/usb_types_ch9.h"
+#include "esp_log.h"
 #include "mock_msc.h"
 
 // ---------------------------------------------------- MSC SCSI -------------------------------------------------------
@@ -46,19 +47,19 @@ bool mock_msc_scsi_check_csw(mock_msc_bulk_csw_t *csw, uint32_t tag_expect)
     bool no_issues = true;
     if (csw->dCSWSignature != 0x53425355) {
         no_issues = false;
-        printf("Warning: csw signature corrupt (0x%"PRIX32")\n", csw->dCSWSignature);
+        ESP_LOGW(MSC_CLIENT_TAG, "csw signature corrupt (0x%"PRIX32")", csw->dCSWSignature);
     }
     if (csw->dCSWTag != tag_expect) {
         no_issues = false;
-        printf("Warning: csw tag unexpected! Expected %"PRIu32" got %"PRIu32"\n", tag_expect, csw->dCSWTag);
+        ESP_LOGW(MSC_CLIENT_TAG, "csw tag unexpected! Expected %"PRIu32" got %"PRIu32, tag_expect, csw->dCSWTag);
     }
     if (csw->dCSWDataResidue) {
         no_issues = false;
-        printf("Warning: csw indicates data residue of %"PRIu32" bytes!\n", csw->dCSWDataResidue);
+        ESP_LOGW(MSC_CLIENT_TAG, "csw indicates data residue of %"PRIu32" bytes!", csw->dCSWDataResidue);
     }
     if (csw->bCSWStatus) {
         no_issues = false;
-        printf("Warning: csw indicates non-good status %d!\n", csw->bCSWStatus);
+        ESP_LOGW(MSC_CLIENT_TAG, "csw indicates non-good status %d!", csw->bCSWStatus);
     }
     return no_issues;
 }

--- a/host/usb/test/target_test/ext_port/main/ext_port_common.c
+++ b/host/usb/test/target_test/ext_port/main/ext_port_common.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -23,6 +23,9 @@
 #define EXT_PORT_EVENT_TIMEOUT_MS           100
 
 #define USB_B_REQUEST_ANY                   0xFF
+
+// Buffer for building Unity failure messages that include the caller's file and line
+static char err_msg_buf[128];
 
 const char *const hub_request_string[] = {
     "Get Port Status",
@@ -101,7 +104,8 @@ static void test_ext_port_event_callback(ext_port_hdl_t port_hdl, ext_port_event
         .port_hdl = port_hdl,
         .event = event,
     };
-    xQueueSend(ext_port_event_queue, &msg, portMAX_DELAY);
+    BaseType_t ret = xQueueSend(ext_port_event_queue, &msg, pdMS_TO_TICKS(10000));
+    TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, ret, "External Hub port event queue full, event lost");
 }
 
 static esp_err_t test_ext_port_hub_request(ext_port_hdl_t port_hdl, ext_port_parent_request_data_t *data, void *user_arg)
@@ -117,7 +121,8 @@ static esp_err_t test_ext_port_hub_request(ext_port_hdl_t port_hdl, ext_port_par
             },
         },
     };
-    xQueueSend(hub_req_queue, &msg, portMAX_DELAY);
+    BaseType_t ret = xQueueSend(hub_req_queue, &msg, pdMS_TO_TICKS(10000));
+    TEST_ASSERT_EQUAL_MESSAGE(pdTRUE, ret, "External Hub request queue full, request lost");
     return ESP_OK;
 }
 
@@ -126,7 +131,8 @@ static void test_wait_ext_port_process_request(void)
     TEST_ASSERT_EQUAL(pdTRUE, xSemaphoreTake(_process_cd_req, pdMS_TO_TICKS(EXT_PORT_PROC_CB_TIMEOUT_MS)));
 }
 
-static void test_wait_ext_port_event(ext_port_hdl_t port_hdl, ext_port_event_t event)
+#define test_wait_ext_port_event(port_hdl, event) test_wait_ext_port_event_impl((port_hdl), (event), __FILE__, __LINE__)
+static void test_wait_ext_port_event_impl(ext_port_hdl_t port_hdl, ext_port_event_t event, const char *file, int line)
 {
     uint8_t port_num;
     // Get the port event queue from the port's context variable
@@ -135,12 +141,18 @@ static void test_wait_ext_port_event(ext_port_hdl_t port_hdl, ext_port_event_t e
     // Wait for port callback to send an event message
     ext_port_event_msg_t msg;
     BaseType_t ret = xQueueReceive(ext_port_evt_queue, &msg, pdMS_TO_TICKS(EXT_PORT_EVENT_TIMEOUT_MS));
-    TEST_ASSERT_EQUAL_MESSAGE(pdPASS, ret, "External Hub port event not generated on time");
+    if (ret != pdPASS) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "External Hub port event %s not generated on time at %s:%d", ext_port_event_string[event], file, line);
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
     TEST_ASSERT_EQUAL_MESSAGE(ESP_OK, ext_port_get_port_num(port_hdl, &port_num), "Port number not equal");
     // Check the contents of that event message
     printf("\tHub port %d event: %s\n", port_num, ext_port_event_string[msg.event]);
     TEST_ASSERT_EQUAL_MESSAGE(port_hdl, msg.port_hdl, "Unexpected External Hub port handle");
-    TEST_ASSERT_EQUAL_MESSAGE(event, msg.event, "Unexpected External Hub port event");
+    if (event != msg.event) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf), "Unexpected External Hub port event at %s:%d\n %s expected, %s delivered", file, line, ext_port_event_string[event], ext_port_event_string[msg.event]);
+        TEST_FAIL_MESSAGE(err_msg_buf);
+    }
 }
 
 static esp_err_t test_wait_ext_port_hub_request(ext_port_hdl_t port_hdl, ext_port_parent_request_type_t type, usb_hub_class_request_t request)

--- a/host/usb/test/target_test/ext_port/main/hub_common.c
+++ b/host/usb/test/target_test/ext_port/main/hub_common.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -41,7 +41,7 @@ static void hub_class_request_get_port_status(uint8_t port1, usb_port_status_t *
     USB_SETUP_PACKET_INIT_GET_PORT_STATUS(setup_pkt, port1);
     hub.urb->transfer.num_bytes = sizeof(usb_setup_packet_t) + sizeof(usb_port_status_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(hub.ctrl_pipe_hdl, hub.urb));
-    test_hcd_expect_pipe_event(hub.ctrl_pipe_hdl, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(hub.ctrl_pipe_hdl, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(hub.urb, hcd_urb_dequeue(hub.ctrl_pipe_hdl));
     TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, hub.urb->transfer.status, "Get Port Status: Transfer NOT completed");
     if (status) {
@@ -61,7 +61,7 @@ static void hub_class_request_set_port_feature(uint8_t port1, usb_hub_port_featu
     USB_SETUP_PACKET_INIT_SET_PORT_FEATURE(setup_pkt, port1, feature);
     hub.urb->transfer.num_bytes = sizeof(usb_setup_packet_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(hub.ctrl_pipe_hdl, hub.urb));
-    test_hcd_expect_pipe_event(hub.ctrl_pipe_hdl, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(hub.ctrl_pipe_hdl, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(hub.urb, hcd_urb_dequeue(hub.ctrl_pipe_hdl));
     TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, hub.urb->transfer.status, "Set Port Feature: Transfer NOT completed");
 }
@@ -78,7 +78,7 @@ static void hub_class_request_clear_port_feature(uint8_t port1, usb_hub_port_fea
     USB_SETUP_PACKET_INIT_CLEAR_PORT_FEATURE(setup_pkt, port1, feature);
     hub.urb->transfer.num_bytes = sizeof(usb_setup_packet_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(hub.ctrl_pipe_hdl, hub.urb));
-    test_hcd_expect_pipe_event(hub.ctrl_pipe_hdl, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(hub.ctrl_pipe_hdl, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(hub.urb, hcd_urb_dequeue(hub.ctrl_pipe_hdl));
     TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, hub.urb->transfer.status, "Clear Port Feature: Transfer NOT completed");
 }
@@ -94,7 +94,7 @@ static void hub_get_descriptor(void)
     USB_SETUP_PACKET_INIT_GET_HUB_DESCRIPTOR(setup_pkt);
     hub.urb->transfer.num_bytes = sizeof(usb_setup_packet_t) + sizeof(usb_hub_descriptor_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(hub.ctrl_pipe_hdl, hub.urb));
-    test_hcd_expect_pipe_event(hub.ctrl_pipe_hdl, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(hub.ctrl_pipe_hdl, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(hub.urb, hcd_urb_dequeue(hub.ctrl_pipe_hdl));
     TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, hub.urb->transfer.status, "Get Hub Descriptor: Transfer NOT completed");
 
@@ -156,7 +156,7 @@ void hub_child_quick_enum(hcd_pipe_handle_t ctrl_pipe, uint8_t dev_addr, uint8_t
     USB_SETUP_PACKET_INIT_GET_DEVICE_DESC(setup_pkt);
     hub.urb->transfer.num_bytes = sizeof(usb_setup_packet_t) + sizeof(usb_device_desc_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(ctrl_pipe, hub.urb));
-    test_hcd_expect_pipe_event(ctrl_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(ctrl_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(hub.urb, hcd_urb_dequeue(ctrl_pipe));
     TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, hub.urb->transfer.status, "Transfer NOT completed");
 
@@ -173,7 +173,7 @@ void hub_child_quick_enum(hcd_pipe_handle_t ctrl_pipe, uint8_t dev_addr, uint8_t
     USB_SETUP_PACKET_INIT_SET_ADDR(setup_pkt, dev_addr);
     hub.urb->transfer.num_bytes = sizeof(usb_setup_packet_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(ctrl_pipe, hub.urb));
-    test_hcd_expect_pipe_event(ctrl_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(ctrl_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(hub.urb, hcd_urb_dequeue(ctrl_pipe));
     TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, hub.urb->transfer.status, "Transfer NOT completed");
 
@@ -184,7 +184,7 @@ void hub_child_quick_enum(hcd_pipe_handle_t ctrl_pipe, uint8_t dev_addr, uint8_t
     USB_SETUP_PACKET_INIT_SET_CONFIG(setup_pkt, config_num);
     hub.urb->transfer.num_bytes = sizeof(usb_setup_packet_t);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(ctrl_pipe, hub.urb));
-    test_hcd_expect_pipe_event(ctrl_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(ctrl_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL(hub.urb, hcd_urb_dequeue(ctrl_pipe));
     TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, hub.urb->transfer.status, "Transfer NOT completed");
 }

--- a/host/usb/test/target_test/hcd/main/test_hcd_bulk.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_bulk.c
@@ -9,9 +9,12 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "unity.h"
+#include "esp_log.h"
 #include "mock_msc.h"
 #include "dev_msc.h"
 #include "hcd_common.h"
+
+static const char *TAG = "BULK";
 
 // --------------------------------------------------- Test Cases ------------------------------------------------------
 
@@ -103,11 +106,8 @@ TEST_CASE("Test HCD bulk pipe URBs", "[bulk][full_speed][high_speed]")
         TEST_ASSERT_EQUAL(sizeof(mock_msc_bulk_csw_t), urb_csw->transfer.actual_num_bytes);
         TEST_ASSERT_TRUE(mock_msc_scsi_check_csw((mock_msc_bulk_csw_t *)urb_csw->transfer.data_buffer, 0xAAAAAAAA));
         // Print the read data
-        printf("Block %d to %d:\n", block_num, block_num + TEST_NUM_SECTORS_PER_XFER);
-        for (int i = 0; i < urb_data->transfer.actual_num_bytes; i++) {
-            printf("0x%02x,", ((char *)urb_data->transfer.data_buffer)[i]);
-        }
-        printf("\n\n");
+        ESP_LOGI(TAG, "Block %d to %d:", block_num, block_num + TEST_NUM_SECTORS_PER_XFER);
+        ESP_LOG_BUFFER_HEXDUMP(TAG, urb_data->transfer.data_buffer, urb_data->transfer.actual_num_bytes, ESP_LOG_INFO);
     }
 
     test_hcd_free_urb(urb_cbw);
@@ -177,7 +177,7 @@ TEST_CASE("Test HCD bulk pipe URBs deferred", "[bulk][full_speed][high_speed]")
         test_hcd_root_port_suspend_multi_pipe(port_hdl, pipe_list, sizeof(pipe_list) / sizeof(hcd_pipe_handle_t));
 
         // Defer all urbs
-        printf("Deferring URBs\n");
+        ESP_LOGI(TAG, "Deferring URBs");
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(bulk_out_pipe, urb_cbw));
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(bulk_in_pipe, urb_data));
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(bulk_in_pipe, urb_csw));
@@ -199,11 +199,8 @@ TEST_CASE("Test HCD bulk pipe URBs deferred", "[bulk][full_speed][high_speed]")
         TEST_ASSERT_EQUAL(sizeof(mock_msc_bulk_csw_t), urb_csw->transfer.actual_num_bytes);
         TEST_ASSERT_TRUE(mock_msc_scsi_check_csw((mock_msc_bulk_csw_t *)urb_csw->transfer.data_buffer, 0xAAAAAAAA));
         // Print the read data
-        printf("Block %d to %d:\n", block_num, block_num + TEST_NUM_SECTORS_PER_XFER);
-        for (int i = 0; i < urb_data->transfer.actual_num_bytes; i++) {
-            printf("0x%02x,", ((char *)urb_data->transfer.data_buffer)[i]);
-        }
-        printf("\n\n");
+        ESP_LOGI(TAG, "Block %d to %d:", block_num, block_num + TEST_NUM_SECTORS_PER_XFER);
+        ESP_LOG_BUFFER_HEXDUMP(TAG, urb_data->transfer.data_buffer, urb_data->transfer.actual_num_bytes, ESP_LOG_INFO);
     }
 
     test_hcd_free_urb(urb_cbw);

--- a/host/usb/test/target_test/hcd/main/test_hcd_bulk.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_bulk.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,9 +24,9 @@ static void mock_msc_reset_req(hcd_pipe_handle_t default_pipe, uint8_t bInterfac
     urb->transfer.num_bytes = sizeof(usb_setup_packet_t);
     // Enqueue, wait, dequeue, and check URB
     TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_ASSERT_EQUAL_PTR(urb, hcd_urb_dequeue(default_pipe));
-    TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+    TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
     // Free URB
     test_hcd_free_urb(urb);
 }
@@ -87,19 +87,19 @@ TEST_CASE("Test HCD bulk pipe URBs", "[bulk][full_speed][high_speed]")
                                dev_info->scsi_sector_size,
                                0xAAAAAAAA);
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(bulk_out_pipe, urb_cbw));
-        test_hcd_expect_pipe_event(bulk_out_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(bulk_out_pipe, HCD_PIPE_EVENT_URB_DONE);
         TEST_ASSERT_EQUAL_PTR(urb_cbw, hcd_urb_dequeue(bulk_out_pipe));
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb_cbw->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb_cbw, USB_TRANSFER_STATUS_COMPLETED);
         // Read data through BULK IN pipe
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(bulk_in_pipe, urb_data));
-        test_hcd_expect_pipe_event(bulk_in_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(bulk_in_pipe, HCD_PIPE_EVENT_URB_DONE);
         TEST_ASSERT_EQUAL_PTR(urb_data, hcd_urb_dequeue(bulk_in_pipe));
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb_data->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb_data, USB_TRANSFER_STATUS_COMPLETED);
         // Read the CSW through BULK IN pipe
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(bulk_in_pipe, urb_csw));
-        test_hcd_expect_pipe_event(bulk_in_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(bulk_in_pipe, HCD_PIPE_EVENT_URB_DONE);
         TEST_ASSERT_EQUAL_PTR(urb_csw, hcd_urb_dequeue(bulk_in_pipe));
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb_data->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb_data, USB_TRANSFER_STATUS_COMPLETED);
         TEST_ASSERT_EQUAL(sizeof(mock_msc_bulk_csw_t), urb_csw->transfer.actual_num_bytes);
         TEST_ASSERT_TRUE(mock_msc_scsi_check_csw((mock_msc_bulk_csw_t *)urb_csw->transfer.data_buffer, 0xAAAAAAAA));
         // Print the read data
@@ -185,17 +185,17 @@ TEST_CASE("Test HCD bulk pipe URBs deferred", "[bulk][full_speed][high_speed]")
         // Resume the root port with multiple pipes
         test_hcd_root_port_resume_multi_pipe(port_hdl, pipe_list, sizeof(pipe_list) / sizeof(hcd_pipe_handle_t));
 
-        test_hcd_expect_pipe_event(bulk_out_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(bulk_out_pipe, HCD_PIPE_EVENT_URB_DONE);
         TEST_ASSERT_EQUAL_PTR(urb_cbw, hcd_urb_dequeue(bulk_out_pipe));
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb_cbw->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb_cbw, USB_TRANSFER_STATUS_COMPLETED);
         // Read data through BULK IN pipe
-        test_hcd_expect_pipe_event(bulk_in_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(bulk_in_pipe, HCD_PIPE_EVENT_URB_DONE);
         TEST_ASSERT_EQUAL_PTR(urb_data, hcd_urb_dequeue(bulk_in_pipe));
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb_data->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb_data, USB_TRANSFER_STATUS_COMPLETED);
         // Read the CSW through BULK IN pipe
-        test_hcd_expect_pipe_event(bulk_in_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(bulk_in_pipe, HCD_PIPE_EVENT_URB_DONE);
         TEST_ASSERT_EQUAL_PTR(urb_csw, hcd_urb_dequeue(bulk_in_pipe));
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb_data->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb_data, USB_TRANSFER_STATUS_COMPLETED);
         TEST_ASSERT_EQUAL(sizeof(mock_msc_bulk_csw_t), urb_csw->transfer.actual_num_bytes);
         TEST_ASSERT_TRUE(mock_msc_scsi_check_csw((mock_msc_bulk_csw_t *)urb_csw->transfer.data_buffer, 0xAAAAAAAA));
         // Print the read data

--- a/host/usb/test/target_test/hcd/main/test_hcd_ctrl.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_ctrl.c
@@ -8,7 +8,10 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "unity.h"
+#include "esp_log.h"
 #include "hcd_common.h"
+
+static const char *TAG = "CTRL";
 
 #define TEST_DEV_ADDR               0
 #define NUM_URBS                    3
@@ -60,7 +63,7 @@ TEST_CASE("Test HCD control pipe URBs", "[ctrl][low_speed][full_speed][high_spee
     test_hcd_urb_list_init(urb_list);
 
     // Enqueue URBs but immediately suspend the port
-    printf("Enqueuing URBs\n");
+    ESP_LOGI(TAG, "Enqueuing URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
@@ -79,7 +82,7 @@ TEST_CASE("Test HCD control pipe URBs", "[ctrl][low_speed][full_speed][high_spee
         TEST_ASSERT_LESS_OR_EQUAL(urb->transfer.num_bytes, urb->transfer.actual_num_bytes);
         usb_config_desc_t *config_desc = (usb_config_desc_t *)(urb->transfer.data_buffer + sizeof(usb_setup_packet_t));
         TEST_ASSERT_EQUAL(USB_B_DESCRIPTOR_TYPE_CONFIGURATION, config_desc->bDescriptorType);
-        printf("Config Desc wTotalLength %d\n", config_desc->wTotalLength);
+        ESP_LOGI(TAG, "Config Desc wTotalLength %d", config_desc->wTotalLength);
     }
 
     // Enqueue URBs again but abort them short after
@@ -161,7 +164,7 @@ TEST_CASE("Test HCD control pipe STALL", "[ctrl][full_speed][high_speed]")
         num_enqueued++;
     }
     TEST_ASSERT_GREATER_THAN(0, num_enqueued);
-    printf("Expecting STALL\n");
+    ESP_LOGI(TAG, "Expecting STALL");
     TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_ERROR_STALL);
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
@@ -170,7 +173,7 @@ TEST_CASE("Test HCD control pipe STALL", "[ctrl][full_speed][high_speed]")
     if (num_enqueued > 1) {
         // We expect URB Done after pipe flush, only when more than one URB is enqueued,
         // as the stalled (first) URB has been already dealt with by the HCD driver as done
-        printf("Expecting URB DONE\n");
+        ESP_LOGI(TAG, "Expecting URB DONE");
         TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     }
     for (int i = 0; i < num_enqueued; i++) {
@@ -192,7 +195,7 @@ TEST_CASE("Test HCD control pipe STALL", "[ctrl][full_speed][high_speed]")
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
 
-    printf("Retrying\n");
+    ESP_LOGI(TAG, "Retrying");
     // Correct first URB then requeue
     USB_SETUP_PACKET_INIT_GET_CONFIG_DESC((usb_setup_packet_t *)urb_list[0]->transfer.data_buffer, 0, TRANSFER_MAX_BYTES);
     for (int i = 0; i < NUM_URBS; i++) {
@@ -211,7 +214,7 @@ TEST_CASE("Test HCD control pipe STALL", "[ctrl][full_speed][high_speed]")
         TEST_ASSERT_LESS_OR_EQUAL(urb->transfer.num_bytes, urb->transfer.actual_num_bytes);
         usb_config_desc_t *config_desc = (usb_config_desc_t *)(urb->transfer.data_buffer + sizeof(usb_setup_packet_t));
         TEST_ASSERT_EQUAL(USB_B_DESCRIPTOR_TYPE_CONFIGURATION, config_desc->bDescriptorType);
-        printf("Config Desc wTotalLength %d\n", config_desc->wTotalLength);
+        ESP_LOGI(TAG, "Config Desc wTotalLength %d", config_desc->wTotalLength);
     }
 
     // Free URB list and pipe
@@ -254,19 +257,19 @@ TEST_CASE("Test HCD control pipe runtime halt and clear", "[ctrl][low_speed][ful
     test_hcd_urb_list_init(urb_list);
 
     // Enqueue URBs but immediately halt the pipe
-    printf("Enqueuing URBs\n");
+    ESP_LOGI(TAG, "Enqueuing URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
     TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
-    printf("Pipe halted\n");
+    ESP_LOGI(TAG, "Pipe halted");
 
     // Un-halt the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
-    printf("Pipe cleared\n");
+    ESP_LOGI(TAG, "Pipe cleared");
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time pending for transfers to restart and complete
 
     // Wait for each URB to be done, dequeue, and check results
@@ -280,7 +283,7 @@ TEST_CASE("Test HCD control pipe runtime halt and clear", "[ctrl][low_speed][ful
             TEST_ASSERT_LESS_OR_EQUAL(urb->transfer.num_bytes, urb->transfer.actual_num_bytes);
             usb_config_desc_t *config_desc = (usb_config_desc_t *)(urb->transfer.data_buffer + sizeof(usb_setup_packet_t));
             TEST_ASSERT_EQUAL(USB_B_DESCRIPTOR_TYPE_CONFIGURATION, config_desc->bDescriptorType);
-            printf("Config Desc wTotalLength %d\n", config_desc->wTotalLength);
+            ESP_LOGI(TAG, "Config Desc wTotalLength %d", config_desc->wTotalLength);
         } else {
             // A failed transfer should 0 actual number of bytes transmitted
             TEST_ASSERT_EQUAL(0, urb->transfer.actual_num_bytes);
@@ -346,7 +349,7 @@ TEST_CASE("Test HCD control pipe URBs deferred", "[ctrl][low_speed][full_speed][
     test_hcd_root_port_suspend(port_hdl, default_pipe);
 
     // Defer URBs, while the root port is suspended
-    printf("Deferring URBs\n");
+    ESP_LOGI(TAG, "Deferring URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
@@ -380,7 +383,7 @@ TEST_CASE("Test HCD control pipe URBs deferred", "[ctrl][low_speed][full_speed][
     test_hcd_root_port_suspend(port_hdl, default_pipe);
 
     // Defer URBs again, while the root port is suspended
-    printf("Deferring URBs\n");
+    ESP_LOGI(TAG, "Deferring URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
@@ -394,7 +397,7 @@ TEST_CASE("Test HCD control pipe URBs deferred", "[ctrl][low_speed][full_speed][
     test_hcd_root_port_resume(port_hdl, default_pipe);
 
     // Expect no pipe event
-    printf("Expecting NO Pipe event\n");
+    ESP_LOGI(TAG, "Expecting NO Pipe event");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_HCD_EXPECT_NO_PIPE_EVENT(default_pipe);
     }
@@ -413,7 +416,7 @@ TEST_CASE("Test HCD control pipe URBs deferred", "[ctrl][low_speed][full_speed][
     test_hcd_root_port_suspend(port_hdl, default_pipe);
 
     // Defer URBs again, while the root port is suspended
-    printf("Deferring URBs\n");
+    ESP_LOGI(TAG, "Deferring URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
@@ -492,14 +495,14 @@ TEST_CASE("Test HCD control pipe STALL, URBs deferred", "[ctrl][low_speed][full_
     test_hcd_root_port_suspend(port_hdl, default_pipe);
 
     // Defer URBs, while the root port is suspended
-    printf("Deferring URBs\n");
+    ESP_LOGI(TAG, "Deferring URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
 
     // Resume the root port
     test_hcd_root_port_resume(port_hdl, default_pipe);
-    printf("Expecting STALL\n");
+    ESP_LOGI(TAG, "Expecting STALL");
     TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_ERROR_STALL);
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
@@ -525,7 +528,7 @@ TEST_CASE("Test HCD control pipe STALL, URBs deferred", "[ctrl][low_speed][full_
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
 
-    printf("Retrying\n");
+    ESP_LOGI(TAG, "Retrying");
     // Correct first URB then requeue
     USB_SETUP_PACKET_INIT_GET_CONFIG_DESC((usb_setup_packet_t *)urb_list[0]->transfer.data_buffer, 0, TRANSFER_MAX_BYTES);
     for (int i = 0; i < NUM_URBS; i++) {
@@ -548,7 +551,7 @@ TEST_CASE("Test HCD control pipe STALL, URBs deferred", "[ctrl][low_speed][full_
         TEST_ASSERT_LESS_OR_EQUAL(urb->transfer.num_bytes, urb->transfer.actual_num_bytes);
         usb_config_desc_t *config_desc = (usb_config_desc_t *)(urb->transfer.data_buffer + sizeof(usb_setup_packet_t));
         TEST_ASSERT_EQUAL(USB_B_DESCRIPTOR_TYPE_CONFIGURATION, config_desc->bDescriptorType);
-        printf("Config Desc wTotalLength %d\n", config_desc->wTotalLength);
+        ESP_LOGI(TAG, "Config Desc wTotalLength %d", config_desc->wTotalLength);
     }
 
     // Free URB list and pipe
@@ -594,7 +597,7 @@ TEST_CASE("Test HCD control pipe runtime halt and clear, URBs deferred", "[ctrl]
     test_hcd_root_port_suspend(port_hdl, default_pipe);
 
     // Enqueue URBs but immediately halt the pipe
-    printf("Deferring URBs\n");
+    ESP_LOGI(TAG, "Deferring URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
@@ -606,12 +609,12 @@ TEST_CASE("Test HCD control pipe runtime halt and clear, URBs deferred", "[ctrl]
     // Wait for the first URB to be done, caused by the pipe halt
     TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
-    printf("Pipe halted\n");
+    ESP_LOGI(TAG, "Pipe halted");
 
     // Un-halt the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
-    printf("Pipe cleared\n");
+    ESP_LOGI(TAG, "Pipe cleared");
 
     // Wait for the rest of the URBs to be done, after clearing the pipe
     for (int i = 0; i < NUM_URBS - 1; i++) {
@@ -629,7 +632,7 @@ TEST_CASE("Test HCD control pipe runtime halt and clear, URBs deferred", "[ctrl]
             TEST_ASSERT_LESS_OR_EQUAL(urb->transfer.num_bytes, urb->transfer.actual_num_bytes);
             usb_config_desc_t *config_desc = (usb_config_desc_t *)(urb->transfer.data_buffer + sizeof(usb_setup_packet_t));
             TEST_ASSERT_EQUAL(USB_B_DESCRIPTOR_TYPE_CONFIGURATION, config_desc->bDescriptorType);
-            printf("Config Desc wTotalLength %d\n", config_desc->wTotalLength);
+            ESP_LOGI(TAG, "Config Desc wTotalLength %d", config_desc->wTotalLength);
         } else {
             // A failed transfer should 0 actual number of bytes transmitted
             TEST_ASSERT_EQUAL(0, urb->transfer.actual_num_bytes);

--- a/host/usb/test/target_test/hcd/main/test_hcd_ctrl.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_ctrl.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -66,13 +66,13 @@ TEST_CASE("Test HCD control pipe URBs", "[ctrl][low_speed][full_speed][high_spee
     }
     // Wait for each done event of each URB
     for (int i = 0; i < NUM_URBS; i++) {
-        test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     }
     // Dequeue URBs, check, and print
     for (int i = 0; i < NUM_URBS; i++) {
         urb_t *urb = hcd_urb_dequeue(default_pipe);
         TEST_ASSERT_EQUAL(urb_list[i], urb);
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
         TEST_ASSERT_EQUAL(URB_CONTEXT_VAL, urb->transfer.context);
         // We must have transmitted at least the setup packet, but device may return less than bytes requested
         TEST_ASSERT_GREATER_OR_EQUAL(sizeof(usb_setup_packet_t), urb->transfer.actual_num_bytes);
@@ -162,8 +162,8 @@ TEST_CASE("Test HCD control pipe STALL", "[ctrl][full_speed][high_speed]")
     }
     TEST_ASSERT_GREATER_THAN(0, num_enqueued);
     printf("Expecting STALL\n");
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_ERROR_STALL);
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_ERROR_STALL);
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
     // Call the pipe abort command to retire all URBs then dequeue them all
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_FLUSH));
@@ -171,7 +171,7 @@ TEST_CASE("Test HCD control pipe STALL", "[ctrl][full_speed][high_speed]")
         // We expect URB Done after pipe flush, only when more than one URB is enqueued,
         // as the stalled (first) URB has been already dealt with by the HCD driver as done
         printf("Expecting URB DONE\n");
-        test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     }
     for (int i = 0; i < num_enqueued; i++) {
         urb_t *urb = hcd_urb_dequeue(default_pipe);
@@ -190,7 +190,7 @@ TEST_CASE("Test HCD control pipe STALL", "[ctrl][full_speed][high_speed]")
 
     // Call the clear command to un-stall the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
 
     printf("Retrying\n");
     // Correct first URB then requeue
@@ -201,10 +201,10 @@ TEST_CASE("Test HCD control pipe STALL", "[ctrl][full_speed][high_speed]")
 
     // Wait for each URB to be done, dequeue, and check results
     for (int i = 0; i < NUM_URBS; i++) {
-        test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
         urb_t *urb = hcd_urb_dequeue(default_pipe);
         TEST_ASSERT_EQUAL(urb_list[i], urb);
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
         TEST_ASSERT_EQUAL(URB_CONTEXT_VAL, urb->transfer.context);
         // We must have transmitted at least the setup packet, but device may return less than bytes requested
         TEST_ASSERT_GREATER_OR_EQUAL(sizeof(usb_setup_packet_t), urb->transfer.actual_num_bytes);
@@ -259,13 +259,13 @@ TEST_CASE("Test HCD control pipe runtime halt and clear", "[ctrl][low_speed][ful
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
     printf("Pipe halted\n");
 
     // Un-halt the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     printf("Pipe cleared\n");
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time pending for transfers to restart and complete
 
@@ -357,14 +357,14 @@ TEST_CASE("Test HCD control pipe URBs deferred", "[ctrl][low_speed][full_speed][
 
     // Expect URB done from each URB
     for (int i = 0; i < NUM_URBS; i++) {
-        test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     }
 
     // Wait for each URB to be done, dequeue, and check results
     for (int i = 0; i < NUM_URBS; i++) {
         urb_t *urb = hcd_urb_dequeue(default_pipe);
         TEST_ASSERT_EQUAL_MESSAGE(urb_list[i], urb, "URBs ptr not equal");
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
         TEST_ASSERT_EQUAL(URB_CONTEXT_VAL, urb->transfer.context);
         // We must have transmitted at least the setup packet, but device may return less than bytes requested
         TEST_ASSERT_GREATER_OR_EQUAL(sizeof(usb_setup_packet_t), urb->transfer.actual_num_bytes);
@@ -396,14 +396,14 @@ TEST_CASE("Test HCD control pipe URBs deferred", "[ctrl][low_speed][full_speed][
     // Expect no pipe event
     printf("Expecting NO Pipe event\n");
     for (int i = 0; i < NUM_URBS; i++) {
-        test_hcd_expect_no_pipe_event(default_pipe);
+        TEST_HCD_EXPECT_NO_PIPE_EVENT(default_pipe);
     }
 
     // Dequeue all urbs and check results, expect all URBs to be canceled
     for (int i = 0; i < NUM_URBS; i++) {
         urb_t *urb = hcd_urb_dequeue(default_pipe);
         TEST_ASSERT_EQUAL_MESSAGE(urb_list[i], urb, "URBs ptr not equal");
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_CANCELED, urb->transfer.status, "Transfer NOT canceled");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_CANCELED);
         TEST_ASSERT_EQUAL(0, urb->transfer.actual_num_bytes);
     }
 
@@ -500,8 +500,8 @@ TEST_CASE("Test HCD control pipe STALL, URBs deferred", "[ctrl][low_speed][full_
     // Resume the root port
     test_hcd_root_port_resume(port_hdl, default_pipe);
     printf("Expecting STALL\n");
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_ERROR_STALL);
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_ERROR_STALL);
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
     // Call the pipe abort command to retire all URBs then dequeue them all
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_FLUSH));
@@ -523,7 +523,7 @@ TEST_CASE("Test HCD control pipe STALL, URBs deferred", "[ctrl][low_speed][full_
 
     // Call the clear command to un-stall the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
 
     printf("Retrying\n");
     // Correct first URB then requeue
@@ -534,14 +534,14 @@ TEST_CASE("Test HCD control pipe STALL, URBs deferred", "[ctrl][low_speed][full_
 
     // Wait for each done event of each URB
     for (int i = 0; i < NUM_URBS; i++) {
-        test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     }
 
     // Wait for each URB to be done, dequeue, and check results
     for (int i = 0; i < NUM_URBS; i++) {
         urb_t *urb = hcd_urb_dequeue(default_pipe);
         TEST_ASSERT_EQUAL_MESSAGE(urb_list[i], urb, "URBs ptr not equal");
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
         TEST_ASSERT_EQUAL(URB_CONTEXT_VAL, urb->transfer.context);
         // We must have transmitted at least the setup packet, but device may return less than bytes requested
         TEST_ASSERT_GREATER_OR_EQUAL(sizeof(usb_setup_packet_t), urb->transfer.actual_num_bytes);
@@ -604,18 +604,18 @@ TEST_CASE("Test HCD control pipe runtime halt and clear, URBs deferred", "[ctrl]
 
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
     // Wait for the first URB to be done, caused by the pipe halt
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
     printf("Pipe halted\n");
 
     // Un-halt the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     printf("Pipe cleared\n");
 
     // Wait for the rest of the URBs to be done, after clearing the pipe
     for (int i = 0; i < NUM_URBS - 1; i++) {
-        test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     }
 
     // Dequeue all URBs, and check results

--- a/host/usb/test/target_test/hcd/main/test_hcd_intr.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_intr.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,8 +8,11 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "unity.h"
+#include "esp_log.h"
 #include "dev_hid.h"
 #include "hcd_common.h"
+
+static const char *TAG = "INTR";
 
 // --------------------------------------------------- Test Cases ------------------------------------------------------
 
@@ -70,7 +73,7 @@ TEST_CASE("Test HCD interrupt pipe URBs", "[intr][low_speed]")
         TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
         TEST_ASSERT_EQUAL(URB_CONTEXT_VAL, urb->transfer.context);
         // Byte 1 and 2 contains x and y movement respectively
-        printf("X mov %d, Y mov %d\n", urb->transfer.data_buffer[1], urb->transfer.data_buffer[2]);
+        ESP_LOGI(TAG, "X mov %d, Y mov %d", urb->transfer.data_buffer[1], urb->transfer.data_buffer[2]);
         // Requeue URB
         if (iter_count > NUM_URBS) {
             TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(intr_pipe, urb));

--- a/host/usb/test/target_test/hcd/main/test_hcd_intr.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_intr.c
@@ -64,10 +64,10 @@ TEST_CASE("Test HCD interrupt pipe URBs", "[intr][low_speed]")
     int iter_count = NUM_URB_ITERS;
     for (iter_count = NUM_URB_ITERS; iter_count > 0; iter_count--) {
         // Wait for an URB to be done
-        test_hcd_expect_pipe_event(intr_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(intr_pipe, HCD_PIPE_EVENT_URB_DONE);
         // Dequeue the URB and check results
         urb_t *urb = hcd_urb_dequeue(intr_pipe);
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
         TEST_ASSERT_EQUAL(URB_CONTEXT_VAL, urb->transfer.context);
         // Byte 1 and 2 contains x and y movement respectively
         printf("X mov %d, Y mov %d\n", urb->transfer.data_buffer[1], urb->transfer.data_buffer[2]);

--- a/host/usb/test/target_test/hcd/main/test_hcd_isoc.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_isoc.c
@@ -72,7 +72,7 @@ TEST_CASE("Test HCD isochronous pipe URBs", "[isoc][full_speed][high_speed]")
     }
     // Wait for each done event from each URB
     for (int i = 0; i < NUM_URBS; i++) {
-        test_hcd_expect_pipe_event(isoc_out_pipe, HCD_PIPE_EVENT_URB_DONE);
+        TEST_HCD_EXPECT_PIPE_EVENT(isoc_out_pipe, HCD_PIPE_EVENT_URB_DONE);
     }
     // Dequeue URBs
     for (int urb_idx = 0; urb_idx < NUM_URBS; urb_idx++) {
@@ -81,7 +81,7 @@ TEST_CASE("Test HCD isochronous pipe URBs", "[isoc][full_speed][high_speed]")
         TEST_ASSERT_EQUAL(URB_CONTEXT_VAL, urb->transfer.context);
         // Overall URB status and overall number of bytes
         TEST_ASSERT_EQUAL(NUM_PACKETS_PER_URB * isoc_packet_size, urb->transfer.actual_num_bytes);
-        TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+        TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
         for (int pkt_idx = 0; pkt_idx < NUM_PACKETS_PER_URB; pkt_idx++) {
             TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.isoc_packet_desc[pkt_idx].status, "Transfer NOT completed");
         }
@@ -169,7 +169,7 @@ TEST_CASE("Test HCD isochronous pipe URBs all", "[isoc][full_speed][high_speed]"
             }
             // Wait for each done event from each URB
             for (int i = 0; i < NUM_URBS; i++) {
-                test_hcd_expect_pipe_event(isoc_out_pipe, HCD_PIPE_EVENT_URB_DONE);
+                TEST_HCD_EXPECT_PIPE_EVENT(isoc_out_pipe, HCD_PIPE_EVENT_URB_DONE);
             }
             // Dequeue URBs
             for (int urb_idx = 0; urb_idx < NUM_URBS; urb_idx++) {
@@ -178,7 +178,7 @@ TEST_CASE("Test HCD isochronous pipe URBs all", "[isoc][full_speed][high_speed]"
                 TEST_ASSERT_EQUAL(URB_CONTEXT_VAL, urb->transfer.context);
                 // Overall URB status and overall number of bytes
                 TEST_ASSERT_EQUAL(num_packets_per_urb * isoc_packet_size, urb->transfer.actual_num_bytes);
-                TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.status, "Transfer NOT completed");
+                TEST_HCD_EXPECT_TRANSFER_STATUS(urb, USB_TRANSFER_STATUS_COMPLETED);
                 for (int pkt_idx = 0; pkt_idx < num_packets_per_urb; pkt_idx++) {
                     TEST_ASSERT_EQUAL_MESSAGE(USB_TRANSFER_STATUS_COMPLETED, urb->transfer.isoc_packet_desc[pkt_idx].status, "Transfer NOT completed");
                 }
@@ -260,19 +260,19 @@ TEST_CASE("Test HCD isochronous pipe sudden disconnect", "[isoc][full_speed][hig
     // Power-off the port to trigger a disconnection
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_POWER_OFF));
     // Disconnect event should have occurred. Handle the port event
-    test_hcd_expect_port_event(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
+    TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_DISCONNECTION, hcd_port_handle_event(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_RECOVERY, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_RECOVERY);
     printf("Sudden disconnect\n");
 
     // Both pipes should still be active
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(isoc_out_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
+    TEST_HCD_EXPECT_PIPE_STATE(isoc_out_pipe, HCD_PIPE_STATE_ACTIVE);
     // Halt both pipes
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(isoc_out_pipe, HCD_PIPE_CMD_HALT));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(isoc_out_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
+    TEST_HCD_EXPECT_PIPE_STATE(isoc_out_pipe, HCD_PIPE_STATE_HALTED);
     // Flush both pipes. ISOC pipe should return completed URBs
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_FLUSH));
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(isoc_out_pipe, HCD_PIPE_CMD_FLUSH));

--- a/host/usb/test/target_test/hcd/main/test_hcd_isoc.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_isoc.c
@@ -10,9 +10,12 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "unity.h"
+#include "esp_log.h"
 #include "dev_isoc.h"
 #include "usb/usb_types_ch9.h"
 #include "hcd_common.h"
+
+static const char *TAG = "ISOC";
 
 #define NUM_URBS                3
 #define NUM_PACKETS_PER_URB     3
@@ -263,7 +266,7 @@ TEST_CASE("Test HCD isochronous pipe sudden disconnect", "[isoc][full_speed][hig
     TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_DISCONNECTION, hcd_port_handle_event(port_hdl));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_RECOVERY);
-    printf("Sudden disconnect\n");
+    ESP_LOGI(TAG, "Sudden disconnect");
 
     // Both pipes should still be active
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);

--- a/host/usb/test/target_test/hcd/main/test_hcd_port.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_port.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -89,18 +89,18 @@ TEST_CASE("Test HCD port sudden disconnect", "[port][low_speed][full_speed][high
     // Power-off the port to trigger a disconnection
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_POWER_OFF));
     // Disconnect event should have occurred. Handle the port event
-    test_hcd_expect_port_event(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
+    TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_DISCONNECTION, hcd_port_handle_event(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_RECOVERY, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_RECOVERY);
     printf("Sudden disconnect\n");
 
     // We should be able to halt then flush the pipe
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
     printf("Pipe halted\n");
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_FLUSH));
-    test_hcd_expect_pipe_event(default_pipe, HCD_PIPE_EVENT_URB_DONE);
+    TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
     printf("Pipe flushed\n");
 
     // Dequeue URBs
@@ -126,7 +126,7 @@ TEST_CASE("Test HCD port sudden disconnect", "[port][low_speed][full_speed][high
 
     // Recover the port should return to the to NOT POWERED state
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_recover(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_NOT_POWERED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_NOT_POWERED);
 
     // Recovered port should be able to connect and disconnect again
     test_hcd_wait_for_conn(port_hdl);
@@ -170,24 +170,24 @@ TEST_CASE("Test HCD port suspend and resume", "[port][low_speed][full_speed][hig
     TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
 
     // Halt the default pipe before suspending
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
     // Suspend the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_SUSPENDED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
     printf("Suspended\n");
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time for bus to remain suspended
 
     // Resume the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESUME));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_ENABLED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
     printf("Resumed\n");
 
     // Clear the default pipe's halt
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time for resumed URBs to complete
 
     test_hcd_ping_device(default_pipe, urb);
@@ -233,22 +233,22 @@ TEST_CASE("Test HCD port suspend and resume sudden disconnect", "[port][low_spee
     test_hcd_ping_device(default_pipe, urb);
 
     // Halt the default pipe before suspending
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
     // Suspend the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_SUSPENDED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
     printf("Suspended\n");
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time for bus to remain suspended
 
     // Power-off the port to trigger a disconnection
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_POWER_OFF));
     // Disconnect event should have occurred. Handle the port event
-    test_hcd_expect_port_event(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
+    TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_DISCONNECTION, hcd_port_handle_event(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_RECOVERY, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_RECOVERY);
     printf("Sudden disconnect\n");
 
     // Free the pipe and its urb, to be able to recover the port
@@ -256,7 +256,7 @@ TEST_CASE("Test HCD port suspend and resume sudden disconnect", "[port][low_spee
     test_hcd_pipe_free(default_pipe);
     // Recover the port should return to the NOT POWERED state
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_recover(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_NOT_POWERED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_NOT_POWERED);
 
     // Check, that the port can NOT be suspended/resumed with no device connected
     TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
@@ -307,13 +307,13 @@ TEST_CASE("Test HCD port suspend and resume port reset", "[port][low_speed][full
     test_hcd_ping_device(default_pipe, urb);
 
     // Halt the default pipe before suspending
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
     // Suspend the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_SUSPENDED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
     printf("Suspended\n");
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time for bus to remain suspended
 
@@ -322,11 +322,11 @@ TEST_CASE("Test HCD port suspend and resume port reset", "[port][low_speed][full
     printf("Port reset\n");
 
     // Port should be in enabled state, and the default pipe still halted
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_ENABLED, hcd_port_get_state(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
     // Clear the pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
 
     test_hcd_ping_device(default_pipe, urb);
 
@@ -377,13 +377,13 @@ TEST_CASE("Test HCD port disable", "[port][low_speed][full_speed][high_speed]")
     }
 
     // Halt the default pipe before suspending
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
     // Check that port can be disabled
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_DISABLE));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_DISABLED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_DISABLED);
     printf("Disabled\n");
 
     // Flush pipe
@@ -463,9 +463,9 @@ TEST_CASE("Test HCD port command bailout", "[port][low_speed][full_speed][high_s
     TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, hcd_port_command(port_hdl, HCD_PORT_CMD_RESUME));
 
     // Check that concurrent task triggered a sudden disconnection
-    test_hcd_expect_port_event(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
+    TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_DISCONNECTION, hcd_port_handle_event(port_hdl));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_RECOVERY, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_RECOVERY);
 
     // Cleanup task and semaphore
     vTaskDelay(pdMS_TO_TICKS(10)); // Short delay for concurrent task finish running
@@ -505,30 +505,30 @@ TEST_CASE("Test HCD port remote wakeup", "[port][low_speed][full_speed][high_spe
     TEST_ASSERT_EQUAL_MESSAGE(true, test_hcd_remote_wake_check(default_pipe, get_status_urb), "Remote wake-up is disabled, but expected to be enabled");
 
     // Halt the default pipe before suspending
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
 
     // Suspend the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_SUSPENDED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
     printf("Root port suspended\n");
     printf("Do the remote wakeup on the connected USB device (Keyboard button press)\n");
 
     // Expect remote wakeup event from the device
-    test_hcd_expect_port_event(port_hdl, HCD_PORT_EVENT_REMOTE_WAKEUP);
+    TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_REMOTE_WAKEUP);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_REMOTE_WAKEUP, hcd_port_handle_event(port_hdl));
     printf("Remote wake-up detected\n");
 
     // Resume the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESUME));
-    TEST_ASSERT_EQUAL(HCD_PORT_STATE_ENABLED, hcd_port_get_state(port_hdl));
+    TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
     printf("Resumed\n");
 
     // Clear the pipe after the port has been resumed
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_HALTED, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
-    TEST_ASSERT_EQUAL(HCD_PIPE_STATE_ACTIVE, hcd_pipe_get_state(default_pipe));
+    TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
 
     // Check the current wake-up status, (issue transfer to ping the device)
     TEST_ASSERT_EQUAL_MESSAGE(true, test_hcd_remote_wake_check(default_pipe, get_status_urb), "Remote wake-up is disabled, but expected to be enabled");

--- a/host/usb/test/target_test/hcd/main/test_hcd_port.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_port.c
@@ -9,7 +9,10 @@
 #include "freertos/semphr.h"
 #include "unity.h"
 #include "esp_rom_sys.h"
+#include "esp_log.h"
 #include "hcd_common.h"
+
+static const char *TAG = "PORT";
 
 #define TEST_DEV_ADDR               0
 #define NUM_URBS                    3
@@ -33,7 +36,7 @@ Procedure:
 TEST_CASE("Test HCD port disconnect event, port enabled", "[port][low_speed][full_speed][high_speed]")
 {
     usb_speed_t port_speed = test_hcd_wait_for_conn(port_hdl); // Trigger a connection
-    printf("Connected %s speed device \n", (char *[]) {
+    ESP_LOGI(TAG, "Connected %s speed device", (char *[]) {
         "Low", "Full", "High"
     }[port_speed]);
     vTaskDelay(pdMS_TO_TICKS(100)); // Short delay send of SOF (for FS, HS) or EOPs (for LS)
@@ -80,7 +83,7 @@ TEST_CASE("Test HCD port sudden disconnect", "[port][low_speed][full_speed][high
     }
 
     // Enqueue URBs but immediately trigger a disconnect
-    printf("Enqueuing URBs\n");
+    ESP_LOGI(TAG, "Enqueuing URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
     }
@@ -92,16 +95,16 @@ TEST_CASE("Test HCD port sudden disconnect", "[port][low_speed][full_speed][high
     TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_DISCONNECTION, hcd_port_handle_event(port_hdl));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_RECOVERY);
-    printf("Sudden disconnect\n");
+    ESP_LOGI(TAG, "Sudden disconnect");
 
     // We should be able to halt then flush the pipe
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_ACTIVE);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_HALT));
-    printf("Pipe halted\n");
+    ESP_LOGI(TAG, "Pipe halted");
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_FLUSH));
     TEST_HCD_EXPECT_PIPE_EVENT(default_pipe, HCD_PIPE_EVENT_URB_DONE);
-    printf("Pipe flushed\n");
+    ESP_LOGI(TAG, "Pipe flushed");
 
     // Dequeue URBs
     for (int i = 0; i < NUM_URBS; i++) {
@@ -177,13 +180,13 @@ TEST_CASE("Test HCD port suspend and resume", "[port][low_speed][full_speed][hig
     // Suspend the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
-    printf("Suspended\n");
+    ESP_LOGI(TAG, "Suspended");
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time for bus to remain suspended
 
     // Resume the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESUME));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
-    printf("Resumed\n");
+    ESP_LOGI(TAG, "Resumed");
 
     // Clear the default pipe's halt
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_CLEAR));
@@ -240,7 +243,7 @@ TEST_CASE("Test HCD port suspend and resume sudden disconnect", "[port][low_spee
     // Suspend the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
-    printf("Suspended\n");
+    ESP_LOGI(TAG, "Suspended");
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time for bus to remain suspended
 
     // Power-off the port to trigger a disconnection
@@ -249,7 +252,7 @@ TEST_CASE("Test HCD port suspend and resume sudden disconnect", "[port][low_spee
     TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_DISCONNECTION);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_DISCONNECTION, hcd_port_handle_event(port_hdl));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_RECOVERY);
-    printf("Sudden disconnect\n");
+    ESP_LOGI(TAG, "Sudden disconnect");
 
     // Free the pipe and its urb, to be able to recover the port
     test_hcd_free_urb(urb);
@@ -314,12 +317,12 @@ TEST_CASE("Test HCD port suspend and resume port reset", "[port][low_speed][full
     // Suspend the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
-    printf("Suspended\n");
+    ESP_LOGI(TAG, "Suspended");
     vTaskDelay(pdMS_TO_TICKS(100)); // Give some time for bus to remain suspended
 
     // Reset the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESET));
-    printf("Port reset\n");
+    ESP_LOGI(TAG, "Port reset");
 
     // Port should be in enabled state, and the default pipe still halted
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
@@ -369,7 +372,7 @@ TEST_CASE("Test HCD port disable", "[port][low_speed][full_speed][high_speed]")
     }
 
     // Enqueue URBs but immediately disable the port
-    printf("Enqueuing URBs\n");
+    ESP_LOGI(TAG, "Enqueuing URBs");
     for (int i = 0; i < NUM_URBS; i++) {
         TEST_ASSERT_EQUAL(ESP_OK, hcd_urb_enqueue(default_pipe, urb_list[i]));
         // Add a short delay to let the transfers run for a bit
@@ -384,7 +387,7 @@ TEST_CASE("Test HCD port disable", "[port][low_speed][full_speed][high_speed]")
     // Check that port can be disabled
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_DISABLE));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_DISABLED);
-    printf("Disabled\n");
+    ESP_LOGI(TAG, "Disabled");
 
     // Flush pipe
     TEST_ASSERT_EQUAL(ESP_OK, hcd_pipe_command(default_pipe, HCD_PIPE_CMD_FLUSH));
@@ -452,12 +455,12 @@ TEST_CASE("Test HCD port command bailout", "[port][low_speed][full_speed][high_s
     TEST_ASSERT_EQUAL(pdTRUE, xTaskCreatePinnedToCore(concurrent_task, "tsk", 4096, (void *) sync_sem, uxTaskPriorityGet(NULL) + 1, &task_handle, 0));
 
     // Suspend the device
-    printf("Suspending\n");
+    ESP_LOGI(TAG, "Suspending");
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
     vTaskDelay(pdMS_TO_TICKS(20)); // Short delay for device to enter suspend state
 
     // Attempt to resume the port. But the concurrent task should override this with a disconnection event
-    printf("Attempting to resume\n");
+    ESP_LOGI(TAG, "Attempting to resume");
     xSemaphoreGive(sync_sem);   // Trigger concurrent task
     vTaskDelay(pdMS_TO_TICKS(20)); // Short delay for concurrent task to trigger disconnection
     TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, hcd_port_command(port_hdl, HCD_PORT_CMD_RESUME));
@@ -512,18 +515,18 @@ TEST_CASE("Test HCD port remote wakeup", "[port][low_speed][full_speed][high_spe
     // Suspend the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_SUSPEND));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_SUSPENDED);
-    printf("Root port suspended\n");
-    printf("Do the remote wakeup on the connected USB device (Keyboard button press)\n");
+    ESP_LOGI(TAG, "Root port suspended");
+    ESP_LOGI(TAG, "Do the remote wakeup on the connected USB device (Keyboard button press)");
 
     // Expect remote wakeup event from the device
     TEST_HCD_EXPECT_PORT_EVENT(port_hdl, HCD_PORT_EVENT_REMOTE_WAKEUP);
     TEST_ASSERT_EQUAL(HCD_PORT_EVENT_REMOTE_WAKEUP, hcd_port_handle_event(port_hdl));
-    printf("Remote wake-up detected\n");
+    ESP_LOGI(TAG, "Remote wake-up detected");
 
     // Resume the port
     TEST_ASSERT_EQUAL(ESP_OK, hcd_port_command(port_hdl, HCD_PORT_CMD_RESUME));
     TEST_HCD_EXPECT_PORT_STATE(port_hdl, HCD_PORT_STATE_ENABLED);
-    printf("Resumed\n");
+    ESP_LOGI(TAG, "Resumed");
 
     // Clear the pipe after the port has been resumed
     TEST_HCD_EXPECT_PIPE_STATE(default_pipe, HCD_PIPE_STATE_HALTED);


### PR DESCRIPTION
## Improve HCD target-test diagnostics and logging

Improves failure diagnostics and log readability across the USB Host HCD target tests. Previously, a failed event/state/status check printed only a raw integer (e.g. Expected 1 Was 0) and pointed at a line inside the shared hcd_common.c, giving no indication of which test call actually failed.

## Changes

Only logging improvements, no functional changes.

### File/line + named failure messages for event/state/status checks:
  - `test_hcd_expect_port_event()`, `test_hcd_expect_pipe_event()`, and `test_hcd_expect_no_pipe_event()` are now *_impl() functions wrapped by macros that inject __FILE__/__LINE__. On failure they report where the calling test expected the event, plus the expected vs. delivered event by name.
  - Added `test_hcd_expect_port_state()`, `test_hcd_expect_pipe_state()`, and `test_hcd_expect_transfer_status()` helpers (same file/line + named-message pattern) 

  Failure logging before:

```sh
  ./main/test_hcd_bulk.c:128:...:FAIL: Expected 1 Was 0. Pipe event not generated on time.
```

  Failure logging now:

```sh
  Pipe event HCD_PIPE_EVENT_URB_DONE not generated on time at ./main/test_hcd_bulk.c:90
```

  ### Added name-lookup helpers for better logging output for the following typedefs:
  - `hcd_port_event_t`
  - `hcd_pipe_event_t`
  - `hcd_port_state_t`
  - `hcd_pipe_state_t`
  - `usb_transfer_status_t`

  ### Queue-send assertions
  - Event/request callbacks now assert the return value of `xQueueSend`/`xQueueSendFromISR`, so a full queue (a dropped/lost event) fails the test instead of failing silently.

  ### `printf` → `ESP_LOG`
  - Replaced `printf` with tagged `ESP_LOG` across the HCD tests

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to USB host target-test and mock helpers; production HCD is untouched aside from stricter test-only queue handling.
> 
> **Overview**
> Improves **USB Host HCD target test** failure messages and log output without changing production HCD behavior.
> 
> **Assertion helpers** — Port/pipe event waits, “no event” checks, port/pipe state, and URB transfer status move to `*_impl()` functions behind `TEST_HCD_EXPECT_*` macros that pass `__FILE__`/`__LINE__`. Failures now name the expected vs actual enum (e.g. `HCD_PIPE_EVENT_URB_DONE`) and point at the **calling test line**, not only `hcd_common.c`.
> 
> **Enum string tables** — Lookup helpers for `hcd_port_event_t`, `hcd_pipe_event_t`, port/pipe state, and `usb_transfer_status_t` feed those messages and debug logs.
> 
> **Queue robustness in test callbacks** — `xQueueSendFromISR` / `xQueueSend` return values are checked (`configASSERT` in ISR, Unity assert in task context); task-side pipe events use a 10s timeout instead of `portMAX_DELAY`. External-port test helpers get the same queue-full handling and richer event mismatch messages.
> 
> **Logging** — `printf` in HCD tests and mock MSC CSW warnings is replaced with tagged `ESP_LOG` / `ESP_LOG_BUFFER_HEXDUMP`; call sites across bulk/ctrl/intr/isoc/port tests and hub helpers switch to the new macros.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f71614ba3ac7faed775084d7a918c7ad114688f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->