### PR TITLE
chore(host/vcp): Remove redundant compiler options

### DIFF
--- a/host/class/cdc/usb_host_vcp/CMakeLists.txt
+++ b/host/class/cdc/usb_host_vcp/CMakeLists.txt
@@ -1,11 +1,2 @@
 idf_component_register(SRCS "usb_host_vcp.cpp"
                     INCLUDE_DIRS "include")
-
-# TODO IDF-10802
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 13.2)  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116070
-    set_target_properties(${COMPONENT_LIB} PROPERTIES
-        CXX_STANDARD 14
-        CXX_STANDARD_REQUIRED ON
-    )
-    target_compile_options(${COMPONENT_LIB} PRIVATE -fconcepts)
-endif()

--- a/host/class/cdc/usb_host_vcp/README.md
+++ b/host/class/cdc/usb_host_vcp/README.md
@@ -1,6 +1,6 @@
 # Virtual COM Port Service
 
-[![Component Registry](https://components.espressif.com/components/espressif/usb_host_vcp/badge.svg)](https://components.espressif.com/components/espressif/usb_host_vcp)
+[![Component Registry](https://components.espressif.com/components/espressif/usb_host_vcp/badge.svg)](https://components.espressif.com/components/espressif/usb_host_vcp) ![maintenance-status](https://img.shields.io/badge/maintenance-as--is-yellow.svg)
 
 Virtual COM Port (VCP) service manages drivers to connected VCP devices - typically USB \<-> UART converters. In practice, you rarely care about specifics of the devices; you only want uniform interface for them all.
 

--- a/host/class/cdc/usb_host_vcp/idf_component.yml
+++ b/host/class/cdc/usb_host_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.0~5"
+version: "1.0.0~6"
 description: USB Host Virtual COM Port Service
 url: https://github.com/espressif/esp-usb/tree/master/host/class/cdc/usb_host_vcp
 issues: "https://github.com/espressif/esp-usb/issues"


### PR DESCRIPTION
These compiler flags were needed in IDF 4.x where we used C++11.

Now we use C++23 or later in all active esp-idf releases so these flags are redundant

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only cleanup for a host CDC component with no runtime or API changes.
> 
> **Overview**
> Removes the **CMake workaround** for older GCC (≤13.2) that forced **C++14** and **`-fconcepts`** on `usb_host_vcp`, since supported ESP-IDF builds now use **C++23+** and those flags are no longer needed.
> 
> Bumps the component manifest to **`1.0.0~6`** and adds an **as-is maintenance** badge on the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e9bb7dd0e79c3375ea13565bc7f5139b054069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->