### PR TITLE
fix(msc): use `esp_vfs_fat_register` instead of deprecated `esp_vfs_fat_register_cfg` on IDF v6+ (IEC-605)

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- esp_tinyusb: MSC: Use `esp_vfs_fat_register` instead of the deprecated `esp_vfs_fat_register_cfg` for ESP-IDF v6.0 and higher
 - esp_tinyusb: Added support for exposing already-mounted VFS/FATFS paths through Media Transfer Protocol
 - esp_tinyusb: Added power management lock to control automatic light sleep entry based on Device events
 - esp_tinyusb: Added USB Peripheral light sleep wake-up source integration to the esp_tinyusb (only available for USB HS ports)

--- a/device/esp_tinyusb/tinyusb_msc.c
+++ b/device/esp_tinyusb/tinyusb_msc.c
@@ -8,6 +8,7 @@
 #include "esp_log.h"
 #include "esp_err.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_vfs_fat.h"
 #include "esp_partition.h"
 #include "esp_memory_utils.h"
@@ -485,15 +486,19 @@ static esp_err_t msc_storage_mount(msc_storage_obj_t *storage)
     char drv[3] = {(char)('0' + pdrv), ':', 0};
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
-    esp_vfs_fat_conf_t conf = {
+    const esp_vfs_fat_conf_t conf = {
         .base_path = base_path,
         .fat_drive = drv,
         .max_files = max_files,
     };
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ret = esp_vfs_fat_register(&conf, &fs);
+#else
     ret = esp_vfs_fat_register_cfg(&conf, &fs);
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #else
     ret = esp_vfs_fat_register(base_path, drv, max_files, &fs);
-#endif
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     if (ret == ESP_ERR_INVALID_STATE) {
         ESP_LOGD(TAG, "VFS FAT already registered");
     } else if (ret != ESP_OK) {
@@ -1133,15 +1138,19 @@ esp_err_t tinyusb_msc_format_storage(tinyusb_msc_storage_handle_t handle)
     // Register FAT FS with VFS component
     char drv[3] = {(char)('0' + pdrv), ':', 0}; // FATFS drive specificator; if only one drive is used, can be an empty string
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
-    esp_vfs_fat_conf_t conf = {
+    const esp_vfs_fat_conf_t conf = {
         .base_path = base_path,
         .fat_drive = drv,
         .max_files = max_files,
     };
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ESP_RETURN_ON_ERROR(esp_vfs_fat_register(&conf, &fs), TAG, "VFS FAT register failed");
+#else
     ESP_RETURN_ON_ERROR(esp_vfs_fat_register_cfg(&conf, &fs), TAG, "VFS FAT register failed");
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #else
     ESP_RETURN_ON_ERROR(esp_vfs_fat_register(base_path, drv, max_files, &fs), TAG, "VFS FAT register failed");
-#endif
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     // to make format, we need to mount the fs
     // Mount the FAT FS
     ret = vfs_fat_mount(drv, fs, true);

--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Validate SCSI READ CAPACITY `block_size` (power-of-two in [512, 4096]) and refuse FatFS `GET_SECTOR_SIZE` truncation that can overflow `fs->win` (BBP 574)
+- Use `esp_vfs_fat_register` instead of the deprecated `esp_vfs_fat_register_cfg` for ESP-IDF v6.0 and higher
 
 ## [1.2.0] - 2026-04-08
 

--- a/host/class/msc/usb_host_msc/src/msc_host_vfs.c
+++ b/host/class/msc/usb_host_msc/src/msc_host_vfs.c
@@ -102,15 +102,19 @@ esp_err_t msc_host_vfs_register(msc_host_device_handle_t device,
     vfs->pdrv = pdrv;
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
-    esp_vfs_fat_conf_t conf = {
+    const esp_vfs_fat_conf_t conf = {
         .base_path = base_path,
         .fat_drive = drive,
         .max_files = mount_config->max_files,
     };
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    MSC_GOTO_ON_ERROR( esp_vfs_fat_register(&conf, &fs) );
+#else
     MSC_GOTO_ON_ERROR( esp_vfs_fat_register_cfg(&conf, &fs) );
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #else
     MSC_GOTO_ON_ERROR( esp_vfs_fat_register(base_path, drive, mount_config->max_files, &fs) );
-#endif
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 
     FRESULT fresult = f_mount(fs, drive, 1);
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

ESP-IDF v6.0 renamed the FatFS VFS registration API back to `esp_vfs_fat_register(const esp_vfs_fat_conf_t *conf, FATFS **out_fs)` and deprecated `esp_vfs_fat_register_cfg`, which was introduced in IDF v5.3. Both `esp_tinyusb` (MSC device) and `usb_host_msc` (MSC host) still called the now-deprecated `_cfg` variant, causing deprecation warnings when built against IDF v6+.

This PR adds a version-gated dispatch so each component calls the correct API for the IDF version it's built against:

| ESP-IDF version | API called |
|---|---|
| `>= 6.0.0` | `esp_vfs_fat_register(&conf, &fs)` |
| `5.3.0 – 5.x` | `esp_vfs_fat_register_cfg(&conf, &fs)` |
| `< 5.3.0` | legacy `esp_vfs_fat_register(base_path, drv, max_files, &fs)` |

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time API selection only; mount/format logic and error handling are unchanged aside from the register symbol used on IDF v6+.
> 
> **Overview**
> Updates **MSC device** (`esp_tinyusb`) and **MSC host** (`usb_host_msc`) FatFS VFS registration so builds against ESP-IDF v6.0+ call `esp_vfs_fat_register(&conf, &fs)` instead of the deprecated `esp_vfs_fat_register_cfg`, eliminating deprecation warnings while keeping older IDF behavior unchanged.
> 
> The same **version-gated dispatch** is applied in `tinyusb_msc.c` (app mount and format paths) and `msc_host_vfs.c` (VFS register): IDF **≥ 6.0** uses the new register API, **5.3–5.x** still uses `_cfg`, and **&lt; 5.3** keeps the legacy positional `esp_vfs_fat_register`. Config structs are marked `const`, and both components’ unreleased changelogs note the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71075c4209e97def690128b1e646676e260129c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->