### PR TITLE
feat(ci): Use only /dev/ttyUSB ports for flashing with pytest in CI run

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -207,11 +207,13 @@ jobs:
       - name: Run USB Test App on target
         if: success() && steps.download_artifact.outcome == 'success'
         run: |
-          # Set target argument: usb_host tests require 2 DUTs (device and host)
+          # Set target and port args: usb_host tests require 2 DUTs (device and host)
           if [ "${{ matrix.runner_tag }}" = "usb_host" ]; then
             TARGET_ARG="--target=${{ matrix.idf_target }},${{ matrix.idf_target }}"
+            PORT_ARG='--port=/dev/ttyUSB0|/dev/ttyUSB1'
           else
             TARGET_ARG="--target=${{ matrix.idf_target }}"
+            PORT_ARG='--port=/dev/ttyUSB0'
           fi
 
           MARKER_EXPR="${{ matrix.runner_tag }}"
@@ -224,12 +226,12 @@ jobs:
             fi
           fi
 
-          # Run pytest with the configured target and marker
-          echo "Running pytest with target: $TARGET_ARG and marker: $MARKER_EXPR"
+          # Run pytest with the configured target, port, and marker
+          echo "Running pytest with target: $TARGET_ARG, port: $PORT_ARG, marker: $MARKER_EXPR"
           if [ "${{ matrix.runner_tag }}" = "usb_device" ]; then
             MTP_IGNORE="--ignore=device/esp_tinyusb/test_apps/mtp_storage"
           fi
-          pytest --ignore-no-tests-collected-error $TARGET_ARG -m "$MARKER_EXPR" ${MTP_IGNORE:-} --build-dir=build_${{ matrix.idf_target }}_
+          pytest --ignore-no-tests-collected-error $TARGET_ARG $PORT_ARG -m "$MARKER_EXPR" ${MTP_IGNORE:-} --build-dir=build_${{ matrix.idf_target }}_
       - name: Run MTP Test App on target
         if: success() && steps.check_mtp_artifact.outputs.exists == 'true'
         run: |
@@ -244,5 +246,5 @@ jobs:
 
           export XDG_RUNTIME_DIR=/tmp/xdg-runtime
           install -d -m 700 "$XDG_RUNTIME_DIR"
-          dbus-run-session -- pytest --target=${{ matrix.idf_target }} -m "$MARKER_EXPR" device/esp_tinyusb/test_apps/mtp_storage/pytest_mtp_storage.py \
+          dbus-run-session -- pytest --target=${{ matrix.idf_target }} --port=/dev/ttyUSB0 -m "$MARKER_EXPR" device/esp_tinyusb/test_apps/mtp_storage/pytest_mtp_storage.py \
             --build-dir=build_${{ matrix.idf_target }}_

--- a/device/esp_tinyusb/test_apps/mtp_storage/pytest_mtp_storage.py
+++ b/device/esp_tinyusb/test_apps/mtp_storage/pytest_mtp_storage.py
@@ -31,8 +31,8 @@ _EXTENDED_MTP_TEST_REASON = 'set MTP_RUN_EXTENDED_TESTS=1 to run extended MTP ho
     ],
     indirect=['target'],
 )
-def test_usb_device_mtp_storage(dut: IdfDut, config: str) -> None:
-    dut.run_all_single_board_cases(group=['ci'])
+def test_usb_device_mtp_storage(dut: IdfDut) -> None:
+    dut.run_all_single_board_cases(group=['ci'], timeout=60)
 
 
 def _gio(*args: str, check: bool = True, input_data: bytes | None = None, timeout: float = 10) -> subprocess.CompletedProcess[bytes]:


### PR DESCRIPTION
## Description

Pytest flashing/monitoring ports rules:
- `pytest --port=/dev/ttyUSB0` for a single DUT target tests
- `pytest --port='/dev/ttyUSB0|/dev/ttyUSB1'` for a dual DUT target tests

Fixing failing MTP test in CI due to short timeout.

## Related

pytest has started to prefer `/dev/ttyACM*` ports over `/dev/ttyUSB*` ports for flashing/monitoring. The CI has failed several times due to the pytest tried to access and flash the `/dev/ttyACM0` port created by the DUT cdc-acm USB Device. 

Pytest has failed the CI pipeline with a similar log:

<details>
<summary> Error log </summary>

```sh
[09/10/26 07:11:26] WARNING  Checking binary path: /__w/esp-usb/esp-usb/device/esp_tinyusb/test_apps/teardown_device/build_esp32p4_... missing... trying another location
device/esp_tinyusb/test_apps/teardown_device/pytest_teardown_device.py::test_usb_teardown_device[default-esp32p4] 
-------------------------------- live log setup --------------------------------
2026-09-10 07:11:26 WARNING Checking binary path: /__w/esp-usb/esp-usb/device/esp_tinyusb/test_apps/teardown_device/build_esp32p4_... missing... trying another location
[09/10/26 07:11:26] INFO     Found valid binary path: /__w/esp-usb/esp-usb/device/esp_tinyusb/test_apps/teardown_device/build_esp32p4_default
2026-09-10 07:11:26 INFO Found valid binary path: /__w/esp-usb/esp-usb/device/esp_tinyusb/test_apps/teardown_device/build_esp32p4_default
2026-09-10 07:11:26 Serial port /dev/ttyACM0:
2026-09-10 07:11:26 Connecting...
ERROR

==================================== ERRORS ====================================
_________ ERROR at setup of test_usb_teardown_device[default-esp32p4] __________
/usr/local/lib/python3.11/site-packages/pytest_embedded/plugin.py:541: in wrapper
    res = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.11/site-packages/pytest_embedded/plugin.py:1292: in serial
    return serial_gn(**locals())
           ^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.11/site-packages/pytest_embedded/dut_factory.py:547: in serial_gn
    return cls(**_drop_none_kwargs(kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.11/site-packages/pytest_embedded_idf/serial.py:42: in __init__
    super().__init__(
/usr/local/lib/python3.11/site-packages/pytest_embedded_serial_esp/serial.py:98: in __init__
    self.esp = esptool.get_default_connected_device(
/usr/local/lib/python3.11/site-packages/esptool/__init__.py:1357: in get_default_connected_device
    return connect_first_available(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.11/site-packages/esptool/cmds.py:335: in connect_first_available
    esp.connect(before, connect_attempts)
/usr/local/lib/python3.11/site-packages/esptool/loader.py:888: in connect
    last_error = self._connect_attempt(reset_strategy, mode)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.11/site-packages/esptool/loader.py:762: in _connect_attempt
    self._port.reset_input_buffer()
/usr/local/lib/python3.11/site-packages/serial/serialposix.py:683: in reset_input_buffer
    self._reset_input_buffer()
/usr/local/lib/python3.11/site-packages/serial/serialposix.py:677: in _reset_input_buffer
    termios.tcflush(self.fd, termios.TCIFLUSH)
E   termios.error: (5, 'Input/output error')
------------------------------ Captured log setup ------------------------------
WARNING  idf_ci.idf_pytest.plugin:plugin.py:180 Checking binary path: /__w/esp-usb/esp-usb/device/esp_tinyusb/test_apps/teardown_device/build_esp32p4_... missing... trying another location
INFO     idf_ci.idf_pytest.plugin:plugin.py:177 Found valid binary path: /__w/esp-usb/esp-usb/device/esp_tinyusb/test_apps/teardown_device/build_esp32p4_default
================================= Failed Cases =================================
== you can use --ignore-result-files or --ignore-result-cases to ignore them ===
device/esp_tinyusb/test_apps/teardown_device/pytest_teardown_device.py::test_usb_teardown_device[default-esp32p4]
```

</details>


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pytest invocation and test-timeout tweaks; no production firmware or auth/data-path changes.
> 
> **Overview**
> CI USB target runs now pass explicit **`--port`** flags so pytest-embedded flashes and monitors **`/dev/ttyUSB0`** for single-DUT jobs and **`/dev/ttyUSB0|/dev/ttyUSB1`** for **`usb_host`** dual-DUT matrices, including the separate MTP storage pytest step. This avoids auto-selecting **`/dev/ttyACM*`** CDC-ACM interfaces that were causing connect/I/O failures in the pipeline.
> 
> The MTP storage smoke test drops the unused **`config`** fixture argument and runs on-device CI cases with a **60s** timeout to address short-timeout failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dbeb1fae315bb3e858f14c9af4f8d3bb0340e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->