### PR TITLE
feat(usb): add FS/LS-only root port mode

### DIFF
--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added the `root_port_fsls_only` host configuration option to restrict root ports to Full/Low Speed device enumeration.
+
 ## [1.5.0] - 2026-06-16
 
 ### Changed

--- a/host/usb/include/usb/usb_host.h
+++ b/host/usb/include/usb/usb_host.h
@@ -125,6 +125,7 @@ typedef struct {
     bool root_port_unpowered;                   /**< If set, the USB Host Library will not power on the root port on installation.
                                                      This allows users to power on the root port manually by calling
                                                      usb_host_lib_set_root_port_power(). */
+    bool root_port_fsls_only;                   /**< If set, root ports enumerate devices at full/low speed only. */
     int intr_flags;                             /**< Interrupt flags for the underlying ISR used by the USB Host stack. In dual host applications, this applies to all ports.*/
     usb_host_enum_filter_cb_t enum_filter_cb;   /**< Enumeration filter callback. Enable CONFIG_USB_HOST_ENABLE_ENUM_FILTER_CALLBACK
                                                      to use this feature. Set to NULL otherwise. */

--- a/host/usb/private_include/hcd.h
+++ b/host/usb/private_include/hcd.h
@@ -176,6 +176,7 @@ typedef struct {
     void *callback_arg;                     /**< User argument for HCD port callback */
     void *context;                          /**< Context variable used to associate the port with upper layer object */
     const hcd_fifo_settings_t *fifo_config; /**< Optional pointer to custom FIFO config. If NULL, default configuration is used. */
+    bool fsls_only;                         /**< Limit this port to full/low speed */
     int intr_flags;                         /**< Interrupt flags for HCD interrupt */
 } hcd_port_config_t;
 

--- a/host/usb/private_include/hub.h
+++ b/host/usb/private_include/hub.h
@@ -60,6 +60,7 @@ typedef void (*hub_event_cb_t)(hub_event_data_t *event_data, void *arg);
  */
 typedef struct {
     unsigned port_map;                              /**< Bitmap of root ports to enable */
+    bool root_port_fsls_only;                       /**< Limit root ports to full/low speed */
     usb_proc_req_cb_t proc_req_cb;                  /**< Processing request callback */
     void *proc_req_cb_arg;                          /**< Processing request callback argument */
     hub_event_cb_t event_cb;                        /**< Hub event callback */

--- a/host/usb/src/hcd_dwc.c
+++ b/host/usb/src/hcd_dwc.c
@@ -231,6 +231,7 @@ struct pipe_obj {
 struct port_obj {
     usb_dwc_hal_context_t *hal;
     void *frame_list;
+    bool fsls_only;
     // Pipes routed through this port
     TAILQ_HEAD(tailhead_pipes_idle, pipe_obj) pipes_idle_tailq;
     TAILQ_HEAD(tailhead_pipes_queued, pipe_obj) pipes_active_tailq;
@@ -1508,6 +1509,7 @@ esp_err_t hcd_port_init(int port_number, const hcd_port_config_t *port_config, h
     port_obj->callback = port_config->callback;
     port_obj->callback_arg = port_config->callback_arg;
     port_obj->context = port_config->context;
+    port_obj->fsls_only = port_config->fsls_only;
 
     // Apply custom FIFO config if provided
     if (port_config->fifo_config != NULL) {
@@ -1617,6 +1619,9 @@ esp_err_t hcd_port_command(hcd_port_handle_t port_hdl, hcd_port_cmd_t command)
             break;
         }
         case HCD_PORT_CMD_RESET: {
+            if (port->fsls_only) {
+                usb_dwc_ll_hcfg_set_fsls_supp_only(port->hal->dev);
+            }
             ret = _port_cmd_reset(port);
             break;
         }

--- a/host/usb/src/hub.c
+++ b/host/usb/src/hub.c
@@ -770,6 +770,7 @@ esp_err_t hub_install(hub_config_t *hub_config, void **client_ret)
                 .callback = root_port_callback,
                 .callback_arg = root_hub_port, // To access the root hub port from the callback which is called from an ISR
                 .context = root_hub_port,
+                .fsls_only = hub_config->root_port_fsls_only,
                 .intr_flags = hub_config->intr_flags,
                 .fifo_config = hub_config->fifo_config,
             };

--- a/host/usb/src/usb_host.c
+++ b/host/usb/src/usb_host.c
@@ -756,6 +756,7 @@ esp_err_t usb_host_install(const usb_host_config_t *config)
     // Install Hub
     hub_config_t hub_config = {
         .port_map = peripheral_map, // Each USB-OTG peripheral maps to a root port
+        .root_port_fsls_only = config->root_port_fsls_only,
         .proc_req_cb = proc_req_callback,
         .proc_req_cb_arg = NULL,
         .event_cb = hub_event_callback,

--- a/host/usb/test/host_test/usb_host_layer_test/main/usb_host_install_unit_test.cpp
+++ b/host/usb/test/host_test/usb_host_layer_test/main/usb_host_install_unit_test.cpp
@@ -61,6 +61,7 @@ SCENARIO("USB Host install")
     usb_host_config_t usb_host_config = {
         .skip_phy_setup = false,
         .root_port_unpowered = false,
+        .root_port_fsls_only = false,
         .intr_flags = 1,
         .enum_filter_cb = nullptr,
         .fifo_settings_custom = {},
@@ -183,6 +184,7 @@ SCENARIO("USB Dual Host install - valid config")
     usb_host_config_t usb_host_config = {
         .skip_phy_setup = false,
         .root_port_unpowered = false,
+        .root_port_fsls_only = false,
         .intr_flags = 1,
         .enum_filter_cb = nullptr,
         .fifo_settings_custom = {},
@@ -246,6 +248,7 @@ SCENARIO("USB Host install - valid config")
     usb_host_config_t usb_host_config = {
         .skip_phy_setup = false,
         .root_port_unpowered = false,
+        .root_port_fsls_only = false,
         .intr_flags = 1,
         .enum_filter_cb = nullptr,
         .fifo_settings_custom = {},


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description


 This PR adds the root_port_fsls_only option to usb_host_config_t.

  It allows the USB Host controller to operate root ports in FS/LS-only mode, avoiding the unsupported Transaction Translator (TT) path when using FS/LS
  devices. At the same time, applications can retain the larger number of host channels provided by the HS-capable controller.

  Benefits:

  - Avoids the current TT limitation
  - Retains the HS controller’s additional host channels
  - Keeps the existing behavior unchanged by default

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes root-port reset and host-controller configuration during enumeration; misconfiguration could affect device attach, but the feature is opt-in and defaults off.
> 
> **Overview**
> Adds an opt-in **`root_port_fsls_only`** flag on `usb_host_config_t` so applications can restrict root-port enumeration to full/low speed while still using the high-speed-capable controller (and its extra host channels), avoiding the unsupported transaction-translator path for FS/LS devices.
> 
> The setting is threaded through hub install into each root HCD port (`fsls_only` on `hcd_port_config_t` / `port_obj`). When enabled, **`HCD_PORT_CMD_RESET`** applies `usb_dwc_ll_hcfg_set_fsls_supp_only` on the DWC before the normal reset sequence. Default remains **false** (existing behavior). Changelog and install unit tests initialize the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd31c634fbae615a7b2227e7a6d508722330c9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->