### PR TITLE
refactor(esp_tinyusb): Deprecated IDF < 5.3

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking changes
 
 - esp_tinyusb: Removed DCD Slave/IRQ mode. Only Buffer DMA mode is supported. For more details, refer to the [Espressif's Addition to TinyUSB Migration guide v3](../../docs/device/migration-guides/v3/tinyusb.md)
+- esp_tinyusb: Dropped support for ESP-IDF versions older than v5.3. ESP-IDF v5.3 or later is now required
 
 ## Unreleased
 

--- a/device/esp_tinyusb/CMakeLists.txt
+++ b/device/esp_tinyusb/CMakeLists.txt
@@ -58,11 +58,7 @@ if(${target} STREQUAL "esp32p4" OR ${target} STREQUAL "esp32s31")
     list(APPEND srcs "tinyusb_vbus_monitor.c")
 
     # VBUS monitoring requires GPIO driver
-    if(IDF_VERSION VERSION_GREATER_EQUAL "5.3")
-        list(APPEND priv_req esp_driver_gpio)
-    else()
-        list(APPEND priv_req driver)
-    endif()
+    list(APPEND priv_req esp_driver_gpio)
 endif() # esp32p4/esp32s31
 
 # TinyUSB PM locks

--- a/device/esp_tinyusb/test_apps/msc_storage/main/storage_common.c
+++ b/device/esp_tinyusb/test_apps/msc_storage/main/storage_common.c
@@ -15,7 +15,6 @@
 #include "esp_err.h"
 //
 #include "unity.h"
-#include "esp_idf_version.h"
 #include "sdkconfig.h"
 #include "storage_common.h"
 
@@ -31,15 +30,12 @@
 #define TEST_SDMMC_PIN_D2               CONFIG_TEST_SDMMC_PIN_D2
 #define TEST_SDMMC_PIN_D3               CONFIG_TEST_SDMMC_PIN_D3
 
-// IDF VERSION
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 #if (SOC_SDMMC_IO_POWER_EXTERNAL)
 // Some boards required internal LDO to be enabled for SDMMC initialization
 // To understand if your board requires this, please refer to the board's documentation
 #define TEST_SDMMC_INIT_INTERNAL_LDO    1 // Enable internal LDO for SDMMC initialization
 #define TEST_SDMMC_LDO_CHAN_ID          4
 #endif // (SOC_SDMMC_IO_POWER_EXTERNAL)
-#endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
 
 #if (TEST_SDMMC_INIT_INTERNAL_LDO)
 #include "sd_pwr_ctrl_by_on_chip_ldo.h"

--- a/device/esp_tinyusb/test_apps/runtime_config/main/test_cpu_load.c
+++ b/device/esp_tinyusb/test_apps/runtime_config/main/test_cpu_load.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,19 +35,10 @@ static TaskStatus_t *end_array = NULL;
 static UBaseType_t start_array_size;
 static UBaseType_t end_array_size;
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 static configRUN_TIME_COUNTER_TYPE start_run_time;
 static configRUN_TIME_COUNTER_TYPE end_run_time;
-#else
-static uint32_t start_run_time;
-static uint32_t end_run_time;
-#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 #define CPU_AMOUNT_OF_CORES    CONFIG_FREERTOS_NUMBER_OF_CORES
-#else
-#define CPU_AMOUNT_OF_CORES    portNUM_PROCESSORS
-#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 
 /**
  * @brief Initialize CPU load measurement

--- a/device/esp_tinyusb/tinyusb_msc.c
+++ b/device/esp_tinyusb/tinyusb_msc.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -485,7 +485,6 @@ static esp_err_t msc_storage_mount(msc_storage_obj_t *storage)
     // Register FATFS object to VFS
     char drv[3] = {(char)('0' + pdrv), ':', 0};
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     const esp_vfs_fat_conf_t conf = {
         .base_path = base_path,
         .fat_drive = drv,
@@ -496,9 +495,6 @@ static esp_err_t msc_storage_mount(msc_storage_obj_t *storage)
 #else
     ret = esp_vfs_fat_register_cfg(&conf, &fs);
 #endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
-#else
-    ret = esp_vfs_fat_register(base_path, drv, max_files, &fs);
-#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     if (ret == ESP_ERR_INVALID_STATE) {
         ESP_LOGD(TAG, "VFS FAT already registered");
     } else if (ret != ESP_OK) {
@@ -1137,7 +1133,6 @@ esp_err_t tinyusb_msc_format_storage(tinyusb_msc_storage_handle_t handle)
 
     // Register FAT FS with VFS component
     char drv[3] = {(char)('0' + pdrv), ':', 0}; // FATFS drive specificator; if only one drive is used, can be an empty string
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     const esp_vfs_fat_conf_t conf = {
         .base_path = base_path,
         .fat_drive = drv,
@@ -1148,9 +1143,6 @@ esp_err_t tinyusb_msc_format_storage(tinyusb_msc_storage_handle_t handle)
 #else
     ESP_RETURN_ON_ERROR(esp_vfs_fat_register_cfg(&conf, &fs), TAG, "VFS FAT register failed");
 #endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
-#else
-    ESP_RETURN_ON_ERROR(esp_vfs_fat_register(base_path, drv, max_files, &fs), TAG, "VFS FAT register failed");
-#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     // to make format, we need to mount the fs
     // Mount the FAT FS
     ret = vfs_fat_mount(drv, fs, true);

--- a/docs/device/migration-guides/v3/tinyusb.md
+++ b/docs/device/migration-guides/v3/tinyusb.md
@@ -6,14 +6,18 @@ v3.0.0 removes DCD Slave/IRQ mode. The TinyUSB DWC2 Device Controller Driver use
 
 If your project used the default DCD mode (Buffer DMA), you do not need to change application code. If your project selected Slave/IRQ mode, you must switch to Buffer DMA. Slave/IRQ mode is no longer available.
 
+v3.0.0 requires ESP-IDF v5.3 or later. Compatibility code for older ESP-IDF versions has been removed.
+
 ## Changes Required After Migration
 
+- Use ESP-IDF v5.3 or later
 - Do not set `CONFIG_TINYUSB_MODE_SLAVE` or `CONFIG_TINYUSB_MODE_DMA` as they do not have any effect anymore
 
 ## List of changes
 
 ### Removed
 
+- Support for ESP-IDF versions older than v5.3.
 - Kconfig menu `TinyUSB DCD` and choice `TINYUSB_MODE`:
   - `TINYUSB_MODE_SLAVE`,
   - `TINYUSB_MODE_DMA`.


### PR DESCRIPTION
Remove all IDF compatibiliy code for IDF < 5.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional platform break for projects still on ESP-IDF before v5.3; MSC/VFS registration paths are simplified but still diverge at IDF 6.0.
> 
> **Overview**
> **Breaking:** `esp_tinyusb` v3.0.0 now **requires ESP-IDF v5.3+**. The changelog and v3 migration guide document this alongside the existing DCD/DMA breaking changes.
> 
> This PR **removes compile-time branches for IDF &lt; 5.3** across the component and tests. VBUS monitoring on HS targets always pulls in `esp_driver_gpio` (no fallback to legacy `driver`). MSC storage always registers FAT through `esp_vfs_fat_conf_t` and `esp_vfs_fat_register_cfg` on 5.3–5.x, keeping the IDF 6.0+ switch to `esp_vfs_fat_register`. MSC test SDMMC setup no longer gates on-chip LDO helpers on IDF version, and the CPU load runtime test assumes FreeRTOS run-time stats and `CONFIG_FREERTOS_NUMBER_OF_CORES` from newer IDF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b57691b5c0fe342b15a182dbd3c2a24b270263bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->