### PR TITLE
fix(esp_tinyusb): Fix device PM lock acquire

### DIFF
--- a/device/esp_tinyusb/include_private/tinyusb_usb_wakeup.h
+++ b/device/esp_tinyusb/include_private/tinyusb_usb_wakeup.h
@@ -56,6 +56,19 @@ typedef struct {
 void tinyusb_usb_wakeup_register_pm_cbs(const tinyusb_usb_wakeup_pm_cbs_t *cbs);
 
 /**
+ * @brief Notify the wakeup module that the USB bus has resumed
+ *
+ * Restores the UTMI OTG suspend state that was armed on the last light-sleep enter, if it is
+ * still armed. Must be called by `tinyusb_pm.c` from the `TINYUSB_EVENT_RESUMED` handler.
+ *
+ * The light-sleep exit callback only restores the OTG state when the wakeup was caused by USB.
+ * When the bus is instead resumed by a device-initiated remote wakeup (after e.g. a UART, or GPIO wake),
+ * the OTG state stays armed with a stale wakeup latch; this hook clears it so the next
+ * light-sleep cycle re-arms the PHY cleanly.
+ */
+void tinyusb_usb_wakeup_notify_bus_resumed(void);
+
+/**
  * @brief Initialize USB Device light-sleep wakeup integration
  *
  * Registers light-sleep event callbacks that prepare and restore UTMI OTG suspend state

--- a/device/esp_tinyusb/test_apps/power_management/main/CMakeLists.txt
+++ b/device/esp_tinyusb/test_apps/power_management/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRC_DIRS .
                        INCLUDE_DIRS .
-                       REQUIRES unity
+                       REQUIRES unity esp_driver_uart
                        WHOLE_ARCHIVE)

--- a/device/esp_tinyusb/test_apps/power_management/main/common_pm.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/common_pm.c
@@ -168,6 +168,18 @@ void expect_device_event_impl(const uint32_t expected_event, TickType_t ticks, c
     TEST_FAIL_MESSAGE(err_msg_buf);
 }
 
+void expect_any_device_event_impl(const uint32_t expected_events, TickType_t ticks, const char *file, int line)
+{
+    // Wait for ANY of the expected event bits (unlike expect_device_event_impl, which requires all).
+    const EventBits_t bits = xEventGroupWaitBits(device_event_group, expected_events, pdTRUE, pdFALSE, ticks);
+    if ((bits & expected_events) != 0) {
+        return;
+    }
+
+    snprintf(err_msg_buf, sizeof(err_msg_buf), "None of events 0x%lx at %s:%d\n was delivered on time", (uint32_t)expected_events, file, line);
+    TEST_FAIL_MESSAGE(err_msg_buf);
+}
+
 SemaphoreHandle_t test_pm_get_rx_sem(void)
 {
     return rx_data_sem;

--- a/device/esp_tinyusb/test_apps/power_management/main/common_pm.h
+++ b/device/esp_tinyusb/test_apps/power_management/main/common_pm.h
@@ -27,8 +27,8 @@ extern "C" {
 #define DEVICE_EVENT_WAIT_MS                    5000    /** Maximum time to wait for a device event, in milliseconds. */
 #define DATA_RECEPTION_WAIT_MS                  7000    /** Maximum time to wait for CDC RX data, in milliseconds. */
 #define SUSPEND_RESUME_TEST_ITERATIONS          5       /** Number of host-driven suspend/resume iterations in PM loop tests. */
-#define PM_LIGHT_SLEEP_TIMER_US                 (2 * 1000 * 1000ULL) /** Light sleep timer wakeup period for PM-only tests, in microseconds. */
-#define PM_LIGHT_SLEEP_WAKE_WAIT_MS             10000   /** Maximum time to wait for a timer light sleep wakeup, in milliseconds. */
+#define PM_LIGHT_SLEEP_WAKE_WAIT_MS             10000   /** Maximum time to wait for a light sleep wakeup, in milliseconds. */
+#define PM_UART_WAKEUP_EDGE_THRESHOLD           6       /**< The active-threshold minimum is 3 on most targets but 6 on the ESP32-P4 HP UART */
 #define TINYUSB_CDC_RX_BUFSIZE                  CONFIG_TINYUSB_CDC_RX_BUFSIZE
 
 #define EVENT_BITS_ATTACHED                     BIT0    /**< Device attached event */
@@ -65,6 +65,19 @@ typedef struct {
  */
 void expect_device_event_impl(uint32_t expected_event, TickType_t ticks, const char *file, int line);
 #define expect_device_event(expected_event, ticks) expect_device_event_impl((expected_event), (ticks), __FILE__, __LINE__)
+
+/**
+ * @brief Wait for any one of an expected device event bit mask
+ *
+ * Like `expect_device_event`, but succeeds as soon as *any* of the bits in `expected_events` is delivered
+ *
+ * @param[in] expected_events Event bit mask from `EVENT_BITS_*` (any one of them matches)
+ * @param[in] ticks           FreeRTOS timeout in ticks
+ * @param[in] file            File from which the function was called
+ * @param[in] line            Line from which the function was called
+ */
+void expect_any_device_event_impl(uint32_t expected_events, TickType_t ticks, const char *file, int line);
+#define expect_any_device_event(expected_events, ticks) expect_any_device_event_impl((expected_events), (ticks), __FILE__, __LINE__)
 
 /**
  * @brief Get the RX synchronization semaphore used by PM tests

--- a/device/esp_tinyusb/test_apps/power_management/main/test_device_pm.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_device_pm.c
@@ -78,8 +78,9 @@ TEST_CASE("tinyusb_suspend_resume_events", "[device_events][tinyusb_suspend_resu
         }
     } while (test_iterations < SUSPEND_RESUME_TEST_ITERATIONS);
 
-    // Wait for the last auto suspend to finish the pytest
-    expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    // Wait for the last auto suspend to finish the pytest. This time the host closes the CDC port, so it may report
+    // remote wakeup as either enabled (normal autosuspend) or disabled (port close) depending on host behavior
+    expect_any_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN | EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
 }
 
 /**

--- a/device/esp_tinyusb/test_apps/power_management/main/test_esp_pm_integration.c
+++ b/device/esp_tinyusb/test_apps/power_management/main/test_esp_pm_integration.c
@@ -16,38 +16,149 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 #include "esp_log.h"
+#include "esp_idf_version.h"
 #include "unity.h"
+#include "driver/uart.h"
+#include "esp_private/sleep_event.h"
 #include "tinyusb.h"
 #include "tinyusb_cdc_acm.h"
 #include "tusb_config.h"
 #include "common_pm.h"
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+#include "driver/uart_wakeup.h"
+#endif
+
 static const char *TAG = "PM_EspPM";
 
-#if !CONFIG_TINYUSB_USB_OTG_WAKEUP
+/**
+ * @brief Set when a light sleep exit was caused by the console UART
+ */
+static volatile bool s_uart_light_sleep_wakeup;
 
-static void pm_wait_light_sleep_timer_wakeup(void)
+/**
+ * @brief Light sleep exit callback
+ *
+ * Runs on every light sleep exit and gets wake-up cause. If the wake-up source is UART, sets the wakeup flag
+ *
+ * @param[in] user_arg Unused
+ * @param[in] ext_arg  Unused
+ *
+ * @return ESP_OK always
+ */
+static esp_err_t pm_exit_light_sleep_cb(void *user_arg, void *ext_arg)
 {
-    const TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(PM_LIGHT_SLEEP_WAKE_WAIT_MS);
-
-    while (xTaskGetTickCount() < deadline) {
-        const uint32_t causes = esp_sleep_get_wakeup_causes();
-        if (causes & BIT(ESP_SLEEP_WAKEUP_TIMER)) {
-            printf("Woken form light sleep by timer\n");
-            return;
-        }
-        vTaskDelay(pdMS_TO_TICKS(50));
+    (void)user_arg;
+    (void)ext_arg;
+    if (esp_sleep_get_wakeup_causes() & BIT(ESP_SLEEP_WAKEUP_UART)) {
+        s_uart_light_sleep_wakeup = true;
     }
+    return ESP_OK;
+}
 
-    TEST_FAIL_MESSAGE("Timed out waiting for light sleep timer wakeup");
+static const esp_sleep_event_cb_config_t pm_exit_light_sleep_cb_cfg = {
+    .cb = pm_exit_light_sleep_cb,
+    .user_arg = NULL,
+    // Lower priority value runs earlier; keep it distinct from the tinyusb wakeup callback (prior 2)
+    .prior = 1,
+    .next = NULL,
+};
+
+static void pm_console_uart_wakeup_threshold_enable(void)
+{
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+    const uart_wakeup_cfg_t uart_wakeup_cfg = {
+        .wakeup_mode = UART_WK_MODE_ACTIVE_THRESH,
+        .rx_edge_threshold = PM_UART_WAKEUP_EDGE_THRESHOLD,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, uart_wakeup_setup(CONFIG_ESP_CONSOLE_UART_NUM, &uart_wakeup_cfg));
+#else
+    TEST_ASSERT_EQUAL(ESP_OK, uart_set_wakeup_threshold(CONFIG_ESP_CONSOLE_UART_NUM, PM_UART_WAKEUP_EDGE_THRESHOLD));
+#endif
+}
+
+static void pm_console_uart_wakeup_threshold_disable(void)
+{
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+    uart_wakeup_clear(CONFIG_ESP_CONSOLE_UART_NUM, UART_WK_MODE_ACTIVE_THRESH);
+#endif
 }
 
 /**
- * @brief PM-only suspend/resume cycles using timer light sleep wakeup and USB remote wakeup
+ * @brief Re-arm console UART wakeup after a successful light sleep exit
+ *
+ * ACTIVE_THRESH mode leaves the UART wake_up signal asserted until the UART is
+ * used in active mode. Flush any host data and re-apply the threshold so the
+ * next light sleep cycle can wake on UART again.
+ */
+static void pm_console_uart_wakeup_rearm(void)
+{
+    uart_flush_input(CONFIG_ESP_CONSOLE_UART_NUM);
+    pm_console_uart_wakeup_threshold_enable();
+}
+
+/**
+ * @brief Enable the console UART as a light sleep wakeup source
+ *
+ * Uses the active-threshold mode, which is supported on every target that runs these PM tests.
+ * The host (pytest) wakes the SoC from light sleep by sending characters over the console UART.
+ */
+static void pm_console_uart_wakeup_enable(void)
+{
+    pm_console_uart_wakeup_threshold_enable();
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_enable_uart_wakeup(CONFIG_ESP_CONSOLE_UART_NUM));
+
+    s_uart_light_sleep_wakeup = false;
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_register_event_callback(SLEEP_EVENT_SW_EXIT_SLEEP, &pm_exit_light_sleep_cb_cfg));
+}
+
+/**
+ * @brief Disable the console UART light sleep wakeup source
+ */
+static void pm_console_uart_wakeup_disable(void)
+{
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_unregister_event_callback(SLEEP_EVENT_SW_EXIT_SLEEP, pm_exit_light_sleep_cb));
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_UART));
+    pm_console_uart_wakeup_threshold_disable();
+}
+
+/**
+ * @brief Wait for a non-USB (UART) light sleep wakeup while verifying the PM lock stays released
+ *
+ * While the USB device is suspended the PM lock is released and the SoC enters automatic light
+ * sleep. The host wakes it over the console UART. On every non-USB light sleep exit the PM lock
+ * must stay released.
+ */
+static void pm_wait_light_sleep_uart_wakeup(void)
+{
+    const TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(PM_LIGHT_SLEEP_WAKE_WAIT_MS);
+
+    // Ignore any UART wakeup from previous iteration; only this wait's wakeups count
+    s_uart_light_sleep_wakeup = false;
+
+    while (xTaskGetTickCount() < deadline) {
+        // Block so tickless idle can actually enter light sleep and the exit callback can run
+        vTaskDelay(pdMS_TO_TICKS(50));
+
+        // The lock must remain released across every (non-USB) light sleep wakeup
+        test_pm_assert_lock_acquired(false);
+
+        if (s_uart_light_sleep_wakeup) {
+            printf("Woken from light sleep by UART\n");
+            break;
+        }
+    }
+
+    TEST_ASSERT_TRUE_MESSAGE(s_uart_light_sleep_wakeup, "Timed out waiting for light sleep UART wakeup");
+}
+
+/**
+ * @brief PM-only suspend/resume cycles using UART light sleep wakeup and USB remote wakeup
  *
  * After host suspend the PM lock is released and the SoC may enter automatic light sleep.
- * USB host traffic cannot wake FS targets from light sleep, so a sleep timer wakes the SoC.
- * The device then signals remote wakeup to resume the USB bus and re-acquire the PM lock.
+ * The host wakes the SoC over the console UART (a non-USB wakeup). The device verifies that the
+ * PM lock is still released after the wakeup, then signals USB remote wakeup to resume the bus
+ * and re-acquire the PM lock.
  */
 static void run_esp_pm_light_sleep_suspend_resume_cycles(void)
 {
@@ -60,13 +171,16 @@ static void run_esp_pm_light_sleep_suspend_resume_cycles(void)
         expect_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
         test_pm_assert_lock_acquired(false);
 
-        pm_wait_light_sleep_timer_wakeup();
+        pm_wait_light_sleep_uart_wakeup();
+        pm_console_uart_wakeup_rearm();
+
+        // A non-USB light sleep wakeup must not re-acquire the PM lock
+        test_pm_assert_lock_acquired(false);
 
         TEST_ASSERT_EQUAL(ESP_OK, tinyusb_remote_wakeup());
         test_pm_assert_lock_acquired(true);
         expect_device_event(EVENT_BITS_RESUMED, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
 
-        TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_enable_timer_wakeup(PM_LIGHT_SLEEP_TIMER_US));
         test_iterations++;
     } while (test_iterations < SUSPEND_RESUME_TEST_ITERATIONS);
 
@@ -75,7 +189,11 @@ static void run_esp_pm_light_sleep_suspend_resume_cycles(void)
 }
 
 /**
- * @brief Verify PM lock acquire/release during host-driven suspend/resume (PM only, no USB wakeup)
+ * @brief Verify PM lock acquire/release around automatic light sleep with a non-USB (UART) wakeup
+ *
+ * Runs on all PM-capable targets, including those with USB OTG light sleep wakeup enabled, to
+ * verify that a non-USB light sleep wakeup keeps the ESP_PM_NO_LIGHT_SLEEP lock released so that
+ * automatic light sleep is not blocked until the host resumes the USB bus.
  */
 TEST_CASE("tinyusb_power_management", "[device_pm][tinyusb_pm]")
 {
@@ -89,9 +207,10 @@ TEST_CASE("tinyusb_power_management", "[device_pm][tinyusb_pm]")
     TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_ON));
 #endif // SOC_PM_SUPPORT_CNNT_PD
 
-    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_enable_timer_wakeup(PM_LIGHT_SLEEP_TIMER_US));
+    pm_console_uart_wakeup_enable();
     run_esp_pm_light_sleep_suspend_resume_cycles();
-    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
+    pm_console_uart_wakeup_disable();
+
 #if SOC_PM_SUPPORT_CNNT_PD
     TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_pd_config(ESP_PD_DOMAIN_CNNT, ESP_PD_OPTION_OFF));
 #endif // SOC_PM_SUPPORT_CNNT_PD
@@ -103,10 +222,15 @@ TEST_CASE("tinyusb_power_management", "[device_pm][tinyusb_pm]")
 #endif // SOC_PM_SUPPORT_CPU_PD
 }
 
-#endif // !CONFIG_TINYUSB_USB_OTG_WAKEUP
-
 #if CONFIG_TINYUSB_USB_OTG_WAKEUP
 
+/**
+ * @brief Host-driven suspend/resume cycles woken from light sleep by USB activity
+ *
+ * The USB bus is resumed by host CDC traffic. On targets with USB OTG light sleep wakeup the host
+ * traffic wakes the SoC from automatic light sleep through the USB peripheral, and the resulting
+ * USB wakeup re-acquires the PM lock so the bus can stay resumed.
+ */
 static void run_esp_pm_suspend_resume_cycles(void)
 {
     const uint32_t suspend_event = EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN;
@@ -148,12 +272,17 @@ static void run_esp_pm_suspend_resume_cycles(void)
         }
     } while (test_iterations < SUSPEND_RESUME_TEST_ITERATIONS);
 
-    expect_device_event(suspend_event, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
+    // Wait for the last auto suspend to finish the pytest. This time the host closes the CDC port, so it may report
+    // remote wakeup as either enabled (normal autosuspend) or disabled (port close) depending on host behavior
+    expect_any_device_event(EVENT_BITS_SUSPENDED_REMOTE_WAKE_EN | EVENT_BITS_SUSPENDED_REMOTE_WAKE_DIS, pdMS_TO_TICKS(DEVICE_EVENT_WAIT_MS));
     test_pm_assert_lock_acquired(false);
 }
 
 /**
- * @brief Verify PM lock acquire/release during host-driven suspend/resume (esp_tinyusb callbacks)
+ * @brief Verify PM lock re-acquire when the USB bus is resumed by the host (USB light sleep wakeup)
+ *
+ * Complements `tinyusb_power_management` (non-USB UART wakeup): here a USB wakeup must re-acquire
+ * the ESP_PM_NO_LIGHT_SLEEP lock, while there a non-USB wakeup must leave it released.
  */
 TEST_CASE("tinyusb_power_management_usb_wakeup", "[device_pm][tinyusb_pm_otg_wake]")
 {

--- a/device/esp_tinyusb/test_apps/power_management/pytest_remote_wake.py
+++ b/device/esp_tinyusb/test_apps/power_management/pytest_remote_wake.py
@@ -64,7 +64,7 @@ def set_remote_wake_on_device(VID: int, PID: int) -> None:
     except usb.core.USBError as e:
         raise RuntimeError("Control transfer not sent") from e
 
-    print("CTRL transfer sent")
+    print("CTRL transfer sent", flush=True)
 
     try:
         usb.util.dispose_resources(dev)
@@ -90,9 +90,9 @@ def check_remote_wake_feature(VID: int, PID: int, has_remote_wake: bool) -> None
     remote_wake_supported = bool(cfg.bmAttributes & USB_BM_ATTRIBUTES_WAKEUP)
 
     if remote_wake_supported:
-        print("Device advertises remote wakeup feature in it's descriptor")
+        print("Device advertises remote wakeup feature in it's descriptor", flush=True)
     else:
-        print("Device does not advertise remote wakeup feature in it's descriptor")
+        print("Device does not advertise remote wakeup feature in it's descriptor", flush=True)
 
     # Assertion to fail on mismatch
     assert remote_wake_supported == has_remote_wake, (

--- a/device/esp_tinyusb/test_apps/power_management/pytest_usb_pm.py
+++ b/device/esp_tinyusb/test_apps/power_management/pytest_usb_pm.py
@@ -3,6 +3,7 @@
 
 from time import sleep
 import pytest
+from pexpect.exceptions import TIMEOUT as PexpectTimeout
 from serial import Serial, SerialException
 from serial.tools.list_ports import comports
 from pytest_embedded_idf.dut import IdfDut
@@ -10,6 +11,12 @@ from pytest_embedded_idf.dut import IdfDut
 # Device Under Test VID:PID
 DUT_VID = 0x303A
 DUT_PID = 0x4002
+
+# Console-UART light-sleep wakeup tuning (non-USB wakeup path). The DUT waits up to
+# PM_LIGHT_SLEEP_WAKE_WAIT_MS (10 s) for a UART wakeup, so the pytest keeps sending uart strings during that window
+UART_WAKEUP_ARM_DELAY_S = 0.5   # Let the DUT actually enter light sleep before nudging
+UART_WAKEUP_RETRIES = 5         # Number of nudge attempts (RETRIES * RETRY_TIMEOUT <= 10 s)
+UART_WAKEUP_RETRY_TIMEOUT_S = 2 # Time to wait for the resume event after each nudge
 
 # Tinyusb device events from device event handler
 TINYUSB_EVENTS = {
@@ -30,13 +37,13 @@ def find_dut_cdc_ports() -> list[str]:
             ports.append(p.device)
     return ports
 
-def run_suspend_resume_cdc_test(
-    dut: IdfDut,
-    *,
-    resumed_event: str,
-    suspended_event: str,
-) -> None:
-    '''Run the write/read cycle test body'''
+def run_usb_wakeup_test(dut: IdfDut) -> None:
+    '''Run PM suspend/resume test using a USB light sleep wakeup.
+
+    Host suspends the device (auto-suspend after 3s).
+    Pytest wakes the SoC over the console USB-CDC (USB wakeup).
+    '''
+
     dut.expect_exact('TinyUSB: TinyUSB Driver installed')
     sleep(2)  # Some time for the OS to enumerate our USB device
 
@@ -50,17 +57,15 @@ def run_suspend_resume_cdc_test(
         with Serial(ports[0], timeout=5, write_timeout=5) as cdc:
             dut.expect_exact(TINYUSB_EVENTS['attached'])
 
-            # Wait for auto suspend (set to 3 seconds)
-            # This expect_exact is ignored by pytest when running second rerun of flaky test (unknown reason),
-            # making the test fail in further steps, adding explicit sleep(3) to wait for the suspend events
-            sleep(3)
-            dut.expect_exact(suspended_event, timeout=10)
-            sleep(1)
-
             for i in range(5):
-                print(f"Power cycle iteration {i}.")
+                print(f"Power cycle iteration {i}.", flush=True)
 
-                # Resume the device by accessing it
+                # Wait for the host to auto-suspend the idle device (~3 s) and for the SoC to enter automatic light sleep.
+                # We don't wait for the suspend event here, as UART log from the DUT is flushed only after exiting the light sleep.
+                # while the SoC is in light sleep the monitor-UART output is deferred, so gating the
+                sleep(4)
+
+                # Resume the bus by accessing the device. This wakes the SoC through the USB peripheral
                 cdc.reset_input_buffer()
                 cdc.write(b'Time to resume\r\n')
                 cdc.flush()
@@ -68,32 +73,38 @@ def run_suspend_resume_cdc_test(
                 res = cdc.readline()
                 assert b'Time to suspend\r\n' in res
 
-                dut.expect_exact(resumed_event, timeout=10)
+                # Suspended event is delivered after resuming, so we first resume the target, then expect the suspend event
+                dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'], timeout=10)
 
-                # Wait for auto suspend (set to 3 seconds)
-                dut.expect_exact(suspended_event, timeout=10)
-
-                # Stay suspended for a while
-                sleep(1)
+                # Also expect the resume event
+                dut.expect_exact(TINYUSB_EVENTS['resumed'], timeout=10)
 
     except SerialException as e:
         raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
 
+    sleep(1)
     # Wait for the test app to finish
     dut.expect_exact('PM_Device_main_app: Cleanup')
     dut.expect_exact(TINYUSB_EVENTS['detached'])
     sleep(1)
 
-def run_pm_light_sleep_suspend_resume_test(
-    dut: IdfDut,
-    *,
-    resumed_event: str,
-    suspended_event: str,
-) -> None:
-    '''Run PM-only suspend/resume test without host CDC resume.
+def wake_dut_over_console_uart(dut: IdfDut) -> None:
+    '''Wake the DUT from light sleep over UART.
 
-    On FS targets the host cannot wake the SoC from light sleep. The DUT wakes itself
-    with a sleep timer, signals USB remote wakeup, and pytest only observes events.
+    Sending a stream of characters generates the RX edges needed to cross the console-UART
+    wakeup threshold (PM_UART_WAKEUP_EDGE_THRESHOLD, 6 edges on the ESP32-P4 HP UART). Send a long burst
+    so enough edges are guaranteed to land while the SoC is in light sleep.
+    '''
+
+    print("UART-wakeup", flush=True)    # Logging
+    dut.write('wakeup' * 4)             # Actual wakeup: long burst to guarantee enough RX edges
+
+def run_non_usb_wakeup_test(dut: IdfDut) -> None:
+    '''Run PM suspend/resume test using a non-USB (UART) light sleep wakeup.
+
+    Host suspends the device (auto-suspend after 3s).
+    Pytest wakes the SoC over the console UART (a non-USB wakeup).
+    The DUT signals USB remote wakeup to resume the bus.
     '''
     dut.expect_exact('TinyUSB: TinyUSB Driver installed')
     sleep(2)  # Some time for the OS to enumerate our USB device
@@ -108,13 +119,27 @@ def run_pm_light_sleep_suspend_resume_test(
             dut.expect_exact(TINYUSB_EVENTS['attached'])
 
             for i in range(5):
-                print(f"PM light sleep iteration {i}.")
+                print(f"PM light sleep iteration {i}.", flush=True)
 
                 # Auto-suspend
-                dut.expect_exact(suspended_event)
+                dut.expect_exact(TINYUSB_EVENTS['suspended_remote_wake_en'])
 
-                # Wait for the timer to wake the SoC from light sleep and call the remote wakeup
-                dut.expect_exact(resumed_event)
+                # Wait some time, before sending UART wakeup attempts
+                sleep(UART_WAKEUP_ARM_DELAY_S)
+
+                # Wake the SoC from light sleep over the console UART (non-USB wakeup).
+                # A single burst could be missed if it races the light-sleep entry, sending UART wakeup strings
+                # until the DUT resumes, staying within the device-side PM_LIGHT_SLEEP_WAKE_WAIT_MS (10 s) wait window.
+                for attempt in range(UART_WAKEUP_RETRIES):
+                    wake_dut_over_console_uart(dut)
+                    try:
+                        # The DUT signals USB remote wakeup to resume once it observed the UART wakeup
+                        dut.expect_exact(TINYUSB_EVENTS['resumed'], timeout=UART_WAKEUP_RETRY_TIMEOUT_S)
+                        break
+                    except PexpectTimeout:
+                        if attempt == UART_WAKEUP_RETRIES - 1:
+                            raise
+                        print(f"UART-wakeup not observed, retrying ({attempt + 1}/{UART_WAKEUP_RETRIES})", flush=True)
 
     except SerialException as e:
         raise RuntimeError(f"Failed to open CDC device on {ports[0]}") from e
@@ -152,38 +177,38 @@ def test_usb_device_suspend_resume_signaling(config: str, dut: IdfDut) -> None:
     2. Connect you DUT to your test runner (local machine) with USB port and flashing port
     3. Run `pytest --target <target>`
 
-    Test procedure:
-    1. Run the test on the DUT
-    2. Expect one COM Port in the system
-    3. Open it and and test power management of the USB device (Suspend/Resume)
-    4. Suspend: Device enters suspended state after some time of inactivity
-    5. Resume: Device is resumed by accessing it (sending some data to it)
     '''
     sleep(5) # When rerunning flaky test, to re-initialize the device
     dut.expect_exact('Press ENTER to see the list of tests.')
 
-    resumed_event=TINYUSB_EVENTS['resumed']
-    suspended_event=TINYUSB_EVENTS['suspended_remote_wake_en']
-
     if config == 'default' or config == 'esp32p4_eco4':
+        # Run plain suspend/resume signalling target test. No light sleep, no power management
         dut.write('[tinyusb_suspend_resume_events]')
-    elif config == 'pm':
-        dut.write('[tinyusb_pm]')
-    elif config == 'pm_otg_wake':
-        dut.write('[tinyusb_pm_otg_wake]')
+        run_usb_wakeup_test(dut)
 
-    if config == 'pm':
-        run_pm_light_sleep_suspend_resume_test(
-            dut,
-            resumed_event=resumed_event,
-            suspended_event=suspended_event,
-        )
-    else:
-        run_suspend_resume_cdc_test(
-            dut,
-            resumed_event=resumed_event,
-            suspended_event=suspended_event,
-        )
+    elif config == 'pm':
+        # Run suspend/resume signalling target tests with esp_tinyusb Power management.
+        # 1. PM automatically suspends the USB peripheral + puts the SoC to the sleep
+        # 2. UART (pytest writing to UART) wakes up the SoC
+        # 3. App calls remote wakeup to wake the USB peripheral
+        dut.write('[tinyusb_pm]')
+        run_non_usb_wakeup_test(dut)
+
+    elif config == 'pm_otg_wake':
+        # Run suspend/resume signalling target tests with esp_tinyusb Power management and USB wakeup.
+        # 1. PM automatically suspends the USB peripheral + puts the SoC to the sleep
+        # 2. USB (pytest writing to CDC device) wakes up the SoC
+        # 3. Peripheral and SoC is woken
+        dut.write('[tinyusb_pm_otg_wake]')
+        run_usb_wakeup_test(dut)
+
+        # Run suspend/resume signalling target tests with esp_tinyusb Power management.
+        # 1. PM automatically suspends the USB peripheral + puts the SoC to the sleep
+        # 2. UART (pytest writing to UART) wakes up the SoC
+        # 3. App calls remote wakeup to wake the USB peripheral
+        dut.write('[tinyusb_pm]')
+        run_non_usb_wakeup_test(dut)
+
 
 @pytest.mark.usb_device
 @pytest.mark.flaky(reruns=2, reruns_delay=10)

--- a/device/esp_tinyusb/test_apps/power_management/sdkconfig.ci.pm
+++ b/device/esp_tinyusb/test_apps/power_management/sdkconfig.ci.pm
@@ -1,6 +1,8 @@
 # Enable Tinyusb power management
 CONFIG_PM_ENABLE=y
 CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+# Required only for the test procedure, not for the feature itself.
+CONFIG_ESP_SLEEP_EVENT_CALLBACKS=y
 CONFIG_TINYUSB_PM=y
 
 # Tinyusb Suspend/Resume events are registered internally in sdkconfig.defaults

--- a/device/esp_tinyusb/tinyusb_pm.c
+++ b/device/esp_tinyusb/tinyusb_pm.c
@@ -256,6 +256,20 @@ static esp_err_t tinyusb_pm_on_light_sleep_usb_wakeup(void)
     }
     return tinyusb_pm_lock_acquire();
 }
+
+/**
+ * @brief Restore the UTMI OTG suspend state
+ *
+ * The light-sleep exit callback only restores the OTG state when the wakeup was caused by USB.
+ * When the bus is instead resumed by a device-initiated remote wakeup (after e.g. a UART, or GPIO wake), the OTG state
+ * stays armed with a stale wakeup latch.
+ */
+static void tinyusb_pm_phy_notify(void)
+{
+    tinyusb_usb_wakeup_notify_bus_resumed();
+}
+#else // CONFIG_TINYUSB_USB_OTG_WAKEUP
+static void tinyusb_pm_phy_notify(void) {}
 #endif // CONFIG_TINYUSB_USB_OTG_WAKEUP
 
 // --------------------------------------------------- Public API ------------------------------------------------------
@@ -361,6 +375,7 @@ void tinyusb_pm_on_event(tinyusb_event_t *event)
         PM_BREAK_ON_ERROR(tinyusb_pm_enter_suspend(), "Failed to enter USB suspend PM state");
         break;
     case TINYUSB_EVENT_RESUMED:
+        tinyusb_pm_phy_notify();
         PM_BREAK_ON_ERROR(tinyusb_pm_leave_suspend(), "Failed to leave USB suspend PM state");
         break;
     default:

--- a/device/esp_tinyusb/tinyusb_usb_wakeup.c
+++ b/device/esp_tinyusb/tinyusb_usb_wakeup.c
@@ -6,6 +6,7 @@
 
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_bit_defs.h"
 #include "esp_private/usb_phy.h"
 #include "esp_private/sleep_event.h"
 #include "tinyusb_usb_wakeup.h"
@@ -118,7 +119,8 @@ static esp_err_t usb_wakeup_enter_light_sleep(void *user_arg, void *ext_arg)
  * @param[in] ext_arg  Unused sleep event callback argument
  *
  * @return
- *      - ESP_OK on success or when UTMI OTG was not prepared for light sleep
+ *      - ESP_OK on success, when UTMI OTG was not prepared for light sleep, or when the wakeup
+ *        was not caused by USB (the PM lock is intentionally left released in that case)
  *      - ESP_FAIL if the registered PM `acquire_pm_lock` callback fails
  */
 static esp_err_t usb_wakeup_exit_light_sleep(void *user_arg, void *ext_arg)
@@ -126,10 +128,27 @@ static esp_err_t usb_wakeup_exit_light_sleep(void *user_arg, void *ext_arg)
     (void)user_arg;
     (void)ext_arg;
 
+    // Determine the wakeup cause before touching the PHY. This exit callback runs on *every*
+    // light-sleep wakeup (timer, tickless idle, UART, USB, ...), so the actual cause decides
+    // whether the USB bus is being resumed by the host.
+    const bool woken_by_usb = (esp_sleep_get_wakeup_causes() & BIT(ESP_SLEEP_WAKEUP_USB)) != 0;
+
     // UTMI PHY must be already prepared for the light sleep
     USB_WAKE_CHECK(s_usb_wakeup_ctx.otg_prepared_for_light_sleep, ESP_OK);
 
-    // Un-prepare PHY for light sleep
+    // Only USB activity resumes the bus and must re-acquire the PM lock. For any other wakeup cause
+    // (timer, tickless idle, UART, ...) the USB bus stays suspended and no TINYUSB_EVENT_RESUMED
+    // will follow to release the lock. In that case leave the UTMI OTG suspend state armed and the
+    // PM lock released so the SoC transparently re-enters automatic light sleep.
+
+    // Crucially, do NOT touch the PHY here on non-USB wakeups. On the esp32p4 the light-sleep exit
+    // sequence toggles the UTMI PCLK; un-preparing and re-preparing the OTG suspend state on every
+    // tickless wakeup drives the PHY into an undefined state and forces a bus disconnect. Leaving
+    // the PHY armed and untouched also keeps USB wakeup continuously enabled, so a real host resume
+    // is reliably reported as ESP_SLEEP_WAKEUP_USB above.
+    USB_WAKE_CHECK(woken_by_usb, ESP_OK);
+
+    // USB resumed the bus: un-prepare the PHY and clear the wakeup latch
     usb_phy_set_otg_suspend_state(false);
     usb_phy_clear_otg_wakeup_status();
 
@@ -168,6 +187,14 @@ static const esp_sleep_event_cb_config_t exit_light_sleep_cb = {
     .prior = 2,
     .next = NULL,
 };
+
+void tinyusb_usb_wakeup_notify_bus_resumed(void)
+{
+    // The bus was resumed by a device-initiated remote wakeup (the USB-wakeup exit path already
+    // restores the OTG state on ESP_SLEEP_WAKEUP_USB). Clear the armed OTG suspend state and the
+    // stale wakeup latch so the next light-sleep enter re-arms the PHY from a clean state.
+    usb_wakeup_restore_otg_state();
+}
 
 void tinyusb_usb_wakeup_register_pm_cbs(const tinyusb_usb_wakeup_pm_cbs_t *cbs)
 {


### PR DESCRIPTION
## Description
    
- `esp_tinyusb` PM module was acquiring `ESP_PM_NO_LIGHT_SLEEP` lock for all light-sleep wakeup causes (UART, GPIO, ...)
- This caused PM Lock latch, as the USB Bus was still suspended, but the lock was incorrectly acquired preventing the SoC from entering automatic light sleep event with the USB Bus was still suspended
- This Fixes the PM lock acquire and limits it only to USB OTG wakeup causes

## Related

- fix for: #535 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes light-sleep exit PHY handling and PM lock rules on USB-suspended devices; mistakes can cause bus disconnect (notably ESP32-P4) or block automatic light sleep.
> 
> **Overview**
> Fixes incorrect **`ESP_PM_NO_LIGHT_SLEEP`** acquisition when the SoC wakes from light sleep while the USB bus is still suspended (e.g. UART/console wake). The USB light-sleep exit path now restores UTMI OTG state and re-acquires the PM lock **only** when the wakeup cause is **`ESP_SLEEP_WAKEUP_USB`**; other wakeups leave the PHY armed and the lock released so tickless idle can re-enter sleep without latching PM.
> 
> When the bus resumes via **device remote wakeup** after a non-USB wake, **`tinyusb_usb_wakeup_notify_bus_resumed()`** (hooked from **`TINYUSB_EVENT_RESUMED`**) clears the stale armed OTG/wakeup latch so the next sleep cycle re-arms cleanly.
> 
> PM integration tests switch from **timer** to **console UART** light-sleep wake, add **`expect_any_device_event`** for flaky final suspend events, and update pytest to drive UART vs USB wakeup paths (including **`pm_otg_wake`** running both scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f980905267ac22a68df624e0b8b4b661f59dd25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->