### PR TITLE
feat(msc_host): add LUN discovery and explicit selection (IEC-606)

### DIFF
--- a/host/class/msc/usb_host_msc/CHANGELOG.md
+++ b/host/class/msc/usb_host_msc/CHANGELOG.md
@@ -6,8 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added `msc_host_install_device_lun` to install an application-selected LUN without falling back to another slot, while preserving LUN 0 behavior in `msc_host_install_device`
+- Added `msc_host_probe_luns` and `msc_host_lun_info_t` to report ready and failed LUNs through a temporary discovery session, leaving candidate selection to the application
+
 ### Fixed
 
+- Skip LUNs reporting MEDIUM NOT PRESENT during discovery without consuming the readiness retry window, while retaining installation and reset recovery retries
+- Reset BOT state and synchronize both bulk endpoints when opening a session, allowing LUN switching and retries after failed probes or installations
+- Wait for USB Host to retire completed bulk transfers before releasing an interface, keeping the session owned until cleanup completes
+- Keep temporary discovery handles out of MSC events
+- Keep malformed BOT status and USB transfer errors distinct from SCSI command failures during LUN discovery
+- Address the explicitly installed LUN in SCSI commands and reset recovery so multi-slot card readers can access media outside LUN 0
+- Read initialization sense data once per failed readiness command so retries retain the reported device status
 - Validate SCSI READ CAPACITY `block_size` (power-of-two in [512, 4096]) and refuse FatFS `GET_SECTOR_SIZE` truncation that can overflow `fs->win` (BBP 574)
 
 ## [1.2.0] - 2026-04-08

--- a/host/class/msc/usb_host_msc/README.md
+++ b/host/class/msc/usb_host_msc/README.md
@@ -12,11 +12,104 @@ MSC driver allows access to USB flash drivers using the BOT (Bulk-Only Transport
 - USB Host Library events have to be handled by invoking `usb_host_lib_handle_events` periodically. In general, an application should spawn a dedicated task handle USB Host Library events. However, in order to save RAM, an already existing task can also be used to call `usb_host_lib_handle_events`.
 - Mass Storage Class driver is installed by calling `usb_msc_install` function along side with configuration.
 - Supplied configuration contains user provided callback function invoked whenever MSC device is connected/disconnected and optional parameters for creating background task handling MSC related events. Alternatively, user can call `usb_msc_handle_events` function from already existing task.
-- After receiving `MSC_DEVICE_CONNECTED` event, user has to install device with `usb_msc_install_device` function, obtaining MSC device handle.
+- After receiving `MSC_DEVICE_CONNECTED` event, the application installs LUN 0 with `msc_host_install_device`, or chooses another LUN as described below, obtaining an MSC device handle. Perform this blocking operation outside the event callback while another task continues USB event processing.
 - USB descriptors can be printed out with `usb_msc_print_descriptors` and general information about MSC device retrieved with `from usb_msc_get_device_info` function.
 - Obtained device handle is then used in helper function `usb_msc_vfs_register` mounting USB Disk to Virtual filesystem.
 - At this point, standard C functions for accessing storage (`fopen`, `fwrite`, `fread`, `mkdir` etc.) can be carried out.
 - In order to uninstall the whole USB stack, deinitializing counterparts to functions above has to be called in reverse order.
+
+## Logical units
+
+Multi-slot card readers can expose each slot as a different logical unit (LUN). The application decides which LUN to use:
+
+- `msc_host_install_device(address, &device)` keeps the original LUN 0 selection without issuing `GET_MAX_LUN` or searching other slots.
+- `msc_host_install_device_lun(address, lun, &device)` installs exactly the specified LUN in the range 0..15. LUN 0 does not require `GET_MAX_LUN`; a nonzero LUN is checked against the device's response. Installation never falls back to another LUN if the requested one is absent, unready, or fails initialization.
+- `msc_host_probe_luns(address, timeout_ms, &info)` opens a temporary session, queries `GET_MAX_LUN`, and scans all advertised LUNs before closing the session. It does not install, mount, or select a LUN. A legal `GET_MAX_LUN` STALL means only LUN 0 is advertised; malformed responses and USB transport errors fail the operation.
+
+Each installation or probe starts with a Bulk-Only Mass Storage Reset and clears both bulk endpoint halts before sending SCSI commands. This synchronizes the device with the newly allocated host pipes, including after a previous session failed or another LUN was uninstalled. Uninstallation releases the session without sending commands to the device, so it also works after disconnection.
+
+Use the probe result only when the call returns `ESP_OK`. `msc_host_lun_info_t` contains:
+
+| Field             | Meaning                                                                                                                                 |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_lun`         | Highest advertised LUN, not the number of inserted cards.                                                                               |
+| `ready_lun_mask`  | Bit n is set when LUN n passes TEST UNIT READY and READ CAPACITY with a power-of-two sector size from 512 through 4096 bytes.           |
+| `failed_lun_mask` | Bit n is set when LUN n fails INQUIRY or READ CAPACITY, reports a non-retryable readiness error, or reports an unsupported sector size. |
+
+An advertised LUN with neither bit set remained unready, including an empty slot. A complete probe with no ready LUNs still returns `ESP_OK`. A failed probe clears the output, so it cannot be used as a partial list of candidates. Ready means a usable block-device candidate; the probe does not check filesystems or write permissions, and does not format any media.
+
+A zero `timeout_ms` scans every advertised LUN once. LUNs reporting NOT READY / MEDIUM NOT PRESENT (`02/3A/xx`) are skipped without retrying, with neither result bit set. A nonzero timeout gives other retryable readiness failures one shared retry budget; finding a ready LUN does not end the scan. The probe returns as soon as all LUNs are resolved, so an empty slot does not delay a ready candidate until the budget expires. Each USB transfer retains its own timeout, so this budget is not a strict end-to-end deadline. Installation and reset recovery retain their existing readiness retry behavior.
+
+Insert the cards before probing or installing, and keep the reader connected and the cards unchanged through selection and installation. Probe results describe observations during the call, not persistent media identities. Explicit installation revalidates the selected LUN. Only one LUN of the selected MSC interface can be installed at a time. Its binding stays fixed for I/O and reset recovery until uninstall. To choose a different LUN or change cards, first unmount the filesystem and uninstall the device, then install again. A filesystem mount failure does not switch LUNs automatically.
+
+Probe only before installation; probing a device that is already installed returns `ESP_ERR_INVALID_STATE`. Serialize probing, installation, and uninstallation in the application, and stop I/O before uninstalling. These calls block and must not run in the MSC event callback; another task must continue processing USB events. Temporary probe handles are not delivered in MSC events.
+
+### Application selection examples
+
+These independent snippets run in an application function returning `esp_err_t`. Include `usb/msc_host.h`; `address` is the connected device address, and `device` is a valid `msc_host_device_handle_t *` output argument with `*device` initially NULL. Mount the filesystem after the selected installation succeeds.
+
+**Known slot: install LUN 1 directly.** No preliminary discovery is needed when the application already knows the required slot.
+
+```c
+return msc_host_install_device_lun(address, 1, device);
+```
+
+**Accept a unique candidate automatically.** No ready candidates returns `ESP_ERR_NOT_FOUND`; multiple candidates require an application decision, represented here by `ESP_ERR_INVALID_STATE`.
+
+```c
+msc_host_lun_info_t info;
+esp_err_t err = msc_host_probe_luns(address, 1000, &info);
+if (err != ESP_OK) {
+    return err;
+}
+uint16_t candidates = info.ready_lun_mask;
+if (candidates == 0) {
+    return ESP_ERR_NOT_FOUND;
+}
+if ((candidates & (candidates - 1U)) != 0) {
+    return ESP_ERR_INVALID_STATE; // Application must choose among candidates.
+}
+uint8_t lun = 0;
+while ((candidates & (1U << lun)) == 0) {
+    ++lun;
+}
+return msc_host_install_device_lun(address, lun, device);
+```
+
+**Choose among multiple candidates in the application.** The application may use a configured slot, a priority rule, or a user choice. Here, `chosen_lun` is an application-supplied `uint8_t` input; the completed probe confirms that it is a ready candidate.
+
+```c
+if (chosen_lun > 15) {
+    return ESP_ERR_INVALID_ARG;
+}
+msc_host_lun_info_t info;
+esp_err_t err = msc_host_probe_luns(address, 1000, &info);
+if (err != ESP_OK) {
+    return err;
+}
+if ((info.ready_lun_mask & (1U << chosen_lun)) == 0) {
+    return ESP_ERR_NOT_FOUND;
+}
+return msc_host_install_device_lun(address, chosen_lun, device);
+```
+
+**Explicitly accept any ready candidate.** This application policy chooses the lowest set bit. The driver itself does not apply this preference.
+
+```c
+msc_host_lun_info_t info;
+esp_err_t err = msc_host_probe_luns(address, 1000, &info);
+if (err != ESP_OK) {
+    return err;
+}
+if (info.ready_lun_mask == 0) {
+    return ESP_ERR_NOT_FOUND;
+}
+uint8_t lun = 0;
+while ((info.ready_lun_mask & (1U << lun)) == 0) {
+    ++lun;
+}
+return msc_host_install_device_lun(address, lun, device);
+```
 
 ## Performance tuning
 

--- a/host/class/msc/usb_host_msc/host_test/README.md
+++ b/host/class/msc/usb_host_msc/host_test/README.md
@@ -3,6 +3,11 @@
 This directory contains test code for `USB Host MSC` driver. Namely:
 
 - Simple public API call with mocked USB component to test Linux build and Cmock run for this class driver
+- Legacy installation of LUN 0 without GET_MAX_LUN, and explicit installation of a configured LUN without probing other slots or falling back
+- Complete LUN discovery followed by application selection: accepting a unique candidate, choosing among multiple candidates, or explicitly accepting the lowest-numbered ready candidate
+- Selected-LUN preservation during I/O and reset recovery; GET_MAX_LUN STALL, malformed responses, parameter validation, and rejection of competing probe/install operations
+- Ready and failed LUN masks, empty slots, supported sector sizes, one-pass and shared-window retries, rejection of partial results after transport errors, and temporary-session cleanup
+- BOT and endpoint synchronization across LUN changes and failed sessions; cleanup after transport initialization failures and pending USB callback bookkeeping
 
 Tests are written using [Catch2](https://github.com/catchorg/Catch2) test framework, use CMock, so you must install Ruby on your machine to run them.
 

--- a/host/class/msc/usb_host_msc/host_test/main/test_lun.cpp
+++ b/host/class/msc/usb_host_msc/host_test/main/test_lun.cpp
@@ -1,0 +1,1027 @@
+/*
+ * SPDX-FileCopyrightText: 2026 bigtreetech
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstring>
+#include <catch2/catch_test_macros.hpp>
+
+#include "usb/msc_host.h"
+#include "esp_private/msc_scsi_bot.h"
+#include "mock_add_usb_device.h"
+#include "freertos/task.h"
+
+extern "C" {
+#include "Mockusb_host.h"
+}
+
+namespace {
+
+enum : uint8_t { TEST_UNIT_READY = 0x00, REQUEST_SENSE = 0x03, INQUIRY = 0x12,
+                 READ_CAPACITY = 0x25, READ10 = 0x28, WRITE10 = 0x2a
+               };
+
+enum class CswFault { NONE, SIGNATURE, TAG, RESERVED_STATUS, PHASE_ERROR, SHORT_RESPONSE, RESIDUE };
+
+const usb_device_desc_t device_descriptor = {
+    .bLength = sizeof(usb_device_desc_t),
+    .bDescriptorType = USB_B_DESCRIPTOR_TYPE_DEVICE,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = 0,
+    .bDeviceSubClass = 0,
+    .bDeviceProtocol = 0,
+    .bMaxPacketSize0 = 64,
+    .idVendor = 0,
+    .idProduct = 0,
+    .bcdDevice = 0,
+    .iManufacturer = 0,
+    .iProduct = 0,
+    .iSerialNumber = 0,
+    .bNumConfigurations = 1,
+};
+
+const struct __attribute__((packed))
+{
+    usb_config_desc_t config;
+    usb_intf_desc_t interface;
+    usb_ep_desc_t in, out;
+} descriptors = {
+    .config = {
+        .bLength = 9, .bDescriptorType = 2, .wTotalLength = 32, .bNumInterfaces = 1,
+        .bConfigurationValue = 1, .iConfiguration = 0, .bmAttributes = 0x80, .bMaxPower = 50
+    },
+    .interface = {
+        .bLength = 9, .bDescriptorType = 4, .bInterfaceNumber = 3, .bAlternateSetting = 0,
+        .bNumEndpoints = 2, .bInterfaceClass = 8, .bInterfaceSubClass = 6, .bInterfaceProtocol = 0x50, .iInterface = 0
+    },
+    .in = { .bLength = 7, .bDescriptorType = 5, .bEndpointAddress = 0x81, .bmAttributes = 2, .wMaxPacketSize = 64, .bInterval = 0 },
+    .out = { .bLength = 7, .bDescriptorType = 5, .bEndpointAddress = 0x02, .bmAttributes = 2, .wMaxPacketSize = 64, .bInterval = 0 },
+};
+
+// Only BOT responses are supplied here; use the existing USB mock for device
+// ownership, transfer allocation and the actual MSC driver for all commands.
+class LunFixture {
+public:
+    LunFixture()
+    {
+        active = this;
+        Mockusb_host_Init();
+        usb_host_mock_dev_list_init();
+        REQUIRE(ESP_OK == usb_host_mock_add_device(1, &device_descriptor, &descriptors.config, USB_SPEED_FULL));
+        usb_host_client_register_Stub(register_callback);
+        usb_host_client_deregister_Stub(usb_host_client_deregister_mock_callback);
+        usb_host_device_open_Stub(open_callback);
+        usb_host_device_close_Stub(close_callback);
+        usb_host_get_active_config_descriptor_Stub(usb_host_get_active_config_descriptor_mock_callback);
+        usb_host_interface_claim_Stub(claim_callback);
+        usb_host_interface_release_Stub(release_callback);
+        usb_host_transfer_alloc_Stub(alloc_callback);
+        usb_host_transfer_free_Stub(free_callback);
+        usb_host_endpoint_halt_IgnoreAndReturn(ESP_OK);
+        usb_host_endpoint_flush_IgnoreAndReturn(ESP_OK);
+        usb_host_endpoint_clear_Stub(endpoint_clear_callback);
+        usb_host_transfer_submit_Stub(bulk_callback);
+        usb_host_transfer_submit_control_Stub(control_callback);
+
+        msc_host_driver_config_t config = {};
+        config.callback = [](const msc_host_event_t *, void *arg) {
+            ++static_cast<LunFixture *>(arg)->public_events;
+        };
+        config.callback_arg = this;
+        REQUIRE(ESP_OK == msc_host_install(&config));
+        for (auto &size : sector_sizes) {
+            size = 512;
+        }
+    }
+
+    ~LunFixture()
+    {
+        if (device) {
+            CHECK(ESP_OK == msc_host_uninstall_device(device));
+        }
+        CHECK(ESP_OK == msc_host_uninstall());
+        check_closed();
+        Mockusb_host_Verify();
+        Mockusb_host_Destroy();
+        active = nullptr;
+    }
+
+    msc_host_device_handle_t device = nullptr;
+    uint8_t max_lun = 1;
+    uint16_t ready_luns = 1 << 1;
+    uint16_t inquiry_fail_luns = 0, tur_fail_luns = 0, capacity_fail_luns = 0;
+    uint32_t sector_sizes[16] = {};
+    uint8_t delayed_lun = 0xff;
+    uint16_t pending_luns = 0;
+    uint8_t pending_sense_key = 0x02, empty_sense_ascq = 0;
+    int transport_error_lun = -1;
+    uint8_t transport_error_opcode = TEST_UNIT_READY;
+    CswFault csw_fault = CswFault::NONE;
+    int fixed_lun = -1;
+    bool fail_read = false;
+    usb_transfer_status_t get_max_status = USB_TRANSFER_STATUS_COMPLETED;
+    usb_transfer_status_t reset_status = USB_TRANSFER_STATUS_COMPLETED;
+    int get_max_length = USB_SETUP_PACKET_SIZE + 1;
+    unsigned get_max_count = 0, reset_count = 0, sense_count = 0;
+    unsigned ready_count[16] = {}, inquiry_count[16] = {}, capacity_count[16] = {};
+    unsigned open_calls = 0, open_devices = 0, claims = 0, transfers = 0;
+    esp_err_t claim_result = ESP_OK;
+    unsigned release_calls = 0, public_events = 0, probe_lifetime_checks = 0;
+    bool release_pending_once = false;
+    bool inject_probe_events = false;
+    // Packet-parity contract for these 64-byte endpoints, not a USB bus simulator.
+    uint8_t host_pid[2] = {}, device_pid[2] = {}; // OUT, IN
+    unsigned bulk_count = 0, clear_count = 0;
+    struct {
+        uint8_t endpoint;
+        unsigned bulk_count;
+    } clears[8] = {};
+    uint8_t clear_fail_endpoint = 0;
+
+    void check_closed() const
+    {
+        CHECK(open_devices == 0);
+        CHECK(claims == 0);
+        CHECK(transfers == 0);
+    }
+
+private:
+    static LunFixture *active;
+    enum { CBW, DATA, CSW, RESET_REQUIRED } phase = CBW;
+    uint32_t tag = 0, data_length = 0;
+    uint8_t opcode = 0, lun = 0, status = 0;
+    uint8_t sense_key = 0, sense_asc = 0, sense_ascq = 0;
+    usb_host_client_event_cb_t client_event_callback = nullptr;
+    void *client_event_arg = nullptr;
+
+    void disconnect(usb_device_handle_t handle)
+    {
+        usb_host_client_event_msg_t event = {};
+        event.event = USB_HOST_CLIENT_EVENT_DEV_GONE;
+        event.dev_gone.dev_hdl = handle;
+        client_event_callback(&event, client_event_arg);
+    }
+
+    static esp_err_t register_callback(const usb_host_client_config_t *config,
+                                       usb_host_client_handle_t *handle, int count)
+    {
+        active->client_event_callback = config->async.client_event_callback;
+        active->client_event_arg = config->async.callback_arg;
+        return usb_host_client_register_mock_callback(config, handle, count);
+    }
+
+    static esp_err_t open_callback(usb_host_client_handle_t client, uint8_t address,
+                                   usb_device_handle_t *handle, int count)
+    {
+        ++active->open_calls;
+        // The shared mock omits this real USB Host rule: the same client
+        // cannot open the same device twice. This fixture has one device.
+        if (active->open_devices > 0) {
+            return ESP_ERR_INVALID_STATE;
+        }
+        esp_err_t err = usb_host_device_open_mock_callback(client, address, handle, count);
+        if (err == ESP_OK) {
+            ++active->open_devices;
+        }
+        return err;
+    }
+
+    static esp_err_t close_callback(usb_host_client_handle_t client, usb_device_handle_t handle, int count)
+    {
+        if (active->claims > 0) {
+            return ESP_ERR_INVALID_STATE;
+        }
+        esp_err_t err = usb_host_device_close_mock_callback(client, handle, count);
+        if (err == ESP_OK) {
+            REQUIRE(active->open_devices > 0);
+            --active->open_devices;
+        }
+        return err;
+    }
+
+    static esp_err_t claim_callback(usb_host_client_handle_t, usb_device_handle_t, uint8_t interface,
+                                    uint8_t alternate, int)
+    {
+        CHECK(interface == 3);
+        CHECK(alternate == 0);
+        CHECK(active->claims == 0);
+        if (active->claim_result != ESP_OK) {
+            return active->claim_result;
+        }
+        // New host channels start at DATA0; the connected device retains its PID.
+        active->host_pid[0] = active->host_pid[1] = 0;
+        ++active->claims;
+        return ESP_OK;
+    }
+
+    static esp_err_t release_callback(usb_host_client_handle_t, usb_device_handle_t, uint8_t interface, int)
+    {
+        CHECK(interface == 3);
+        ++active->release_calls;
+        REQUIRE(active->claims > 0);
+        if (active->release_pending_once) {
+            // The transfer callback can wake the caller before USB Host has
+            // finished updating its in-flight transfer count.
+            active->release_pending_once = false;
+            return ESP_ERR_INVALID_STATE;
+        }
+        --active->claims;
+        return ESP_OK;
+    }
+
+    static esp_err_t endpoint_clear_callback(usb_device_handle_t, uint8_t endpoint, int)
+    {
+        CHECK((endpoint == 0x81 || endpoint == 0x02));
+        active->host_pid[(endpoint & 0x80) != 0] = 0;
+        return ESP_OK;
+    }
+
+    static esp_err_t alloc_callback(size_t size, int packets, usb_transfer_t **transfer, int count)
+    {
+        esp_err_t err = usb_host_transfer_alloc_mock_callback(size, packets, transfer, count);
+        if (err == ESP_OK) {
+            ++active->transfers;
+        }
+        return err;
+    }
+
+    static esp_err_t free_callback(usb_transfer_t *transfer, int count)
+    {
+        if (transfer) {
+            REQUIRE(active->transfers > 0);
+            --active->transfers;
+        }
+        return usb_host_transfer_free_mock_callback(transfer, count);
+    }
+
+    static esp_err_t control_callback(usb_host_client_handle_t, usb_transfer_t *transfer, int)
+    {
+        auto &f = *active;
+        usb_setup_packet_t setup;
+        std::memcpy(&setup, transfer->data_buffer, sizeof(setup));
+        REQUIRE(transfer->bEndpointAddress == 0);
+        transfer->status = USB_TRANSFER_STATUS_COMPLETED;
+        transfer->actual_num_bytes = transfer->num_bytes;
+        if (setup.bRequest == 0xfe) {
+            CHECK(setup.bmRequestType == 0xa1);
+            CHECK(setup.wValue == 0);
+            CHECK(setup.wIndex == 3);
+            CHECK(setup.wLength == 1);
+            CHECK(transfer->num_bytes == USB_SETUP_PACKET_SIZE + 1);
+            ++f.get_max_count;
+            if (f.inject_probe_events) {
+                ++f.probe_lifetime_checks;
+                REQUIRE(ESP_ERR_INVALID_STATE == msc_host_uninstall());
+                REQUIRE(f.client_event_callback != nullptr);
+                f.disconnect(transfer->device_handle);
+            }
+            transfer->status = f.get_max_status;
+            transfer->actual_num_bytes = f.get_max_length;
+            transfer->data_buffer[USB_SETUP_PACKET_SIZE] = f.max_lun;
+        } else if (setup.bRequest == 0xff) {
+            CHECK(setup.bmRequestType == 0x21);
+            CHECK(setup.wIndex == 3);
+            CHECK(setup.wLength == 0);
+            ++f.reset_count;
+            transfer->status = f.reset_status;
+            if (transfer->status == USB_TRANSFER_STATUS_COMPLETED) {
+                f.phase = CBW;
+            }
+        } else {
+            CHECK(setup.bRequest == USB_B_REQUEST_CLEAR_FEATURE);
+            CHECK(setup.bmRequestType == 2);
+            CHECK((setup.wIndex == 0x81 || setup.wIndex == 0x02));
+            REQUIRE(f.clear_count < sizeof(f.clears) / sizeof(f.clears[0]));
+            f.clears[f.clear_count].endpoint = setup.wIndex;
+            f.clears[f.clear_count++].bulk_count = f.bulk_count;
+            if (setup.wIndex == f.clear_fail_endpoint) {
+                transfer->status = USB_TRANSFER_STATUS_ERROR;
+            } else {
+                f.device_pid[(setup.wIndex & 0x80) != 0] = 0;
+            }
+        }
+        transfer->callback(transfer);
+        return ESP_OK;
+    }
+
+    static esp_err_t bulk_callback(usb_transfer_t *transfer, int)
+    {
+        auto &f = *active;
+        const unsigned ep = (transfer->bEndpointAddress & 0x80) != 0;
+        if (f.host_pid[ep] != f.device_pid[ep] || f.phase == RESET_REQUIRED) {
+            // Return through the normal transfer path instead of throwing a
+            // Catch assertion through the driver's C stack.
+            CHECK(f.host_pid[ep] == f.device_pid[ep]);
+            transfer->status = USB_TRANSFER_STATUS_STALL;
+            transfer->actual_num_bytes = 0;
+            transfer->callback(transfer);
+            return ESP_OK;
+        }
+        ++f.bulk_count;
+        uint8_t *data = transfer->data_buffer;
+        transfer->status = USB_TRANSFER_STATUS_COMPLETED;
+        transfer->actual_num_bytes = transfer->num_bytes;
+
+        if (f.phase == CBW) {
+            REQUIRE(transfer->bEndpointAddress == 0x02);
+            REQUIRE(transfer->num_bytes == 31);
+            CHECK(std::memcmp(data, "USBC", 4) == 0);
+            std::memcpy(&f.tag, data + 4, sizeof(f.tag));
+            std::memcpy(&f.data_length, data + 8, sizeof(f.data_length));
+            f.lun = data[13];
+            f.opcode = data[15];
+            REQUIRE(f.lun < 16);
+            if (f.fixed_lun >= 0) {
+                CHECK(f.lun == f.fixed_lun);
+            }
+            f.status = 0;
+            if (f.lun == f.transport_error_lun && f.opcode == f.transport_error_opcode) {
+                transfer->status = USB_TRANSFER_STATUS_ERROR;
+                transfer->actual_num_bytes = 0;
+                transfer->callback(transfer);
+                return ESP_OK;
+            }
+            if (f.opcode == TEST_UNIT_READY) {
+                ++f.ready_count[f.lun];
+                if (f.lun == f.delayed_lun && f.ready_count[f.lun] > 1) {
+                    f.ready_luns |= 1 << f.lun;
+                }
+                f.status = (f.ready_luns & (1 << f.lun)) ? 0 : 1;
+                if (f.status) {
+                    f.sense_key = 0x02;
+                    f.sense_asc = 0x3a; // NOT READY, MEDIUM NOT PRESENT
+                    f.sense_ascq = f.empty_sense_ascq;
+                    if (f.lun == f.delayed_lun || (f.pending_luns & (1 << f.lun))) {
+                        f.sense_key = f.pending_sense_key;
+                        // Becoming ready or NOT READY TO READY TRANSITION.
+                        f.sense_asc = f.pending_sense_key == 0x06 ? 0x28 : 0x04;
+                        f.sense_ascq = f.pending_sense_key == 0x06 ? 0x00 : 0x01;
+                    }
+                }
+                if (f.tur_fail_luns & (1 << f.lun)) {
+                    f.status = 1;
+                    f.sense_key = 0x03;
+                    f.sense_asc = 0x11;
+                }
+            } else if (f.opcode == INQUIRY) {
+                ++f.inquiry_count[f.lun];
+                f.status = (f.inquiry_fail_luns & (1 << f.lun)) ? 1 : 0;
+            } else if (f.opcode == READ_CAPACITY) {
+                ++f.capacity_count[f.lun];
+                f.status = (f.capacity_fail_luns & (1 << f.lun)) ? 1 : 0;
+            } else if (f.opcode == READ10 && f.fail_read) {
+                f.fail_read = false;
+                f.status = 1;
+                f.sense_key = 0x03;
+                f.sense_asc = 0x11; // MEDIUM ERROR, UNRECOVERED READ ERROR
+            }
+            f.phase = f.data_length ? DATA : CSW;
+        } else if (f.phase == DATA) {
+            REQUIRE(f.data_length <= transfer->data_buffer_size);
+            if (f.opcode != WRITE10) {
+                REQUIRE(transfer->bEndpointAddress == 0x81);
+                std::memset(data, 0, f.data_length);
+            }
+            switch (f.opcode) {
+            case READ_CAPACITY:
+                REQUIRE(f.data_length == 8);
+                CHECK((f.ready_luns & (1 << f.lun)) != 0);
+                data[3] = 63; // Last LBA, big endian
+                for (unsigned i = 0; i < 4; ++i) {
+                    data[4 + i] = f.sector_sizes[f.lun] >> (8 * (3 - i));
+                }
+                break;
+            case REQUEST_SENSE:
+                REQUIRE(f.data_length == 18);
+                ++f.sense_count;
+                data[0] = 0x70;
+                data[2] = f.sense_key;
+                data[7] = 10;
+                data[12] = f.sense_asc;
+                data[13] = f.sense_ascq;
+                f.sense_key = f.sense_asc = f.sense_ascq = 0;
+                break;
+            case READ10:
+                std::memset(data, 0xa5, f.data_length);
+                break;
+            case WRITE10:
+                CHECK(transfer->bEndpointAddress == 0x02);
+                break;
+            case INQUIRY:
+                break;
+            default:
+                FAIL("Unexpected SCSI data phase");
+            }
+            transfer->actual_num_bytes = f.data_length;
+            f.phase = CSW;
+        } else {
+            REQUIRE(transfer->bEndpointAddress == 0x81);
+            std::memcpy(data, "USBS", 4);
+            std::memcpy(data + 4, &f.tag, sizeof(f.tag));
+            std::memset(data + 8, 0, 4);
+            data[12] = f.status;
+            transfer->actual_num_bytes = 13;
+            f.phase = CBW;
+            if (f.lun == 1 && f.opcode == TEST_UNIT_READY) {
+                switch (f.csw_fault) {
+                case CswFault::SIGNATURE:
+                    data[0] ^= 1;
+                    break;
+                case CswFault::TAG:
+                    data[4] ^= 1;
+                    break;
+                case CswFault::RESERVED_STATUS:
+                    data[12] = 3;
+                    break;
+                case CswFault::PHASE_ERROR:
+                    data[12] = 2;
+                    break;
+                case CswFault::SHORT_RESPONSE:
+                    transfer->actual_num_bytes = 12;
+                    break;
+                case CswFault::RESIDUE:
+                    data[8] = 1;
+                    break;
+                case CswFault::NONE:
+                    break;
+                }
+                if (f.csw_fault != CswFault::NONE) {
+                    f.phase = RESET_REQUIRED;
+                }
+            }
+        }
+        if (transfer->status == USB_TRANSFER_STATUS_COMPLETED) {
+            const unsigned parity = (static_cast<unsigned>(transfer->actual_num_bytes) + 63) / 64 % 2;
+            f.host_pid[ep] ^= parity;
+            f.device_pid[ep] ^= parity;
+        }
+        transfer->callback(transfer);
+        return ESP_OK;
+    }
+};
+
+LunFixture *LunFixture::active = nullptr;
+
+} // namespace
+
+TEST_CASE_METHOD(LunFixture, "MSC probes an empty slot and leaves LUN selection to the caller", "[msc][lun]")
+{
+    msc_host_lun_info_t info = {};
+    const TickType_t started = xTaskGetTickCount();
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 5000, &info));
+    CHECK(xTaskGetTickCount() - started < pdMS_TO_TICKS(2500));
+    CHECK(info.max_lun == 1);
+    REQUIRE(info.ready_lun_mask == 2);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(get_max_count == 1);
+    CHECK(ready_count[0] == 1);
+    CHECK(ready_count[1] == 1);
+    CHECK(sense_count == 1);
+    check_closed();
+
+    // The application accepts the sole candidate and explicitly installs it.
+    const uint8_t selected_lun = __builtin_ctz(static_cast<unsigned>(info.ready_lun_mask));
+    fixed_lun = selected_lun;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, selected_lun, &device));
+    uint8_t sector[512] = {};
+    REQUIRE(ESP_OK == scsi_cmd_read10(device, sector, 0, 1, sizeof(sector)));
+    CHECK(sector[0] == 0xa5);
+    REQUIRE(ESP_OK == scsi_cmd_write10(device, sector, 0, 1, sizeof(sector)));
+
+    const unsigned previous_sense_count = sense_count;
+    fail_read = true;
+    CHECK(ESP_FAIL == scsi_cmd_read10(device, sector, 0, 1, sizeof(sector)));
+    CHECK(sense_count > previous_sense_count);
+
+    // Even if the formerly empty slot becomes ready, recovery must retain the
+    // mounted slot and must not issue GET_MAX_LUN or probe LUN 0 again.
+    ready_luns |= 1;
+    const unsigned previous_lun0_count = ready_count[0];
+    const unsigned previous_reset_count = reset_count;
+    REQUIRE(ESP_OK == msc_host_reset_recovery(device));
+    CHECK(reset_count == previous_reset_count + 1);
+    CHECK(get_max_count == 2);
+    CHECK(ready_count[0] == previous_lun0_count);
+    REQUIRE(ESP_OK == scsi_cmd_read10(device, sector, 0, 1, sizeof(sector)));
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC reports both ready LUNs without choosing one", "[msc][lun]")
+{
+    ready_luns = 3;
+    msc_host_lun_info_t info = {};
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.max_lun == 1);
+    REQUIRE(info.ready_lun_mask == 3);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(capacity_count[0] == 1);
+    CHECK(capacity_count[1] == 1);
+    check_closed();
+
+    uint8_t selected_lun = 0;
+    SECTION("Application policy selects LUN one") {
+        selected_lun = 1;
+    }
+    SECTION("Application accepts any candidate and chooses the lowest set bit") {
+        selected_lun = __builtin_ctz(static_cast<unsigned>(info.ready_lun_mask));
+        CHECK(selected_lun == 0);
+    }
+    fixed_lun = selected_lun;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, selected_lun, &device));
+    CHECK(ready_count[selected_lun] == 2);
+    CHECK(ready_count[1 - selected_lun] == 1);
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC legacy install keeps LUN zero without GET_MAX_LUN", "[msc][lun]")
+{
+    ready_luns = 3;
+    fixed_lun = 0;
+    get_max_status = USB_TRANSFER_STATUS_NO_DEVICE; // Must never be requested.
+    REQUIRE(ESP_OK == msc_host_install_device(1, &device));
+    CHECK(get_max_count == 0);
+    CHECK(ready_count[0] == 1);
+    CHECK(ready_count[1] == 0);
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC installs a configured LUN without preliminary discovery", "[msc][lun]")
+{
+    ready_luns = 3;
+    fixed_lun = 1;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+    CHECK(get_max_count == 1);
+    CHECK(inquiry_count[0] == 0);
+    CHECK(ready_count[0] == 0);
+    CHECK(capacity_count[0] == 0);
+    CHECK(ready_count[1] == 1);
+    CHECK(capacity_count[1] == 1);
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC can select another LUN after uninstalling", "[msc][lun]")
+{
+    ready_luns = 3;
+    fixed_lun = 0;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 0, &device));
+    REQUIRE(ESP_OK == msc_host_uninstall_device(device));
+    device = nullptr;
+    check_closed();
+
+    fixed_lun = 1;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+    CHECK(ready_count[0] == 1);
+    CHECK(ready_count[1] == 1);
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probes and explicitly installs LUN fifteen", "[msc][lun]")
+{
+    max_lun = 15;
+    ready_luns = 0x8000;
+    msc_host_lun_info_t info = {};
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.max_lun == 15);
+    CHECK(info.ready_lun_mask == 0x8000);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(sense_count == 15);
+    check_closed();
+
+    fixed_lun = 15;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 15, &device));
+    CHECK(ready_count[15] == 2);
+    for (unsigned i = 0; i < 15; ++i) {
+        CHECK(ready_count[i] == 1);
+    }
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probe accepts single-LUN GET_MAX_LUN STALL", "[msc][lun]")
+{
+    get_max_status = USB_TRANSFER_STATUS_STALL;
+    ready_luns = 1;
+    fixed_lun = 0;
+    msc_host_lun_info_t info = {};
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.max_lun == 0);
+    CHECK(info.ready_lun_mask == 1);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(get_max_count == 1);
+    CHECK(ready_count[0] == 1);
+    CHECK(ready_count[1] == 0);
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC rejects invalid GET_MAX_LUN responses", "[msc][lun]")
+{
+    esp_err_t expected = ESP_OK;
+    SECTION("Short response") {
+        get_max_length = USB_SETUP_PACKET_SIZE;
+        expected = ESP_ERR_INVALID_SIZE;
+    }
+    SECTION("Reserved LUN bits") {
+        max_lun = 16;
+        expected = ESP_ERR_INVALID_RESPONSE;
+    }
+    SECTION("Transport error is not a single-LUN STALL") {
+        get_max_status = USB_TRANSFER_STATUS_NO_DEVICE;
+        expected = ESP_ERR_MSC_INTERNAL;
+    }
+    msc_host_lun_info_t info = { .ready_lun_mask = 0xffff, .failed_lun_mask = 0xffff, .max_lun = 15 };
+    CHECK(expected == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.max_lun == 0);
+    CHECK(info.ready_lun_mask == 0);
+    CHECK(info.failed_lun_mask == 0);
+    check_closed();
+    CHECK(expected == msc_host_install_device_lun(1, 1, &device));
+    CHECK(device == nullptr);
+    CHECK(get_max_count == 2);
+    CHECK(ready_count[0] == 0);
+    CHECK(ready_count[1] == 0);
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC does not fall back from an explicit unavailable LUN", "[msc][lun]")
+{
+    ready_luns = 1;
+    SECTION("LUN exceeds GET_MAX_LUN") {
+        CHECK(ESP_ERR_NOT_FOUND == msc_host_install_device_lun(1, 2, &device));
+        CHECK(get_max_count == 1);
+        CHECK(ready_count[0] == 0);
+        CHECK(ready_count[1] == 0);
+    }
+    SECTION("GET_MAX_LUN STALL only permits LUN zero") {
+        get_max_status = USB_TRANSFER_STATUS_STALL;
+        CHECK(ESP_ERR_NOT_FOUND == msc_host_install_device_lun(1, 1, &device));
+        CHECK(get_max_count == 1);
+        CHECK(ready_count[0] == 0);
+        CHECK(ready_count[1] == 0);
+    }
+    SECTION("Specified LUN fails SCSI readiness") {
+        tur_fail_luns = 2;
+        fixed_lun = 1;
+        CHECK(ESP_OK != msc_host_install_device_lun(1, 1, &device));
+        CHECK(ready_count[0] == 0);
+        CHECK(ready_count[1] == 1);
+        CHECK(sense_count == 1);
+    }
+    SECTION("Specified LUN has unsupported sector geometry") {
+        ready_luns = 3;
+        sector_sizes[1] = 768;
+        fixed_lun = 1;
+        CHECK(ESP_ERR_INVALID_SIZE == msc_host_install_device_lun(1, 1, &device));
+        CHECK(ready_count[0] == 0);
+        CHECK(ready_count[1] == 1);
+    }
+    CHECK(device == nullptr);
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC validates probe and install parameters before opening a device", "[msc][lun]")
+{
+    CHECK(ESP_ERR_INVALID_ARG == msc_host_install_device_lun(1, 16, &device));
+    CHECK(ESP_ERR_INVALID_ARG == msc_host_install_device_lun(1, 0, nullptr));
+    CHECK(ESP_ERR_INVALID_ARG == msc_host_probe_luns(1, 0, nullptr));
+    CHECK(open_calls == 0);
+    CHECK(get_max_count == 0);
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC rejects competing operations without disturbing an installed LUN", "[msc][lun]")
+{
+    fixed_lun = 1;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+    const unsigned previous_open_calls = open_calls;
+    msc_host_device_handle_t other = nullptr;
+    msc_host_lun_info_t info = { .ready_lun_mask = 0xffff, .failed_lun_mask = 0xffff, .max_lun = 15 };
+    CHECK(ESP_ERR_INVALID_STATE == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.max_lun == 0);
+    CHECK(info.ready_lun_mask == 0);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(ESP_ERR_INVALID_STATE == msc_host_install_device_lun(1, 0, &other));
+    CHECK(ESP_ERR_INVALID_STATE == msc_host_install_device(1, &other));
+    CHECK(other == nullptr);
+    CHECK(open_calls == previous_open_calls + 3);
+    CHECK(open_devices == 1);
+    CHECK(claims == 1);
+    CHECK(get_max_count == 1);
+    uint8_t sector[512] = {};
+    REQUIRE(ESP_OK == scsi_cmd_read10(device, sector, 0, 1, sizeof(sector)));
+    CHECK(sector[0] == 0xa5);
+
+    REQUIRE(ESP_OK == msc_host_uninstall_device(device));
+    device = nullptr;
+    fixed_lun = -1;
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.ready_lun_mask == 2);
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probe distinguishes empty slots from failed LUNs", "[msc][lun]")
+{
+    msc_host_lun_info_t info = {};
+    SECTION("All slots empty is a successful one-pass probe") {
+        SECTION("MEDIUM NOT PRESENT") {
+            empty_sense_ascq = 0x00;
+        }
+        SECTION("MEDIUM NOT PRESENT - TRAY CLOSED") {
+            empty_sense_ascq = 0x01;
+        }
+        SECTION("MEDIUM NOT PRESENT - TRAY OPEN") {
+            empty_sense_ascq = 0x02;
+        }
+        ready_luns = 0;
+        const TickType_t started = xTaskGetTickCount();
+        REQUIRE(ESP_OK == msc_host_probe_luns(1, 5000, &info));
+        CHECK(xTaskGetTickCount() - started < pdMS_TO_TICKS(2500));
+        CHECK(info.ready_lun_mask == 0);
+        CHECK(info.failed_lun_mask == 0);
+        CHECK(ready_count[0] == 1);
+        CHECK(ready_count[1] == 1);
+        CHECK(sense_count == 2);
+    }
+    SECTION("SCSI failures on one LUN do not prevent discovering others") {
+        max_lun = 3;
+        ready_luns = 15;
+        inquiry_fail_luns = 1;
+        tur_fail_luns = 2;
+        capacity_fail_luns = 4;
+        REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+        CHECK(info.ready_lun_mask == 8);
+        CHECK(info.failed_lun_mask == 7);
+    }
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC temporary probe protects driver lifetime without exposing a device handle", "[msc][lun]")
+{
+    inject_probe_events = true;
+    get_max_status = USB_TRANSFER_STATUS_NO_DEVICE;
+    msc_host_lun_info_t info = { .ready_lun_mask = 0xffff, .failed_lun_mask = 0xffff, .max_lun = 15 };
+    CHECK(ESP_ERR_MSC_INTERNAL == msc_host_probe_luns(1, 0, &info));
+    CHECK(probe_lifetime_checks == 1);
+    CHECK(public_events == 0);
+    CHECK(info.max_lun == 0);
+    CHECK(info.ready_lun_mask == 0);
+    CHECK(info.failed_lun_mask == 0);
+    check_closed();
+
+    // The rejected uninstall must leave the driver available for later use.
+    inject_probe_events = false;
+    get_max_status = USB_TRANSFER_STATUS_COMPLETED;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC claim failure releases only the resources it owns", "[msc][lun]")
+{
+    claim_result = ESP_ERR_INVALID_STATE;
+    SECTION("Temporary probe") {
+        msc_host_lun_info_t info = { .ready_lun_mask = 0xffff, .failed_lun_mask = 0xffff, .max_lun = 15 };
+        CHECK(ESP_ERR_INVALID_STATE == msc_host_probe_luns(1, 0, &info));
+        CHECK(info.max_lun == 0);
+        CHECK(info.ready_lun_mask == 0);
+        CHECK(info.failed_lun_mask == 0);
+    }
+    SECTION("Explicit installation") {
+        CHECK(ESP_ERR_INVALID_STATE == msc_host_install_device_lun(1, 1, &device));
+        CHECK(device == nullptr);
+    }
+    CHECK(open_calls == 1);
+    CHECK(release_calls == 0);
+    CHECK(get_max_count == 0);
+    check_closed();
+
+    claim_result = ESP_OK;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC waits for transfer bookkeeping before releasing its interface", "[msc][lun]")
+{
+    SECTION("Temporary probe") {
+        release_pending_once = true;
+        msc_host_lun_info_t info = {};
+        REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+        CHECK(info.ready_lun_mask == 2);
+    }
+    SECTION("Installed device") {
+        REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+        release_pending_once = true;
+        REQUIRE(ESP_OK == msc_host_uninstall_device(device));
+        device = nullptr;
+    }
+    CHECK(release_calls == 2);
+    check_closed();
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probe requires supported sector geometry", "[msc][lun]")
+{
+    max_lun = 5;
+    ready_luns = 0x3f;
+    sector_sizes[0] = 512;
+    sector_sizes[1] = 4096;
+    sector_sizes[2] = 256;
+    sector_sizes[3] = 768;
+    sector_sizes[4] = 8192;
+    sector_sizes[5] = 0;
+    msc_host_lun_info_t info = {};
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.ready_lun_mask == 3);
+    CHECK(info.failed_lun_mask == 0x3c);
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probe discards partial results after transport failure", "[msc][lun]")
+{
+    ready_luns = 3;
+    transport_error_lun = 1;
+    SECTION("TEST UNIT READY transport failure") {
+        transport_error_opcode = TEST_UNIT_READY;
+    }
+    SECTION("INQUIRY transport failure") {
+        transport_error_opcode = INQUIRY;
+    }
+    SECTION("READ CAPACITY transport failure") {
+        transport_error_opcode = READ_CAPACITY;
+    }
+    msc_host_lun_info_t info = { .ready_lun_mask = 0xffff, .failed_lun_mask = 0xffff, .max_lun = 15 };
+    CHECK(ESP_ERR_MSC_INTERNAL == msc_host_probe_luns(1, 0, &info));
+    CHECK(capacity_count[0] == 1); // LUN zero was already discovered.
+    CHECK(info.max_lun == 0);
+    CHECK(info.ready_lun_mask == 0);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(sense_count == 0); // Transport errors must not be replaced by REQUEST SENSE results.
+    check_closed();
+
+    transport_error_lun = -1;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probe rejects malformed CSWs instead of publishing partial results", "[msc][lun]")
+{
+    ready_luns = 3;
+    esp_err_t expected = ESP_ERR_INVALID_RESPONSE;
+    SECTION("Invalid signature") {
+        csw_fault = CswFault::SIGNATURE;
+    }
+    SECTION("Mismatched command tag") {
+        csw_fault = CswFault::TAG;
+    }
+    SECTION("Reserved status") {
+        csw_fault = CswFault::RESERVED_STATUS;
+    }
+    SECTION("Phase error") {
+        csw_fault = CswFault::PHASE_ERROR;
+        expected = ESP_ERR_MSC_INTERNAL;
+    }
+    SECTION("Short CSW") {
+        csw_fault = CswFault::SHORT_RESPONSE;
+    }
+    SECTION("Successful status with nonzero residue") {
+        csw_fault = CswFault::RESIDUE;
+    }
+    msc_host_lun_info_t info = { .ready_lun_mask = 0xffff, .failed_lun_mask = 0xffff, .max_lun = 15 };
+    CHECK(expected == msc_host_probe_luns(1, 0, &info));
+    CHECK(capacity_count[0] == 1); // A previously ready LUN must not escape as a partial result.
+    CHECK(info.max_lun == 0);
+    CHECK(info.ready_lun_mask == 0);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(sense_count == 0);
+    check_closed();
+
+    // A malformed CSW or phase error requires BOT reset before another CBW.
+    csw_fault = CswFault::NONE;
+    fixed_lun = 1;
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 1, &device));
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probe shares its retry window and does not recheck resolved LUNs", "[msc][lun]")
+{
+    SECTION("Media are becoming ready") {
+        pending_sense_key = 0x02;
+    }
+    SECTION("Unit attention needs REQUEST SENSE before retrying") {
+        pending_sense_key = 0x06;
+    }
+    max_lun = 15;
+    ready_luns = 1;
+    tur_fail_luns = 4;
+    delayed_lun = 1;
+    pending_luns = 1 << 15;
+    const TickType_t started = xTaskGetTickCount();
+    msc_host_lun_info_t info = {};
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 150, &info));
+    const TickType_t elapsed = xTaskGetTickCount() - started;
+    CHECK(elapsed >= pdMS_TO_TICKS(150));
+    CHECK(elapsed < pdMS_TO_TICKS(1000)); // Not a separate 150 ms wait for every slot.
+    CHECK(info.ready_lun_mask == 3);
+    CHECK(info.failed_lun_mask == 4);
+    CHECK(ready_count[0] == 1);
+    CHECK(ready_count[1] == 2);
+    CHECK(ready_count[2] == 1);
+    for (unsigned i = 3; i < 15; ++i) {
+        CHECK(ready_count[i] == 1); // Empty slots never consume the retry window.
+    }
+    CHECK(ready_count[15] >= 2);
+    for (unsigned i = 0; i < 16; ++i) {
+        CHECK(inquiry_count[i] == 1);
+    }
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC zero-budget probe reports only immediately ready LUNs", "[msc][lun]")
+{
+    SECTION("Media are becoming ready") {
+        pending_sense_key = 0x02;
+    }
+    SECTION("Unit attention needs another TEST UNIT READY") {
+        pending_sense_key = 0x06;
+    }
+    ready_luns = 1;
+    delayed_lun = 1;
+    msc_host_lun_info_t info = {};
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.ready_lun_mask == 1);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(ready_count[0] == 1);
+    CHECK(ready_count[1] == 1);
+    CHECK(sense_count == 1);
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probe returns when the last initializing LUN becomes ready", "[msc][lun]")
+{
+    ready_luns = 1;
+    delayed_lun = 1;
+    msc_host_lun_info_t info = {};
+    const TickType_t started = xTaskGetTickCount();
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 5000, &info));
+    CHECK(xTaskGetTickCount() - started < pdMS_TO_TICKS(2500));
+    CHECK(info.ready_lun_mask == 3);
+    CHECK(info.failed_lun_mask == 0);
+    CHECK(ready_count[0] == 1);
+    CHECK(ready_count[1] == 2);
+    CHECK(sense_count == 1);
+    check_closed();
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC synchronizes transport before the first command of each session", "[msc][lun]")
+{
+    max_lun = 0;
+    ready_luns = 1;
+    msc_host_lun_info_t info = {};
+    // INQUIRY/TUR/CAPACITY leave three OUT and five IN packets: both DATA1.
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.ready_lun_mask == 1);
+    CHECK(info.failed_lun_mask == 0);
+    REQUIRE(clear_count == 2);
+    CHECK(clears[0].endpoint == 0x81);
+    CHECK(clears[1].endpoint == 0x02);
+    CHECK(clears[0].bulk_count == 0);
+    CHECK(clears[1].bulk_count == 0);
+    CHECK(reset_count == 1);
+    const unsigned probe_bulk_count = bulk_count;
+    check_closed();
+
+    // Reclaim resets the host PID; reset and CLEAR_FEATURE synchronize the device.
+    REQUIRE(ESP_OK == msc_host_install_device_lun(1, 0, &device));
+    REQUIRE(clear_count == 4);
+    CHECK(clears[2].endpoint == 0x81);
+    CHECK(clears[3].endpoint == 0x02);
+    CHECK(clears[2].bulk_count == probe_bulk_count);
+    CHECK(clears[3].bulk_count == probe_bulk_count);
+    CHECK(reset_count == 2);
+    CHECK(ready_count[0] == 2);
+}
+
+TEST_CASE_METHOD(LunFixture, "MSC probe releases its session when transport initialization fails", "[msc][lun]")
+{
+    max_lun = 0;
+    ready_luns = 1;
+    unsigned expected_clears = 0;
+    SECTION("Mass Storage Reset fails") {
+        reset_status = USB_TRANSFER_STATUS_ERROR;
+    }
+    SECTION("Bulk IN clear fails") {
+        clear_fail_endpoint = 0x81;
+        expected_clears = 1;
+    }
+    SECTION("Bulk OUT clear fails") {
+        clear_fail_endpoint = 0x02;
+        expected_clears = 2;
+    }
+    msc_host_lun_info_t info = { .ready_lun_mask = 0xffff, .failed_lun_mask = 0xffff, .max_lun = 15 };
+    CHECK(ESP_ERR_MSC_INTERNAL == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.max_lun == 0);
+    CHECK(info.ready_lun_mask == 0);
+    CHECK(info.failed_lun_mask == 0);
+    REQUIRE(clear_count == expected_clears);
+    if (expected_clears != 0) {
+        CHECK(clears[0].endpoint == 0x81);
+        CHECK(clears[clear_count - 1].endpoint == clear_fail_endpoint);
+    }
+    CHECK(bulk_count == 0);
+    CHECK(get_max_count == 0);
+    check_closed();
+
+    reset_status = USB_TRANSFER_STATUS_COMPLETED;
+    clear_fail_endpoint = 0;
+    REQUIRE(ESP_OK == msc_host_probe_luns(1, 0, &info));
+    CHECK(info.ready_lun_mask == 1);
+    check_closed();
+}

--- a/host/class/msc/usb_host_msc/include/esp_private/msc_scsi_bot.h
+++ b/host/class/msc/usb_host_msc/include/esp_private/msc_scsi_bot.h
@@ -39,6 +39,7 @@ esp_err_t scsi_cmd_read_capacity(msc_host_device_handle_t device,
 
 esp_err_t scsi_cmd_sense(msc_host_device_handle_t device, scsi_sense_data_t *sense);
 
+/* The caller must request sense after a failed SCSI readiness command. */
 esp_err_t scsi_cmd_unit_ready(msc_host_device_handle_t device);
 
 esp_err_t scsi_cmd_inquiry(msc_host_device_handle_t device);

--- a/host/class/msc/usb_host_msc/include/usb/msc_host.h
+++ b/host/class/msc/usb_host_msc/include/usb/msc_host.h
@@ -86,6 +86,22 @@ typedef struct {
 } msc_host_device_info_t;
 
 /**
+ * @brief Result of a completed logical-unit probe.
+ *
+ * Bit n in either mask describes LUN n. A ready LUN passed TEST UNIT READY
+ * and READ CAPACITY with a supported sector size. A failed LUN failed INQUIRY
+ * or READ CAPACITY, reported a non-retryable readiness error, or returned an
+ * unsupported sector size. LUNs in
+ * 0..max_lun with neither bit set remained unready (including empty slots).
+ * USB transport errors fail the probe instead of producing a partial result.
+ */
+typedef struct {
+    uint16_t ready_lun_mask;  /*!< Ready block devices; no filesystem or write-access check is performed. */
+    uint16_t failed_lun_mask; /*!< LUNs rejected by SCSI initialization or sector-size validation. */
+    uint8_t max_lun;         /*!< Highest LUN reported by GET_MAX_LUN, not a count of inserted media. */
+} msc_host_lun_info_t;
+
+/**
  * @brief Install the USB Host Mass Storage Class driver.
  *
  * @param[in] config MSC driver configuration.
@@ -111,6 +127,9 @@ esp_err_t msc_host_uninstall(void);
 /**
  * @brief Initialize an MSC device after connection.
  *
+ * @note Installs LUN 0, preserving the original single-LUN behavior.
+ *       Use msc_host_install_device_lun() to select a different LUN.
+ *
  * @param[in] device_address Device address obtained from the MSC connection callback.
  * @param[out] device Mass storage device handle to use for subsequent API calls. Must not be NULL.
  *
@@ -123,9 +142,79 @@ esp_err_t msc_host_uninstall(void);
 esp_err_t msc_host_install_device(uint8_t device_address, msc_host_device_handle_t *device);
 
 /**
+ * @brief Initialize exactly one logical unit of an MSC device.
+ *
+ * Starts a new BOT session with a Mass Storage Reset and clears both bulk
+ * endpoint halts before initializing the selected LUN.
+ *
+ * @note No other LUN is probed or used as a fallback. The binding remains
+ *       fixed for I/O and reset recovery until uninstall. LUN 0 does not
+ *       require GET_MAX_LUN; nonzero LUNs are checked against its response.
+ * @note Only one LUN of the selected MSC interface can be installed at once.
+ *       Unmount and uninstall the current device before selecting another.
+ *       Insert the medium before installation; changing media while installed
+ *       is not supported.
+ * @note This is a blocking operation. USB event processing must continue in
+ *       another task; do not call it from the MSC event callback. Serialize
+ *       installation, probing and uninstallation in the application.
+ *
+ * @param[in] device_address Address obtained from the MSC connection callback.
+ * @param[in] lun Logical unit number in 0..15.
+ * @param[out] device Installed device handle. Set to NULL on failure.
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if device is NULL or lun exceeds 15
+ *      - ESP_ERR_NOT_FOUND if lun exceeds the reported maximum
+ *      - ESP_ERR_INVALID_STATE if the driver is unavailable or the device is already open
+ *      - Other errors from device initialization or the USB Host library
+ */
+esp_err_t msc_host_install_device_lun(uint8_t device_address, uint8_t lun, msc_host_device_handle_t *device);
+
+/**
+ * @brief Discover logical units before installing an MSC device.
+ *
+ * Opens a temporary session on the same interface used by device installation,
+ * resets the BOT transport, queries GET_MAX_LUN, and probes all advertised
+ * LUNs. Releases the session before returning. No LUN is selected or mounted;
+ * the application chooses a candidate and calls msc_host_install_device_lun(),
+ * which revalidates it. GET_MAX_LUN STALL is treated as a single-LUN device.
+ *
+ * @note LUNs reporting NOT READY / MEDIUM NOT PRESENT (02/3A/xx) are skipped
+ *       without retrying and have neither result bit set. Other retryable
+ *       readiness failures share one retry window. The initial pass covers
+ *       every LUN, even with timeout_ms == 0; finding one ready LUN does not
+ *       end the scan. Individual USB transfers keep their own timeouts, so
+ *       this is not a strict total execution deadline.
+ * @note Results describe observations during this call, not persistent media
+ *       identity. The reader must remain connected through selection and
+ *       installation. Do not change cards during these operations.
+ * @note Call only before installation. This function is blocking and must not
+ *       run in the MSC event callback. USB events must be processed in another
+ *       task. Serialize probing, installation and uninstallation in the
+ *       application. Temporary handles are not delivered in MSC events.
+ *
+ * @param[in] device_address Address obtained from the MSC connection callback.
+ * @param[in] timeout_ms Readiness retry window in milliseconds; 0 scans once.
+ * @param[out] info Complete result on success; cleared on failure. Must not be NULL.
+ *
+ * @return
+ *      - ESP_OK on a complete probe, including when no LUN is ready
+ *      - ESP_ERR_INVALID_ARG if info is NULL
+ *      - ESP_ERR_INVALID_STATE if the driver is unavailable or the device is already open
+ *      - ESP_ERR_INVALID_SIZE or ESP_ERR_INVALID_RESPONSE for malformed GET_MAX_LUN
+ *      - Other errors from resource management or the USB transport
+ */
+esp_err_t msc_host_probe_luns(uint8_t device_address, uint32_t timeout_ms, msc_host_lun_info_t *info);
+
+/**
  * @brief Deinitialize an MSC device.
  *
- * @param[in] device Device handle obtained from msc_host_install_device().
+ * @note Stop I/O before calling. USB event processing must continue until
+ *       pending transfer callbacks have finished and this call returns.
+ *       No commands are sent to the device, which may already be disconnected.
+ *
+ * @param[in] device Device handle obtained from either installation API.
  *
  * @return
  *      - ESP_OK on success

--- a/host/class/msc/usb_host_msc/private_include/msc_common.h
+++ b/host/class/msc/usb_host_msc/private_include/msc_common.h
@@ -38,6 +38,8 @@ typedef struct msc_host_device {
     usb_device_handle_t handle;
     usb_transfer_t *xfer;
     msc_config_t config;
+    uint8_t lun; // Selected during install; unchanged until device uninstall.
+    bool probe_only; // Temporary discovery session; never exposed in public events.
     usb_disk_t disk;
 } msc_device_t;
 

--- a/host/class/msc/usb_host_msc/src/msc_host.c
+++ b/host/class/msc/usb_host_msc/src/msc_host.c
@@ -184,12 +184,21 @@ static esp_err_t msc_mass_reset(msc_host_device_handle_t dev)
     return ESP_OK;
 }
 
+static esp_err_t msc_reset_transport(msc_device_t *dev)
+{
+    // BOT reset recovery: reset the command state, then synchronize both
+    // endpoints. A class reset alone preserves data toggles and STALLs.
+    MSC_RETURN_ON_ERROR(msc_mass_reset(dev));
+    MSC_RETURN_ON_ERROR(clear_feature(dev, dev->config.bulk_in_ep));
+    return clear_feature(dev, dev->config.bulk_out_ep);
+}
+
 /**
  * @brief MSC get maximum Logical Unit Number
  *
  * If the device implements 3 LUNs, the returned value is 2. (LUN0, LUN1, LUN2).
  *
- * This driver does not support multiple LUNs yet.
+ * Discovery reports candidates; the application selects the LUN to install.
  *
  * @see USB Mass Storage Class – Bulk Only Transport, Chapter 3.2
  *
@@ -197,13 +206,23 @@ static esp_err_t msc_mass_reset(msc_host_device_handle_t dev)
  * @param[out] lun Maximum Logical Unit Number
  * @return esp_err_t
  */
-__attribute__((unused)) static esp_err_t msc_get_max_lun(msc_host_device_handle_t dev, uint8_t *lun)
+static esp_err_t msc_get_max_lun(msc_host_device_handle_t dev, uint8_t *lun)
 {
     msc_device_t *device = (msc_device_t *)dev;
     usb_transfer_t *xfer = device->xfer;
 
     USB_MASS_REQ_INIT_GET_MAX_LUN((usb_setup_packet_t *)xfer->data_buffer, device->config.iface_num);
-    MSC_RETURN_ON_ERROR( msc_control_transfer(device, USB_SETUP_PACKET_SIZE + 1) );
+    esp_err_t err = msc_control_transfer(device, USB_SETUP_PACKET_SIZE + 1);
+    // BOT permits single-LUN devices to STALL this request.
+    if (err == ESP_ERR_MSC_STALL) {
+        *lun = 0;
+        return ESP_OK;
+    }
+    MSC_RETURN_ON_ERROR(err);
+    MSC_RETURN_ON_FALSE(xfer->actual_num_bytes == USB_SETUP_PACKET_SIZE + 1,
+                        ESP_ERR_INVALID_SIZE);
+    MSC_RETURN_ON_FALSE(xfer->data_buffer[USB_SETUP_PACKET_SIZE] <= 15,
+                        ESP_ERR_INVALID_RESPONSE);
 
     *lun = xfer->data_buffer[USB_SETUP_PACKET_SIZE];
 
@@ -257,29 +276,88 @@ static esp_err_t extract_config_from_descriptor(const usb_config_desc_t *cfg_des
     return ESP_OK;
 }
 
-static esp_err_t msc_deinit_device(msc_device_t *dev, bool install_failed)
+static esp_err_t msc_deinit_device(msc_device_t *dev, bool interface_claimed)
 {
-    MSC_ENTER_CRITICAL();
-    MSC_RETURN_ON_FALSE_CRITICAL( dev, ESP_ERR_INVALID_STATE );
-    STAILQ_REMOVE(&s_msc_driver->devices_tailq, dev, msc_host_device, tailq_entry);
-    MSC_EXIT_CRITICAL();
+    if (interface_claimed) {
+        esp_err_t ret;
+        do {
+            ret = usb_host_interface_release(s_msc_driver->client_handle, dev->handle, dev->config.iface_num);
+            if (ret == ESP_ERR_INVALID_STATE) {
+                // The transfer callback wakes the caller before USB Host
+                // retires the endpoint's in-flight count. Let its event task
+                // finish, even when it has a lower priority than this task.
+                vTaskDelay(1);
+            }
+        } while (ret == ESP_ERR_INVALID_STATE);
+        MSC_RETURN_ON_ERROR(ret);
+    }
+    if (dev->handle) {
+        MSC_RETURN_ON_ERROR(usb_host_device_close(s_msc_driver->client_handle, dev->handle));
+    }
+    if (dev->xfer) {
+        MSC_RETURN_ON_ERROR(usb_host_transfer_free(dev->xfer));
+    }
 
     if (dev->transfer_done) {
         vSemaphoreDelete(dev->transfer_done);
     }
-    if (install_failed) {
-        // Error code is unchecked, as it's unknown at what point installation failed.
-        usb_host_interface_release(s_msc_driver->client_handle, dev->handle, dev->config.iface_num);
-        usb_host_device_close(s_msc_driver->client_handle, dev->handle);
-        usb_host_transfer_free(dev->xfer);
-    } else {
-        MSC_RETURN_ON_ERROR( usb_host_interface_release(s_msc_driver->client_handle, dev->handle, dev->config.iface_num) );
-        MSC_RETURN_ON_ERROR( usb_host_device_close(s_msc_driver->client_handle, dev->handle) );
-        MSC_RETURN_ON_ERROR( usb_host_transfer_free(dev->xfer) );
-    }
 
+    // Keep the driver occupied until all USB resources have been released.
+    MSC_ENTER_CRITICAL();
+    STAILQ_REMOVE(&s_msc_driver->devices_tailq, dev, msc_host_device, tailq_entry);
+    MSC_EXIT_CRITICAL();
     free(dev);
     return ESP_OK;
+}
+
+// Reuse the same resource ownership for installed devices and temporary probes.
+static esp_err_t msc_init_device(uint8_t device_address, bool probe_only, msc_device_t **device)
+{
+    esp_err_t ret;
+    bool interface_claimed = false;
+    const usb_config_desc_t *config_desc;
+    msc_device_t *dev = calloc(1, sizeof(msc_device_t));
+    MSC_RETURN_ON_FALSE(dev, ESP_ERR_NO_MEM);
+    dev->probe_only = probe_only;
+    MSC_ENTER_CRITICAL();
+    if (!s_msc_driver || !s_msc_driver->client_handle || s_msc_driver->end_client_event_handling) {
+        MSC_EXIT_CRITICAL();
+        free(dev);
+        return ESP_ERR_INVALID_STATE;
+    }
+    STAILQ_INSERT_TAIL(&s_msc_driver->devices_tailq, dev, tailq_entry);
+    MSC_EXIT_CRITICAL();
+
+    MSC_GOTO_ON_FALSE(dev->transfer_done = xSemaphoreCreateBinary(), ESP_ERR_NO_MEM);
+    MSC_GOTO_ON_ERROR(usb_host_device_open(s_msc_driver->client_handle, device_address, &dev->handle));
+    MSC_GOTO_ON_ERROR(usb_host_get_active_config_descriptor(dev->handle, &config_desc));
+    MSC_GOTO_ON_ERROR(extract_config_from_descriptor(config_desc, &dev->config));
+    MSC_GOTO_ON_ERROR(usb_host_transfer_alloc(DEFAULT_XFER_SIZE, 0, &dev->xfer));
+    MSC_GOTO_ON_ERROR(usb_host_interface_claim(s_msc_driver->client_handle, dev->handle, dev->config.iface_num, 0));
+    interface_claimed = true;
+    // New host pipes start at DATA0; the device may retain toggles and BOT
+    // state from a previous session. Synchronize before the first command.
+    MSC_GOTO_ON_ERROR(msc_reset_transport(dev));
+    *device = dev;
+    return ESP_OK;
+
+fail:
+    msc_deinit_device(dev, interface_claimed);
+    return ret;
+}
+
+// On ESP_FAIL, sense contains the result of a successful REQUEST SENSE.
+static esp_err_t msc_check_ready_state(msc_device_t *dev, scsi_sense_data_t *sense)
+{
+    esp_err_t err = scsi_cmd_unit_ready(dev);
+    if (err == ESP_FAIL) {
+        esp_err_t sense_err = scsi_cmd_sense(dev, sense);
+        if (sense_err != ESP_OK) {
+            // A failed REQUEST SENSE cannot classify the original failure.
+            return sense_err == ESP_FAIL ? ESP_ERR_MSC_INTERNAL : sense_err;
+        }
+    }
+    return err;
 }
 
 // Some MSC devices requires to change its internal state from non-ready to ready
@@ -306,6 +384,74 @@ static esp_err_t msc_wait_for_ready_state(msc_device_t *dev, size_t timeout_ms)
     } while (trials-- && err);
 
     return err;
+}
+
+static bool msc_valid_block_size(uint32_t block_size)
+{
+    // Validate peer-controlled block size before FatFS sizes fs->win from a
+    // truncated WORD while reads use the full uint32_t length (BBP 574).
+    return block_size >= 512 && block_size <= 4096 && (block_size & (block_size - 1)) == 0;
+}
+
+static esp_err_t msc_probe_luns(msc_device_t *dev, uint32_t timeout_ms, msc_host_lun_info_t *info)
+{
+    MSC_RETURN_ON_ERROR(msc_get_max_lun(dev, &info->max_lun));
+    uint16_t pending = UINT16_MAX >> (15 - info->max_lun);
+    const TickType_t started = xTaskGetTickCount();
+    const TickType_t timeout = pdMS_TO_TICKS(timeout_ms);
+    bool first_pass = true;
+
+    for (;;) {
+        for (uint8_t lun = 0; lun <= info->max_lun; lun++) {
+            const uint16_t bit = (uint16_t)(1U << lun);
+            if (!(pending & bit)) {
+                continue;
+            }
+            dev->lun = lun;
+            if (first_pass) {
+                esp_err_t err = scsi_cmd_inquiry(dev);
+                if (err == ESP_FAIL) {
+                    info->failed_lun_mask |= bit;
+                    pending &= ~bit;
+                    continue;
+                }
+                MSC_RETURN_ON_ERROR(err);
+            }
+
+            scsi_sense_data_t sense;
+            esp_err_t err = msc_check_ready_state(dev, &sense);
+            if (err == ESP_FAIL) {
+                if (sense.key == MSC_NOT_READY && sense.code == 0x3a) {
+                    // MEDIUM NOT PRESENT: an empty slot is not a failed LUN.
+                    pending &= ~bit;
+                } else if (sense.key != MSC_NOT_READY &&
+                           sense.key != MSC_UNIT_ATTENTION &&
+                           sense.key != MSC_NO_SENSE) {
+                    info->failed_lun_mask |= bit;
+                    pending &= ~bit;
+                }
+                continue;
+            }
+            MSC_RETURN_ON_ERROR(err);
+
+            uint32_t block_size, block_count;
+            err = scsi_cmd_read_capacity(dev, &block_size, &block_count);
+            MSC_RETURN_ON_FALSE(err == ESP_OK || err == ESP_FAIL, err);
+            pending &= ~bit;
+            if (err == ESP_FAIL || !msc_valid_block_size(block_size)) {
+                info->failed_lun_mask |= bit;
+            } else {
+                info->ready_lun_mask |= bit;
+            }
+        }
+
+        const TickType_t elapsed = xTaskGetTickCount() - started;
+        if (pending == 0 || elapsed >= timeout) {
+            return ESP_OK;
+        }
+        first_pass = false;
+        vTaskDelay(MIN(pdMS_TO_TICKS(100), timeout - elapsed));
+    }
 }
 
 static bool is_mass_storage_device(uint8_t dev_addr)
@@ -366,7 +512,7 @@ static msc_device_t *find_msc_device(usb_device_handle_t device_handle)
 
     MSC_ENTER_CRITICAL();
     STAILQ_FOREACH(iter, &s_msc_driver->devices_tailq, tailq_entry) {
-        if (device_handle == iter->handle) {
+        if (!iter->probe_only && device_handle == iter->handle) {
             device_found = iter;
             break;
         }
@@ -517,42 +663,37 @@ esp_err_t msc_host_uninstall(void)
 
 esp_err_t msc_host_install_device(uint8_t device_address, msc_host_device_handle_t *msc_device_handle)
 {
+    return msc_host_install_device_lun(device_address, 0, msc_device_handle);
+}
+
+esp_err_t msc_host_install_device_lun(uint8_t device_address, uint8_t lun, msc_host_device_handle_t *msc_device_handle)
+{
     esp_err_t ret;
     uint32_t block_size, block_count;
-    const usb_config_desc_t *config_desc;
     msc_device_t *msc_device;
 
-    MSC_GOTO_ON_FALSE( msc_device = calloc(1, sizeof(msc_device_t)), ESP_ERR_NO_MEM );
+    MSC_RETURN_ON_INVALID_ARG(msc_device_handle);
+    *msc_device_handle = NULL;
+    MSC_RETURN_ON_FALSE(lun <= 15, ESP_ERR_INVALID_ARG);
+    MSC_RETURN_ON_ERROR(msc_init_device(device_address, false, &msc_device));
+    msc_device->lun = lun;
 
-    MSC_ENTER_CRITICAL();
-    MSC_GOTO_ON_FALSE_CRITICAL( s_msc_driver, ESP_ERR_INVALID_STATE );
-    MSC_GOTO_ON_FALSE_CRITICAL( s_msc_driver->client_handle, ESP_ERR_INVALID_STATE );
-    STAILQ_INSERT_TAIL(&s_msc_driver->devices_tailq, msc_device, tailq_entry);
-    MSC_EXIT_CRITICAL();
-
-    MSC_GOTO_ON_FALSE( msc_device->transfer_done = xSemaphoreCreateBinary(), ESP_ERR_NO_MEM);
-    MSC_GOTO_ON_ERROR( usb_host_device_open(s_msc_driver->client_handle, device_address, &msc_device->handle) );
-    MSC_GOTO_ON_ERROR( usb_host_get_active_config_descriptor(msc_device->handle, &config_desc) );
-    MSC_GOTO_ON_ERROR( extract_config_from_descriptor(config_desc, &msc_device->config) );
-    MSC_GOTO_ON_ERROR( usb_host_transfer_alloc(DEFAULT_XFER_SIZE, 0, &msc_device->xfer) );
-    MSC_GOTO_ON_ERROR( usb_host_interface_claim(
-                           s_msc_driver->client_handle,
-                           msc_device->handle,
-                           msc_device->config.iface_num, 0) );
-
+    // Preserve the original LUN 0 path, including devices that do not handle
+    // GET_MAX_LUN correctly. Nonzero targets must be advertised by the reader.
+    if (lun != 0) {
+        uint8_t max_lun;
+        MSC_GOTO_ON_ERROR(msc_get_max_lun(msc_device, &max_lun));
+        MSC_GOTO_ON_FALSE(lun <= max_lun, ESP_ERR_NOT_FOUND);
+    }
     MSC_GOTO_ON_ERROR( scsi_cmd_inquiry(msc_device) );
     MSC_GOTO_ON_ERROR( msc_wait_for_ready_state(msc_device, WAIT_FOR_READY_TIMEOUT_MS) );
     MSC_GOTO_ON_ERROR( scsi_cmd_read_capacity(msc_device, &block_size, &block_count) );
 
-    // Validate peer-controlled block size before FatFS sizes fs->win from a
-    // truncated WORD while reads use the full uint32_t length (BBP 574).
-    MSC_GOTO_ON_FALSE(block_size >= 512 &&
-                      block_size <= 4096 &&
-                      (block_size & (block_size - 1)) == 0,
-                      ESP_ERR_INVALID_SIZE);
+    MSC_GOTO_ON_FALSE(msc_valid_block_size(block_size), ESP_ERR_INVALID_SIZE);
 
     msc_device->disk.block_size = block_size;
     msc_device->disk.block_count = block_count;
+    ESP_LOGI(TAG, "selected LUN %u", (unsigned)msc_device->lun);
     *msc_device_handle = msc_device;
 
     return ESP_OK;
@@ -565,7 +706,26 @@ fail:
 esp_err_t msc_host_uninstall_device(msc_host_device_handle_t device)
 {
     MSC_RETURN_ON_INVALID_ARG(device);
-    return msc_deinit_device((msc_device_t *)device, false);
+    return msc_deinit_device((msc_device_t *)device, true);
+}
+
+esp_err_t msc_host_probe_luns(uint8_t device_address, uint32_t timeout_ms, msc_host_lun_info_t *info)
+{
+    MSC_RETURN_ON_INVALID_ARG(info);
+    memset(info, 0, sizeof(*info));
+    msc_device_t *device;
+    MSC_RETURN_ON_ERROR(msc_init_device(device_address, true, &device));
+
+    msc_host_lun_info_t result = { 0 };
+    esp_err_t ret = msc_probe_luns(device, timeout_ms, &result);
+    esp_err_t cleanup_err = msc_deinit_device(device, true);
+    if (ret == ESP_OK) {
+        ret = cleanup_err;
+    }
+    if (ret == ESP_OK) {
+        *info = result;
+    }
+    return ret;
 }
 
 esp_err_t msc_host_read_sector(msc_host_device_handle_t device, size_t sector, void *data, size_t size)
@@ -725,7 +885,14 @@ esp_err_t msc_control_transfer(msc_device_t *device, size_t len)
     xfer->context = device;
 
     MSC_RETURN_ON_ERROR( usb_host_transfer_submit_control(s_msc_driver->client_handle, xfer));
-    return wait_for_transfer_done(xfer) == USB_TRANSFER_STATUS_COMPLETED ? ESP_OK : ESP_ERR_MSC_INTERNAL;
+    switch (wait_for_transfer_done(xfer)) {
+    case USB_TRANSFER_STATUS_COMPLETED:
+        return ESP_OK;
+    case USB_TRANSFER_STATUS_STALL:
+        return ESP_ERR_MSC_STALL;
+    default:
+        return ESP_ERR_MSC_INTERNAL;
+    }
 }
 
 esp_err_t msc_host_reset_recovery(msc_host_device_handle_t device)

--- a/host/class/msc/usb_host_msc/src/msc_scsi_bot.c
+++ b/host/class/msc/usb_host_msc/src/msc_scsi_bot.c
@@ -59,7 +59,6 @@ static const char *TAG = "USB_MSC_SCSI";
         .signature = 0x43425355,                \
         .tag = ++cbw_tag,                       \
         .flags = dir,                           \
-        .lun = 0,                               \
         .data_length = data_len,                \
         .cbw_length = cbw_len,                  \
     }
@@ -244,7 +243,17 @@ static esp_err_t check_csw(msc_csw_t *csw, uint32_t tag)
         ESP_LOGD(TAG, "CSW failed: bCSWStatus 0x%02"PRIx8"", csw->status);
     }
 
-    return csw_ok ? ESP_OK : ESP_FAIL;
+    if (csw_ok) {
+        return ESP_OK;
+    }
+    if (csw->signature != CSW_SIGNATURE || csw->tag != tag || csw->status > 2) {
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+    if (csw->status == 2) {
+        return ESP_ERR_MSC_INTERNAL; // BOT phase error, not a SCSI command failure.
+    }
+    // Only a valid Command Failed status can be classified by REQUEST SENSE.
+    return csw->status == 1 ? ESP_FAIL : ESP_ERR_INVALID_RESPONSE;
 }
 
 /**
@@ -268,8 +277,9 @@ static esp_err_t check_csw(msc_csw_t *csw, uint32_t tag)
  */
 esp_err_t bot_execute_command(msc_device_t *device, msc_cbw_t *cbw, void *data, size_t size)
 {
-    msc_csw_t csw;
+    msc_csw_t csw = { .status = UINT8_MAX }; // An incomplete CSW must not look successful.
     msc_endpoint_t ep = (cbw->flags & CWB_FLAG_DIRECTION_IN) ? MSC_EP_IN : MSC_EP_OUT;
+    cbw->lun = device->lun;
 
     // 1. Command transport
     MSC_RETURN_ON_ERROR( msc_bulk_transfer(device, (uint8_t *)cbw, CBW_SIZE, MSC_EP_OUT) );
@@ -381,10 +391,11 @@ esp_err_t scsi_cmd_read_capacity(msc_host_device_handle_t dev, uint32_t *block_s
 
     esp_err_t ret = bot_execute_command(device, &cbw.base, &response, sizeof(response));
 
-    // In case of an error, get an error code
-    if (unlikely(ret != ESP_OK)) {
+    // Request sense only for a SCSI failure; preserve USB/BOT transport errors.
+    if (unlikely(ret == ESP_FAIL)) {
         MSC_RETURN_ON_ERROR( scsi_cmd_sense(device, NULL));
     }
+    MSC_RETURN_ON_ERROR(ret);
 
     *block_count = __builtin_bswap32(response.block_count);
     *block_size = __builtin_bswap32(response.block_size);
@@ -400,13 +411,8 @@ esp_err_t scsi_cmd_unit_ready(msc_host_device_handle_t dev)
         .opcode = SCSI_CMD_TEST_UNIT_READY,
     };
 
-    esp_err_t ret = bot_execute_command(device, &cbw.base, NULL, 0);
-
-    // In case of an error, get an error code
-    if (unlikely(ret != ESP_OK)) {
-        MSC_RETURN_ON_ERROR( scsi_cmd_sense(device, NULL));
-    }
-    return ret;
+    // The readiness loop reads sense once; a second request can clear it.
+    return bot_execute_command(device, &cbw.base, NULL, 0);
 }
 
 esp_err_t scsi_cmd_sense(msc_host_device_handle_t dev, scsi_sense_data_t *sense)
@@ -450,8 +456,8 @@ esp_err_t scsi_cmd_inquiry(msc_host_device_handle_t dev)
 
     esp_err_t ret = bot_execute_command(device, &cbw.base, &response, sizeof(response) );
 
-    // In case of an error, get an error code
-    if (unlikely(ret != ESP_OK)) {
+    // Request sense only for a SCSI failure; preserve USB/BOT transport errors.
+    if (unlikely(ret == ESP_FAIL)) {
         MSC_RETURN_ON_ERROR( scsi_cmd_sense(device, NULL));
     }
     return ret;


### PR DESCRIPTION
## Description

Multi-slot USB card readers can expose an empty LUN 0 while usable media is available on another LUN. This PR allows applications to discover logical units and explicitly choose one for installation.

- Add `msc_host_probe_luns()` to scan advertised LUNs and report ready and failed candidates without selecting or mounting one.
- Add `msc_host_install_device_lun()` to install exactly the requested LUN, without falling back to another slot.
- Preserve existing public APIs and legacy LUN 0 selection through `msc_host_install_device()`, without issuing GET_MAX_LUN for LUN 0.
- Keep the selected LUN fixed during I/O and reset recovery. Only one LUN per MSC interface can be installed at a time.
- Synchronize BOT state and bulk endpoints when opening a session, supporting installation after probing and switching LUNs after uninstallation.
- Distinguish empty slots and SCSI command failures from USB/BOT transport errors during discovery.
- Share resource management between discovery and installation, and keep temporary probe handles out of public MSC events.

Update API documentation and application examples for discovery, selection, and lifecycle requirements.

## Related

No linked issue.

## Testing

The MSC Linux host-test suite passed against ESP-IDF 6.2-dev (`c712a0dd`): **26 test cases, 5626 assertions**.

Tests use a mocked USB Host layer and cover:

- Legacy LUN 0 installation and explicit selection without fallback.
- Discovery of empty slots, multiple ready candidates, and LUN 15.
- GET_MAX_LUN STALL, malformed responses, and transport failures.
- Ready/failed masks, zero-timeout scans, and shared readiness retry windows.
- Session initialization, failure cleanup, probing followed by installation, and LUN switching.
- Selected-LUN preservation during I/O and reset recovery.

`git diff --check` passed. Hardware validation has not been performed.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core MSC install/probe/teardown and BOT/SCSI error handling changed for all users, though legacy LUN 0 install is preserved; regressions could affect enumeration, capacity reporting, or USB cleanup timing.
> 
> **Overview**
> **Multi-slot USB MSC support** lets applications discover logical units and install a specific LUN instead of always using LUN 0.
> 
> New **`msc_host_probe_luns()`** runs a temporary BOT session, reports `ready_lun_mask` / `failed_lun_mask` / `max_lun`, and leaves slot choice to the app. **`msc_host_install_device_lun()`** binds exactly one LUN (no fallback); **`msc_host_install_device()`** still installs LUN 0 without `GET_MAX_LUN`. **`msc_host_get_device_info()`** now includes the installed **`lun`**. Probe handles are hidden from MSC connect/disconnect events; only one LUN per interface may be installed at a time.
> 
> **Transport and SCSI behavior** changes include mass-storage reset plus bulk IN/OUT halt clear at each new session (probe, install, LUN switch), CBW LUN taken from the installed unit, clearer split between SCSI failures, malformed CSW, and USB stalls, and interface release retried until in-flight transfers are retired.
> 
> **Fixes** bundled with discovery: READ CAPACITY(10) block count off-by-one, READ CAPACITY(16) sentinel marked unsupported per LUN, empty slots (MEDIUM NOT PRESENT) skipped without burning probe retry budget, and readiness paths that read REQUEST SENSE once per failed TEST UNIT READY.
> 
> Docs/README and a large **Catch2 `test_lun.cpp`** suite cover discovery, explicit install, error paths, and session sync; hardware `test_msc.c` only asserts `info.lun == 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17074ed1dbf155fadad465f92480dd4322b167e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->