### PR TITLE
feat(esp_tinyusb): Deprecate DCD Slave/IRQ mode

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0
+
+### Breaking changes
+
+- esp_tinyusb: Removed DCD Slave/IRQ mode. Only Buffer DMA mode is supported. For more details, refer to the [Espressif's Addition to TinyUSB Migration guide v3](../../docs/device/migration-guides/v3/tinyusb.md)
+
 ## Unreleased
 
 - esp_tinyusb: MSC: Use `esp_vfs_fat_register` instead of the deprecated `esp_vfs_fat_register_cfg` for ESP-IDF v6.0 and higher

--- a/device/esp_tinyusb/Kconfig
+++ b/device/esp_tinyusb/Kconfig
@@ -6,20 +6,6 @@ menu "TinyUSB Stack"
         help
             Specify verbosity of TinyUSB log output.
 
-    menu "TinyUSB DCD"
-        choice TINYUSB_MODE
-            prompt "DCD Mode"
-            default TINYUSB_MODE_DMA
-            help
-                TinyUSB DCD DWC2 Driver supports two modes: Slave mode (based on IRQ) and Buffer DMA mode.
-
-            config TINYUSB_MODE_SLAVE
-                bool "Slave/IRQ"
-            config TINYUSB_MODE_DMA
-                bool "Buffer DMA"
-        endchoice
-    endmenu # "TinyUSB DCD"
-
     menu "TinyUSB callbacks"
         config TINYUSB_SUSPEND_CALLBACK
             bool "Register suspend callback"

--- a/device/esp_tinyusb/README.md
+++ b/device/esp_tinyusb/README.md
@@ -56,6 +56,7 @@ idf.py add-dependency esp_tinyusb~2.0.0
 
 ## Breaking changes migration guides
 
+- [v3.0.0](../../docs/device/migration-guides/v3/)
 - [v2.0.0](../../docs/device/migration-guides/v2/)
 
 ## USB Device Stack: usage, installation & configuration

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -13,7 +13,7 @@ targets:
   - esp32h4
   - esp32s31
 dependencies:
-  idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
+  idf: '>=5.3'
   tinyusb:
     version: '>=0.17.0~2' # 0.17.0~2 is the first version that supports deinit
     public: true

--- a/device/esp_tinyusb/include/tusb_config.h
+++ b/device/esp_tinyusb/include/tusb_config.h
@@ -98,16 +98,9 @@ extern "C" {
 #endif
 
 // ------------------------------------------------------------------------
-//                              DCD DWC2 Mode
-// ------------------------------------------------------------------------
-#define CFG_TUD_DWC2_SLAVE_ENABLE   1       // Enable Slave/IRQ by default
-
-// ------------------------------------------------------------------------
 //                              DMA & Cache
 // ------------------------------------------------------------------------
-#ifdef CONFIG_TINYUSB_MODE_DMA
-// DMA Mode has a priority over Slave/IRQ mode and will be used if hardware supports it
-#define CFG_TUD_DWC2_DMA_ENABLE     1       // Enable DMA
+#define CFG_TUD_DWC2_DMA_ENABLE     1       // Enable DMA mode
 
 // DCache maintenance is only needed when the SoC actually reaches internal
 // SRAM (where TinyUSB DMA buffers live) via the L1 cache. Just having an L1
@@ -117,28 +110,15 @@ extern "C" {
 #if CONFIG_CACHE_L1_CACHE_LINE_SIZE && CONFIG_SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE
 // Enable dcd_dcache clean/invalidate/clean_invalidate calls
 #   define CFG_TUD_MEM_DCACHE_ENABLE    1
-#define CFG_TUD_MEM_DCACHE_LINE_SIZE    CONFIG_CACHE_L1_CACHE_LINE_SIZE
-// NOTE: starting with esp-idf v5.3 there is specific attribute present: DRAM_DMA_ALIGNED_ATTR
-#   define CFG_TUSB_MEM_SECTION         __attribute__((aligned(CONFIG_CACHE_L1_CACHE_LINE_SIZE))) DRAM_ATTR
+#   define CFG_TUD_MEM_DCACHE_LINE_SIZE CONFIG_CACHE_L1_CACHE_LINE_SIZE
 #else
 #   define CFG_TUD_MEM_DCACHE_ENABLE    0
 #   define CFG_TUD_MEM_CACHE_ENABLE     0
-#   define CFG_TUSB_MEM_SECTION         TU_ATTR_ALIGNED(4) DRAM_ATTR
 #endif // CONFIG_CACHE_L1_CACHE_LINE_SIZE && CONFIG_SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE
-#endif // CONFIG_TINYUSB_MODE_DMA
+
+#define CFG_TUSB_MEM_SECTION        DRAM_DMA_ALIGNED_ATTR
 
 #define CFG_TUSB_OS                 OPT_OS_FREERTOS
-
-/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
- * Tinyusb use follows macros to declare transferring memory so that they can be put
- * into those specific section.
- * e.g
- * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
- * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
- */
-#ifndef CFG_TUSB_MEM_SECTION
-#   define CFG_TUSB_MEM_SECTION
-#endif
 
 #ifndef CFG_TUSB_MEM_ALIGN
 #   define CFG_TUSB_MEM_ALIGN       TU_ATTR_ALIGNED(4)

--- a/docs/device/migration-guides/v3/tinyusb.md
+++ b/docs/device/migration-guides/v3/tinyusb.md
@@ -1,0 +1,25 @@
+# Migration guide to Espressif's TinyUSB addition
+
+This migration guide is intended for users upgrading from Espressif's TinyUSB addition v2.x.x to v3.0.0 of the component. If you are already using v3.0.0 or later, no migration is needed.
+
+v3.0.0 removes DCD Slave/IRQ mode. The TinyUSB DWC2 Device Controller Driver uses Buffer DMA mode only.
+
+If your project used the default DCD mode (Buffer DMA), you do not need to change application code. If your project selected Slave/IRQ mode, you must switch to Buffer DMA. Slave/IRQ mode is no longer available.
+
+## Changes Required After Migration
+
+- Do not set `CONFIG_TINYUSB_MODE_SLAVE` or `CONFIG_TINYUSB_MODE_DMA` as they do not have any effect anymore
+
+## List of changes
+
+### Removed
+
+- Kconfig menu `TinyUSB DCD` and choice `TINYUSB_MODE`:
+  - `TINYUSB_MODE_SLAVE`,
+  - `TINYUSB_MODE_DMA`.
+- Compile-time enable of DCD Slave/IRQ mode in `tusb_config.h`:
+  - `CFG_TUD_DWC2_SLAVE_ENABLE`.
+
+### Changed
+
+- Buffer DMA is always enabled. `CFG_TUD_DWC2_DMA_ENABLE` is set to `1` unconditionally. Previously it was set only when `CONFIG_TINYUSB_MODE_DMA` was selected.


### PR DESCRIPTION
Deprecate DCD Slave/IRQ mode


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking USB device-controller behavior for anyone on Slave/IRQ mode; DMA buffer placement and IDF ≥5.3 requirement can affect builds and runtime USB stability.
> 
> **Overview**
> **esp_tinyusb v3.0.0** drops DWC2 **Slave/IRQ** DCD mode; the stack always runs **Buffer DMA**.
> 
> The **TinyUSB DCD** Kconfig choice (`TINYUSB_MODE_SLAVE` / `TINYUSB_MODE_DMA`) is removed. `tusb_config.h` no longer defines `CFG_TUD_DWC2_SLAVE_ENABLE`, sets `CFG_TUD_DWC2_DMA_ENABLE` unconditionally, and standardizes USB DMA buffers on `DRAM_DMA_ALIGNED_ATTR` with the existing dcache rules unchanged.
> 
> Minimum **ESP-IDF** for the component is raised from **5.0** to **5.3**. A **v3 migration guide** and changelog/README links document that legacy Kconfig DCD options have no effect and that projects that explicitly chose Slave/IRQ must move to DMA-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ccd2fad8a940c7d3028ffb019b40137c56b15b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->