### PR TITLE
Fix/uvc isoc alt setting (IEC-607)

### DIFF
--- a/host/class/uvc/usb_host_uvc/private_include/uvc_descriptors_priv.h
+++ b/host/class/uvc/usb_host_uvc/private_include/uvc_descriptors_priv.h
@@ -56,7 +56,7 @@ esp_err_t uvc_desc_get_streaming_interface_num(
 esp_err_t uvc_desc_get_streaming_intf_and_ep(
     const usb_config_desc_t *cfg_desc,
     uint8_t bInterfaceNumber,
-    uint16_t dwMaxPayloadTransferSize,
+    uint32_t dwMaxPayloadTransferSize,
     const usb_intf_desc_t **intf_desc_ret,
     const usb_ep_desc_t **ep_desc_ret);
 

--- a/host/class/uvc/usb_host_uvc/uvc_descriptor_parsing.c
+++ b/host/class/uvc/usb_host_uvc/uvc_descriptor_parsing.c
@@ -110,7 +110,7 @@ static const uvc_vs_input_header_desc_t *uvc_desc_get_streaming_input_header(con
 esp_err_t uvc_desc_get_streaming_intf_and_ep(
     const usb_config_desc_t *cfg_desc,
     uint8_t bInterfaceNumber,
-    uint16_t dwMaxPayloadTransferSize,
+    uint32_t dwMaxPayloadTransferSize,
     const usb_intf_desc_t **intf_desc_ret,
     const usb_ep_desc_t **ep_desc_ret)
 {

--- a/host/class/uvc/usb_host_uvc/uvc_host.c
+++ b/host/class/uvc/usb_host_uvc/uvc_host.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/queue.h>
+#include <sys/param.h>
 
 #include "esp_log.h"
 #include "esp_check.h"
@@ -561,6 +562,70 @@ static inline esp_err_t uvc_set_interface(uvc_host_stream_hdl_t stream_hdl, bool
 }
 
 /**
+ * @brief Select and claim the alternate setting that fits a given payload size
+ *
+ * @param[in]  uvc_stream      Stream whose bInterfaceNumber is already resolved
+ * @param[in]  max_payload     Largest payload the chosen endpoint may have to carry
+ * @param[in]  already_claimed Release the currently claimed alternate setting first
+ * @param[out] ep_desc_ret     Endpoint descriptor of the selected alternate setting
+ * @return
+ *     - ESP_OK:              Alternate setting selected and claimed
+ *     - ESP_ERR_INVALID_ARG: Input parameter is NULL
+ *     - ESP_ERR_NOT_FOUND:   No alternate setting fits max_payload
+ *     - Other:               Error during interface claim
+ */
+static esp_err_t uvc_select_alt_setting(uvc_stream_t *uvc_stream, uint32_t max_payload,
+                                        bool already_claimed, const usb_ep_desc_t **ep_desc_ret)
+{
+    UVC_CHECK(uvc_stream && ep_desc_ret, ESP_ERR_INVALID_ARG);
+
+    const usb_config_desc_t *cfg_desc;
+    const usb_intf_desc_t *intf_desc;
+    const usb_ep_desc_t *ep_desc;
+
+    ESP_RETURN_ON_ERROR(
+        usb_host_get_active_config_descriptor(uvc_stream->constant.dev_hdl, &cfg_desc),
+        TAG, "Could not read the active configuration descriptor");
+    /* The host IN FIFO is the hard ceiling whatever the camera asks for. */
+    const uint32_t capped_payload = MIN(max_payload, (uint32_t)MAX_MPS_IN);
+    if (capped_payload != max_payload) {
+        ESP_LOGW(TAG, "Negotiated payload %"PRIu32" B exceeds the host IN FIFO, capping at %d B",
+                 max_payload, MAX_MPS_IN);
+    }
+
+    ESP_RETURN_ON_ERROR(
+        uvc_desc_get_streaming_intf_and_ep(cfg_desc, uvc_stream->constant.bInterfaceNumber,
+                                           capped_payload, &intf_desc, &ep_desc),
+        TAG, "No alternate setting of interface %d carries %"PRIu32" B",
+        uvc_stream->constant.bInterfaceNumber, capped_payload);
+
+    *ep_desc_ret = ep_desc;
+
+    if (already_claimed) {
+        if (intf_desc->bAlternateSetting == uvc_stream->constant.bAlternateSetting) {
+            return ESP_OK;   // Already on the right one
+        }
+        ESP_LOGI(TAG, "Alternate setting %d -> %d to match negotiated payload %"PRIu32" B",
+                 uvc_stream->constant.bAlternateSetting, intf_desc->bAlternateSetting, capped_payload);
+        usb_host_interface_release(p_uvc_host_driver->usb_client_hdl,
+                                   uvc_stream->constant.dev_hdl,
+                                   uvc_stream->constant.bInterfaceNumber);
+    }
+
+    ESP_RETURN_ON_ERROR(
+        usb_host_interface_claim(p_uvc_host_driver->usb_client_hdl,
+                                 uvc_stream->constant.dev_hdl,
+                                 intf_desc->bInterfaceNumber,
+                                 intf_desc->bAlternateSetting),
+        TAG, "Could not claim streaming interface %d-%d",
+        intf_desc->bInterfaceNumber, intf_desc->bAlternateSetting);
+
+    uvc_stream->constant.bAlternateSetting = intf_desc->bAlternateSetting;
+    uvc_stream->constant.bEndpointAddress  = ep_desc->bEndpointAddress;
+    return ESP_OK;
+}
+
+/**
  * @brief Find and claim interface for selected frame format
  *
  * @param[in]  uvc_stream  Pointer to UVC stream
@@ -578,8 +643,6 @@ static esp_err_t uvc_claim_interface(uvc_stream_t *uvc_stream, uint8_t uvc_index
     UVC_CHECK(uvc_stream && vs_format && ep_desc_ret, ESP_ERR_INVALID_ARG);
 
     const usb_config_desc_t *cfg_desc;
-    const usb_intf_desc_t *intf_desc;
-    const usb_ep_desc_t *ep_desc;
     ESP_ERROR_CHECK(usb_host_get_active_config_descriptor(uvc_stream->constant.dev_hdl, &cfg_desc));
 
     // Find UVC USB function with desired index
@@ -591,23 +654,11 @@ static esp_err_t uvc_claim_interface(uvc_stream_t *uvc_stream, uint8_t uvc_index
         TAG, "Could not find frame format %dx%d@%2.1fFPS",
         vs_format->h_res, vs_format->v_res, vs_format->fps);
 
-    ESP_RETURN_ON_ERROR(
-        uvc_desc_get_streaming_intf_and_ep(cfg_desc, bInterfaceNumber, MAX_MPS_IN, &intf_desc, &ep_desc),
-        TAG, "Could not find Streaming interface %d", bInterfaceNumber);
-
     // Save all constant information about the UVC stream
     uvc_stream->constant.bInterfaceNumber  = bInterfaceNumber;
     uvc_stream->constant.bcdUVC            = bcdUVC;
-    uvc_stream->constant.bAlternateSetting = intf_desc->bAlternateSetting;
-    uvc_stream->constant.bEndpointAddress  = ep_desc->bEndpointAddress;
-    *ep_desc_ret                           = ep_desc;
 
-    // Claim the interface in USB Host Lib
-    return usb_host_interface_claim(
-               p_uvc_host_driver->usb_client_hdl,
-               uvc_stream->constant.dev_hdl,
-               intf_desc->bInterfaceNumber,
-               intf_desc->bAlternateSetting);
+    return uvc_select_alt_setting(uvc_stream, MAX_MPS_IN, false, ep_desc_ret);
 }
 
 esp_err_t uvc_host_install(const uvc_host_driver_config_t *driver_config)
@@ -843,6 +894,19 @@ esp_err_t uvc_host_stream_open(const uvc_host_stream_config_t *stream_config, in
     ESP_GOTO_ON_ERROR(
         uvc_host_stream_control_probe(uvc_stream, &real_format, &vs_result),
         err, TAG, "Failed to negotiate requested Video Stream format");
+
+    /* Now that the camera has said how much it will actually send per microframe, re-select
+     * the alternate setting to match. uvc_claim_interface() could only cap on MAX_MPS_IN and
+     * takes the largest endpoint the target supports.
+     *
+     * Isochronous only. bAlternateSetting == 0 is how this driver spells "bulk stream"
+     * throughout, and a bulk streaming interface has no alternate settings to choose
+     * between, so re-selecting there could only re-derive what open already claimed. */
+    if (uvc_stream->constant.bAlternateSetting != 0 && vs_result.dwMaxPayloadTransferSize > 0) {
+        ESP_GOTO_ON_ERROR(
+            uvc_select_alt_setting(uvc_stream, vs_result.dwMaxPayloadTransferSize, true, &ep_desc),
+            err, TAG, "Could not match the alternate setting to the negotiated payload");
+    }
 
     // Allocate USB transfers
     ESP_GOTO_ON_ERROR(


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Fix in usb_host_uvc, found while bringing up a UVC camera that encodes H.264 itself
on ESP32-S31. Before them the camera delivered no frames at all, at any resolution or format.

The alternate setting does not match the negotiated payload. uvc_claim_interface()
runs before the probe, so it can only cap on MAX_MPS_IN and takes the largest endpoint
the target supports. A camera that then negotiates a smaller dwMaxPayloadTransferSize
commits to the small payload, sees the host on a high-bandwidth endpoint, and sends
nothing, with no error anywhere, every isochronous packet completing with zero bytes:

```
isoc: xfer=200 pkts=800 done=800 empty=800 skip=0 err=0 bytes=0
```

Instead set again after the probe with the real payload,
before the URBs are sized from the endpoint descriptor. On the test camera that picks
alt 3 for H.264 at 640x480 and alt 10 for YUYV, against alt 11 unconditionally before.

Also: uvc_desc_get_streaming_intf_and_ep() took dwMaxPayloadTransferSize as uint16_t
while the probe result is a uint32_t, truncating payloads of 64 KiB and above.

## Related

[#538](https://github.com/espressif/esp-usb/issues/538) reaches the same alternate-setting selector from the ESP32-P4 side.

## Testing

ESP32-S31 with a UVC H.264 camera at 1920x1080, 29-30 fps

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes UVC stream open path (interface release/claim and endpoint selection) for isochronous cameras; bulk paths are explicitly unchanged but any alt-setting bug could affect streaming stability.
> 
> **Overview**
> Fixes **isochronous UVC streams** that delivered no video because the host stayed on a **high-bandwidth alternate setting** while the camera negotiated a **smaller** `dwMaxPayloadTransferSize` during probe/commit.
> 
> The driver now **re-selects and re-claims** the streaming alternate setting **after** `uvc_host_stream_control_probe()` returns the real payload, and **before** URB allocation, via new helper `uvc_select_alt_setting()` (caps at `MAX_MPS_IN`, skips when `bAlternateSetting == 0` for bulk). Initial open still claims using the host FIFO ceiling through the same helper.
> 
> `uvc_desc_get_streaming_intf_and_ep()` now takes **`uint32_t`** for `dwMaxPayloadTransferSize` so probe values **≥ 64 KiB** are not truncated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f6fca93c0bc000c6c2840d1d91efb48f2b510bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->