### PR TITLE
fix(usb_host): Fixing cleanup path for hcd_port_init

### DIFF
--- a/host/usb/src/hcd_dwc.c
+++ b/host/usb/src/hcd_dwc.c
@@ -1085,7 +1085,7 @@ static void  _calculate_fifo_from_bias(port_t *port, const usb_dwc_hal_context_t
 static port_t *port_obj_alloc(void)
 {
     port_t *port = calloc(1, sizeof(port_t));
-    usb_dwc_hal_context_t *hal = malloc(sizeof(usb_dwc_hal_context_t));
+    usb_dwc_hal_context_t *hal = calloc(1, sizeof(*hal));
     void *frame_list = heap_caps_aligned_calloc(USB_DWC_FRAME_LIST_MEM_ALIGN, FRAME_LIST_LEN, sizeof(uint32_t), MALLOC_CAP_DMA | MALLOC_CAP_CACHE_ALIGNED | MALLOC_CAP_INTERNAL);
     SemaphoreHandle_t port_mux = xSemaphoreCreateMutex();
     if (port == NULL || hal == NULL || frame_list == NULL || port_mux == NULL) {
@@ -1559,7 +1559,7 @@ esp_err_t hcd_port_init(int port_number, const hcd_port_config_t *port_config, h
 
 clean_up:
     if (port_obj != NULL) {
-        if (port_obj->hal != NULL && port_obj->hal->channels.hdls != NULL) {
+        if (hal_inited && port_obj->hal != NULL && port_obj->hal->channels.hdls != NULL) {
             free(port_obj->hal->channels.hdls);
             port_obj->hal->channels.hdls = NULL;
         }

--- a/host/usb/test/target_test/hcd/CMakeLists.txt
+++ b/host/usb/test/target_test/hcd/CMakeLists.txt
@@ -8,4 +8,4 @@ set(EXTRA_COMPONENT_DIRS "../common")
 # "Trim" the build. Include the minimal set of components, main, and anything it depends on.
 idf_build_set_property(MINIMAL_BUILD ON)
 
-project(test_app_usb_host)
+project(test_app_hcd)

--- a/host/usb/test/target_test/hcd/main/test_hcd_public_api.c
+++ b/host/usb/test/target_test/hcd/main/test_hcd_public_api.c
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "unity.h"
+#include "esp_log.h"
+#include "hcd_common.h"
+
+static const char *TAG = "API";
+
+/*
+Simulate interrupt allocation fail inside hcd_port_init()
+
+Purpose:
+    - Test HCD port public API
+    - Test hcd_port_init() cleanup path
+
+Procedure:
+    - Setup HCD and wait for connection
+    - Disconnect the device and teardown the HCD
+    - Init HCD port init with an custom port config init, that would fail the interrupt allocation
+    - Expect the hcd_port_init() to return error code, instead of a hard fault
+    - Teardown
+*/
+TEST_CASE("Test HCD public API: Interrupt alloc failed", "[api][low_speed][full_speed][high_speed]")
+{
+    test_hcd_wait_for_conn(port_hdl);       // Trigger a connection
+    vTaskDelay(pdMS_TO_TICKS(500));         // Short delay send of SOF (for FS) or EOPs (for LS)
+
+    // Manually teardown the port, so we can initialize it with a custom config later
+    test_hcd_wait_for_disconn(port_hdl, false);
+    test_hcd_teardown(port_hdl);
+    ESP_LOGI(TAG, "Port deinitialized");
+    // Manually clear the public port handler
+    port_hdl = NULL;
+
+    // Initialize a port with the Highest interrupt flag priority
+    // where the interrupt allocation would return INVALID_ARG error
+    const hcd_port_config_t port_config = {
+        .callback = NULL,
+        .callback_arg = NULL,
+        .context = NULL,
+        .fifo_config = NULL,
+        .intr_flags = ESP_INTR_FLAG_NMI,
+    };
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, hcd_port_init(TEST_PORT_NUM, &port_config, &port_hdl));
+    TEST_ASSERT_NULL(port_hdl);
+
+    // Setup the port again, to test the stack recovery after a failed initialization
+    port_hdl = test_hcd_setup();
+    test_hcd_wait_for_conn(port_hdl);       // Trigger a connection
+    ESP_LOGI(TAG, "Port initialized");
+    vTaskDelay(pdMS_TO_TICKS(500));         // Short delay send of SOF (for FS) or EOPs (for LS)
+
+    // Teardown the port
+    test_hcd_wait_for_disconn(port_hdl, false);
+}


### PR DESCRIPTION
## Description

Fixing error path for `hcd_port_init()` in case of failed interrupt allocation.

## Related

- fixes #559 

## Testing

- Added new HCD layer public API target test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes USB host controller port initialization teardown on failure paths; incorrect cleanup logic could still affect re-init or memory safety, but scope is narrow and covered by a new target test.
> 
> **Overview**
> Fixes the **`hcd_port_init()` error path** when interrupt allocation fails (e.g. invalid `intr_flags`), which could previously **hard fault** during teardown instead of returning an error.
> 
> In **`hcd_dwc.c`**, the HAL context is now allocated with **`calloc`** so fields like **`channels.hdls`** start as null, and the **`clean_up`** block only frees channel handles and calls **`usb_dwc_hal_deinit`** when **`hal_inited`** is true—avoiding cleanup against a HAL that was never initialized.
> 
> Adds an HCD target test **`test_hcd_public_api.c`** that forces interrupt alloc failure via **`ESP_INTR_FLAG_NMI`**, asserts **`ESP_ERR_INVALID_ARG`** and a null handle, then verifies the port can be set up again. The HCD test project CMake name is updated to **`test_app_hcd`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c085e1c513cde8db0e9e07ed5cc42af550e7860c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->