### PR TITLE
test(host/msc): Fix timing in device suspend test

### DIFF
--- a/host/class/msc/usb_host_msc/test_app/main/test_msc.c
+++ b/host/class/msc/usb_host_msc/test_app/main/test_msc.c
@@ -548,11 +548,12 @@ TEST_CASE("can_be_formated", "[usb_msc]")
     msc_teardown();
 
     printf("Check file does not exist after formatting\n");
+    const bool config_backup = mount_config.format_if_mount_failed;
     mount_config.format_if_mount_failed = true;
     msc_setup();
     TEST_ASSERT_FALSE(file_exists(FILE_NAME));
     msc_teardown();
-    mount_config.format_if_mount_failed = false;
+    mount_config.format_if_mount_failed = config_backup;
 }
 
 /**
@@ -892,6 +893,8 @@ TEST_CASE("suspended_device_sudden_disconnect_by_host", "[usb_msc]")
 TEST_CASE("suspended_device_sudden_disconnect_by_device", "[host_suspend_sudden_dconn]")
 {
     msc_setup();
+
+    vTaskDelay(10);
 
     ESP_OK_ASSERT(usb_host_lib_root_port_suspend());
 


### PR DESCRIPTION
debug commit. fail-fast=false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and config restore changes with no production code impact.
> 
> **Overview**
> **USB MSC host test hardening** in `test_msc.c`.
> 
> In **`can_be_formated`**, the format step still forces `mount_config.format_if_mount_failed = true` for the remount assertion, but teardown now **restores the prior flag** instead of always resetting it to `false`, so shared `mount_config` state does not leak into later tests.
> 
> In **`suspended_device_sudden_disconnect_by_device`**, a **10 ms delay** after `msc_setup()` was added before `usb_host_lib_root_port_suspend()`, matching other suspend tests and giving setup/enumeration time to settle before the abrupt device-side disconnect scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cbf65073b260b61dccbdccb1ffe2acdd114a23f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->