### PR TITLE
fix(usb_host): Fix deep sleep entry for esp32p4 ECO4

### DIFF
--- a/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
+++ b/host/class/cdc/usb_host_cdc_acm/test_app/main/test_cdc_acm_host.cpp
@@ -1630,6 +1630,8 @@ TEST_CASE("light_sleep", "[cdc_acm][light_sleep]")
         printf("Returned from light sleep, reason: timer, t=%lld ms, slept for %lld ms\n", t_after_us / 1000, (t_after_us - t_before_us) / 1000);
     }
 
+    // Disable timer wakeup source
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_close(cdc_dev));
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_uninstall());
     vTaskDelay(20); // Short delay to allow task to be cleaned up
@@ -1748,6 +1750,8 @@ TEST_CASE("light_sleep_during_io", "[cdc_acm][light_sleep]")
     vEventGroupDelete(s_stress_io_event_group);
     s_stress_io_event_group = NULL;
 
+    // Disable timer wakeup source
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_close(cdc_dev));
     TEST_ASSERT_EQUAL(ESP_OK, cdc_acm_host_uninstall());
     vTaskDelay(20); // Short delay to allow task to be cleaned up
@@ -1790,6 +1794,8 @@ TEST_CASE("light_sleep_dconn_no_dev", "[light_sleep][host_suspend_dconn_no_dev]"
 
     light_sleep_enter_catch();                                 // Enter light sleep
 
+    // Disable timer wakeup source after exiting light sleep
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
     // Make sure there is no stale device is present right after exiting light sleep
     usb_host_lib_info_t info;
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_info(&info));
@@ -1871,7 +1877,7 @@ static void cdc_acm_host_deep_sleep_2(void)
 {
     // Get reset reason and check if it's deep sleep reset
     soc_reset_reason_t reason = esp_rom_get_reset_reason(0);
-    TEST_ASSERT(reason == RESET_REASON_CORE_DEEP_SLEEP);
+    TEST_ASSERT_MESSAGE(reason == RESET_REASON_CORE_DEEP_SLEEP, "Incorrect reset reason after exiting deep sleep");
     cdc_acm_deep_sleep_common();
 }
 
@@ -1884,7 +1890,7 @@ static void cdc_acm_host_deep_sleep_3(void)
 {
     // Get reset reason and check if it's deep sleep reset
     soc_reset_reason_t reason = esp_rom_get_reset_reason(0);
-    TEST_ASSERT(reason == RESET_REASON_CORE_DEEP_SLEEP);
+    TEST_ASSERT_MESSAGE(reason == RESET_REASON_CORE_DEEP_SLEEP, "Incorrect reset reason after exiting deep sleep");
 }
 
 /**

--- a/host/usb/test/target_test/usb_sleep_modes/main/test_usb_host_esp_sleep.c
+++ b/host/usb/test/target_test/usb_sleep_modes/main/test_usb_host_esp_sleep.c
@@ -99,6 +99,9 @@ static void light_sleep_task(void *args)
         TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_root_port_resume());
     }
 
+    // Disable timer wakeup source
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
+
     xEventGroupSetBits(test_event_group, EVT_TEST_FINISH);
     vTaskDelete(NULL);
 }
@@ -218,7 +221,7 @@ static void usb_host_deep_sleep_2(void)
     test_setup();
     // Get reset reason and check if it's deep sleep reset
     soc_reset_reason_t reason = esp_rom_get_reset_reason(0);
-    TEST_ASSERT(reason == RESET_REASON_CORE_DEEP_SLEEP);
+    TEST_ASSERT_MESSAGE(reason == RESET_REASON_CORE_DEEP_SLEEP, "Incorrect reset reason after exiting deep sleep");
     // Call common test function with deep sleep mode
     usb_host_sleep_common(ESP_SLEEP_MODE_DEEP_SLEEP);
 }
@@ -234,7 +237,7 @@ static void usb_host_deep_sleep_3(void)
     test_setup();
     // Get reset reason and check if it's deep sleep reset
     soc_reset_reason_t reason = esp_rom_get_reset_reason(0);
-    TEST_ASSERT(reason == RESET_REASON_CORE_DEEP_SLEEP);
+    TEST_ASSERT_MESSAGE(reason == RESET_REASON_CORE_DEEP_SLEEP, "Incorrect reset reason after exiting deep sleep");
 
     // End of last stage of the test:
     // Wait for the device to be connected
@@ -317,6 +320,9 @@ static void light_sleep_enter_task_error(void *args)
     usb_host_lib_info_t info;
     TEST_ASSERT_EQUAL(ESP_OK, usb_host_lib_info(&info));
     TEST_ASSERT_MESSAGE(info.num_devices == 0, "No device shall be connected to the root port");
+
+    // Disable timer wakeup source
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
 
     // Signalize the main task to finish the test and unblock the host lib task
     xTaskNotifyGive(main_task);
@@ -527,6 +533,9 @@ static void light_sleep_enter_latency_task(void *args)
     TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_unregister_event_callback(SLEEP_EVENT_SW_EXIT_SLEEP, test_time_before_exit_light_sleep));
     TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_unregister_event_callback(SLEEP_EVENT_SW_EXIT_SLEEP, test_time_after_exit_light_sleep));
 
+    // Disable timer wakeup source
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
+
     // Disconnect the device, finish test
     TEST_ASSERT_EQUAL(ESP_ERR_NOT_FINISHED, usb_host_device_free_all());
     vTaskDelete(NULL);
@@ -733,6 +742,9 @@ TEST_CASE("Test USB Host light sleep events delivery", "[usb_sleep_modes][low_sp
     // Enter light sleep with root port manually suspended and expect no event
     light_sleep_enter_catch();
     TEST_ASSERT_EQUAL_MESSAGE(pdFALSE, xQueueReceive(notif_queue, &client_event, pdMS_TO_TICKS(1000)), "An event delivered, but none was expected");
+
+    // Disable timer wakeup source
+    TEST_ASSERT_EQUAL(ESP_OK, esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
 
     // Stop the client task, deregister client and release devices
     xTaskNotifyGive(client_task_hdl);


### PR DESCRIPTION
## Description

- Fix failing test case for deep sleep entry
- Previous test cases were affecting the deep sleep test, by not disabling timer wakeup source
- Fixing all the test cases which use wakeup timer to explicitly disable the timer at the end of the test case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup and clearer assertions; no runtime USB host or sleep behavior changes in application code.
> 
> **Overview**
> USB Host and CDC-ACM **sleep-mode tests** now **tear down timer wakeup** by calling `esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER)` after light-sleep (and related) cases that enable it, so a left-enabled timer does not leak into later tests—addressing **deep sleep entry failures on ESP32-P4 ECO4** when earlier cases had not cleared the wakeup source.
> 
> Deep sleep multi-stage checks now use **`TEST_ASSERT_MESSAGE`** for the expected `RESET_REASON_CORE_DEEP_SLEEP` reset reason, with a clear failure string when wakeup reason is wrong.
> 
> Changes are limited to **`test_cdc_acm_host.cpp`** and **`test_usb_host_esp_sleep.c`**; no production USB host or sleep driver logic is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63b6b83a110b7475b6c511fd707f75a12dcc821d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->