### PR TITLE
fix(host/uvc): isochronous alternate setting and EP0 recovery (IEC-604)

### DIFF
--- a/host/class/uvc/usb_host_uvc/CHANGELOG.md
+++ b/host/class/uvc/usb_host_uvc/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `uvc_host_usb_ctrl()` now returns `ESP_ERR_NOT_SUPPORTED` when the device STALLs a control request, rather than the `ESP_ERR_INVALID_RESPONSE` it also returns for a failed transfer.
+
+### Fixed
+
+- Fixed a single EP0 transaction error breaking every later control transfer. Control transfers are now retried a few times with a yield in between. A STALL is deliberately not retried.
+
 ## [2.5.2] - 2026-09-01
 
 ### Added

--- a/host/class/uvc/usb_host_uvc/include/esp_private/uvc_control.h
+++ b/host/class/uvc/usb_host_uvc/include/esp_private/uvc_control.h
@@ -31,7 +31,8 @@ extern "C" {
  *     - ESP_ERR_TIMEOUT: The transfer could not be completed in time
  *     - ESP_ERR_INVALID_SIZE: The transfer is too big
  *     - ESP_ERR_INVALID_ARG: stream_hdl is NULL, or data is not NULL and wValue is greater than zero
- *     - ESP_ERR_INVALID_RESPONSE: Reply corrupted or too short
+ *     - ESP_ERR_NOT_SUPPORTED: The device stalled the request; it does not implement it
+ *     - ESP_ERR_INVALID_RESPONSE: Transfer failed on the bus, or reply corrupted or too short
  */
 esp_err_t uvc_host_usb_ctrl(uvc_host_stream_hdl_t stream_hdl, uint8_t bmRequestType, uint8_t bRequest, uint16_t wValue, uint16_t wIndex, uint16_t wLength, uint8_t *data);
 

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -1195,6 +1195,13 @@ esp_err_t uvc_host_usb_ctrl(uvc_host_stream_hdl_t stream_hdl, uint8_t bmRequestT
             continue;
         }
 
+        /* Report a stall apart from a bus failure. */
+        if (status == USB_TRANSFER_STATUS_STALL) {
+            ESP_LOGD(TAG, "CTRL request 0x%02x stalled: the device does not support it", bRequest);
+            ret = ESP_ERR_NOT_SUPPORTED;
+            goto unblock;
+        }
+
         ESP_GOTO_ON_FALSE(false, ESP_ERR_INVALID_RESPONSE, unblock, TAG, "Control transfer error");
     }
 

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -34,6 +34,12 @@
 
 static const char *TAG = "uvc";
 
+/* Retries for a control transfer whose pipe a transaction error left halted. The USB host
+ * library clears EP0 from its own task, so a retry has to yield first; three attempts, 10 ms
+ * apart, covers that with room to spare. A STALL is not retried - see uvc_host_usb_ctrl(). */
+#define UVC_CTRL_MAX_ATTEMPTS    3
+#define UVC_CTRL_RETRY_DELAY_MS  10
+
 // UVC spinlock
 portMUX_TYPE uvc_lock = portMUX_INITIALIZER_UNLOCKED;
 
@@ -1143,13 +1149,62 @@ esp_err_t uvc_host_usb_ctrl(uvc_host_stream_hdl_t stream_hdl, uint8_t bmRequestT
         memcpy(start_of_data, data, wLength);
     }
 
-    ESP_GOTO_ON_ERROR(
-        usb_host_transfer_submit_control(p_uvc_host_driver->usb_client_hdl, p_uvc_host_driver->ctrl_transfer),
-        unblock, TAG, "CTRL transfer failed");
+    /* Submit, and let the USB host library's asynchronous EP0 recovery finish before giving up.
+     *
+     * ep0_pipe_callback() queues DEV_ACTION_EP0_DEQUEUE | DEV_ACTION_EP0_CLEAR on a STALL and
+     * adds DEV_ACTION_EP0_FLUSH on a transaction error - but it does that on the USB host library
+     * task not inline. Until that task runs, every usb_host_transfer_submit_control()
+     * returns ESP_ERR_INVALID_STATE against the halted pipe. */
+    esp_err_t attempt_err = ESP_ERR_INVALID_RESPONSE;
+    bool completed = false;
 
-    taken = xSemaphoreTake((SemaphoreHandle_t)p_uvc_host_driver->ctrl_transfer->context, pdMS_TO_TICKS(5000)); // This is a fixed timeout. Every device should be able to respond to CTRL transfer in 5 seconds
-    ESP_GOTO_ON_FALSE(taken, ESP_ERR_TIMEOUT, unblock, TAG, "CTRL timeout");
-    ESP_GOTO_ON_FALSE(p_uvc_host_driver->ctrl_transfer->status == USB_TRANSFER_STATUS_COMPLETED, ESP_ERR_INVALID_RESPONSE, unblock, TAG, "Control transfer error");
+    for (int attempt = 0; attempt < UVC_CTRL_MAX_ATTEMPTS; attempt++) {
+        if (attempt > 0) {
+            vTaskDelay(pdMS_TO_TICKS(UVC_CTRL_RETRY_DELAY_MS));   // Let USBH recover EP0
+        }
+
+        const esp_err_t sub = usb_host_transfer_submit_control(p_uvc_host_driver->usb_client_hdl,
+                                                               p_uvc_host_driver->ctrl_transfer);
+        if (sub != ESP_OK) {
+            // ESP_ERR_INVALID_STATE means the default pipe is still halted from an earlier
+            // failure and USBH has not finished recovering it yet. Anything else is our fault.
+            if (sub != ESP_ERR_INVALID_STATE) {
+                ret = sub;
+                ESP_LOGE(TAG, "CTRL transfer failed: %s", esp_err_to_name(sub));
+                goto unblock;
+            }
+            ESP_LOGD(TAG, "CTRL request 0x%02x: EP0 still halted, waiting for recovery", bRequest);
+            attempt_err = sub;
+            continue;
+        }
+
+        taken = xSemaphoreTake((SemaphoreHandle_t)p_uvc_host_driver->ctrl_transfer->context, pdMS_TO_TICKS(5000)); // This is a fixed timeout. Every device should be able to respond to CTRL transfer in 5 seconds
+        ESP_GOTO_ON_FALSE(taken, ESP_ERR_TIMEOUT, unblock, TAG, "CTRL timeout");
+
+        const usb_transfer_status_t status = p_uvc_host_driver->ctrl_transfer->status;
+        if (status == USB_TRANSFER_STATUS_COMPLETED) {
+            completed = true;
+            break;
+        }
+
+        /* Retry a transaction error, never a stall. */
+        if (status == USB_TRANSFER_STATUS_ERROR) {
+            ESP_LOGD(TAG, "CTRL request 0x%02x errored; letting USBH clear EP0 and retrying (%d/%d)",
+                     bRequest, attempt + 1, UVC_CTRL_MAX_ATTEMPTS);
+            attempt_err = ESP_ERR_INVALID_RESPONSE;
+            continue;
+        }
+
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_INVALID_RESPONSE, unblock, TAG, "Control transfer error");
+    }
+
+    if (!completed) {
+        ret = attempt_err;
+        ESP_LOGE(TAG, "CTRL request 0x%02x gave up after %d attempts: %s",
+                 bRequest, UVC_CTRL_MAX_ATTEMPTS, esp_err_to_name(ret));
+        goto unblock;
+    }
+
     ESP_GOTO_ON_FALSE(p_uvc_host_driver->ctrl_transfer->actual_num_bytes == p_uvc_host_driver->ctrl_transfer->num_bytes, ESP_ERR_INVALID_RESPONSE, unblock, TAG, "Incorrect number of bytes transferred");
 
     // For OUT transfers, we must transfer data ownership to user


### PR DESCRIPTION
## Description

Fix in `usb_host_uvc`, found while bringing up a UVC camera that encodes H.264 itself 
on ESP32-S31. Before them the camera delivered no frames at all, at any resolution or format.

One bus error killed every later control transfer. USBH clears a halted EP0 from its
own task, not inline, so an immediate resubmit always returns `ESP_ERR_INVALID_STATE`. A
single `Dev 1 EP 0 Error` after a soft reset therefore failed every later transfer down to
`Failed to open UVC stream`. Submit and wait are now bounded by `UVC_CTRL_MAX_ATTEMPTS`
with a yield at the top of each retry. A STALL is deliberately not retried, and a transfer
that times out still exits immediately.

**A STALL and a bus failure returned the same code.** They are opposite answers: a STALL is
permanent and lets a caller stop asking, a transaction error is transient. A caller that
cannot tell them apart disables a working control after one glitch, which is what happened
to us. A STALL now returns `ESP_ERR_NOT_SUPPORTED`.



## Related

## Testing

- ESP32-S31 with a UVC H.264 camera at 1920x1080, 29-30 fps

---

## Checklist

- [ ] 🚨 This PR does not introduce breaking changes.
  - **Two behaviour changes worth a look.** A stalled control now returns
    `ESP_ERR_NOT_SUPPORTED` rather than `ESP_ERR_INVALID_RESPONSE`, so a caller matching on
    the latter will no longer see STALLs.
- [ ] All CI checks (GH Actions) pass
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change on all UVC control traffic: STALL now maps to `ESP_ERR_NOT_SUPPORTED`, and transient EP0 halts are retried instead of failing immediately.
> 
> **Overview**
> **Hardens UVC EP0 control transfers** so a single transaction error no longer permanently breaks later control requests during stream bring-up.
> 
> `uvc_host_usb_ctrl()` now **retries** submit/wait up to three times with a 10 ms yield between attempts, giving the USB host library time to clear a halted default pipe (`ESP_ERR_INVALID_STATE` and `USB_TRANSFER_STATUS_ERROR` are retried; timeouts and STALLs are not).
> 
> **STALL is distinguished from bus/transfer failure:** a device STALL now returns **`ESP_ERR_NOT_SUPPORTED`** instead of sharing **`ESP_ERR_INVALID_RESPONSE`** with corrupted replies and transaction errors. Public docs in `uvc_control.h` and the changelog are updated accordingly.
> 
> Callers that treated every non-OK control result as a fatal glitch may behave better on transient EP0 errors; code that only handled STALL via `ESP_ERR_INVALID_RESPONSE` needs to handle the new code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7235247915255d3b86f747cb43af88ab021f6f20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->