### PR TITLE
fix(usb): retire control transfers before completion notification (IEC-609)

### DIFF
--- a/host/usb/CHANGELOG.md
+++ b/host/usb/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a race that could trigger an assertion when closing a device immediately after its control transfer completion callback.
+
 ## [1.5.0] - 2026-06-16
 
 ### Changed

--- a/host/usb/src/usbh.c
+++ b/host/usb/src/usbh.c
@@ -617,10 +617,13 @@ static inline void handle_ep0_dequeue(device_t *dev_obj)
 {
     // Empty URBs from EP0's pipe and call the control transfer callback
     ESP_LOGD(USBH_TAG, "Default pipe device %d", dev_obj->constant.address);
-    int num_urbs = 0;
     urb_t *urb = hcd_urb_dequeue(dev_obj->constant.default_pipe);
     while (urb != NULL) {
-        num_urbs++;
+        // Retire the transfer before notifying its client, which may immediately
+        // close the device or resubmit the transfer from its completion callback.
+        USBH_ENTER_CRITICAL();
+        dev_obj->dynamic.num_ctrl_xfers_inflight--;
+        USBH_EXIT_CRITICAL();
         usbh_event_data_t event_data = {
             .event = USBH_EVENT_CTRL_XFER,
             .ctrl_xfer_data = {
@@ -631,9 +634,6 @@ static inline void handle_ep0_dequeue(device_t *dev_obj)
         p_usbh_obj->constant.event_cb(&event_data, p_usbh_obj->constant.event_cb_arg);
         urb = hcd_urb_dequeue(dev_obj->constant.default_pipe);
     }
-    USBH_ENTER_CRITICAL();
-    dev_obj->dynamic.num_ctrl_xfers_inflight -= num_urbs;
-    USBH_EXIT_CRITICAL();
 }
 
 static inline void handle_ep0_clear(device_t *dev_obj)

--- a/host/usb/test/host_test/usbh_layer_test/README.md
+++ b/host/usb/test/host_test/usbh_layer_test/README.md
@@ -3,6 +3,7 @@
 This directory contains test code for `USBH layer` of USB Host stack. Namely:
 
 - USBH public API calls to install and uninstall the USBH driver with partially mocked USB Host stack to test Linux build and Cmock run for this partial Mock
+- Control transfer completion followed by immediate device close from a higher-priority task, including STALL, transfer errors and resubmission from the completion callback
 - Mocked are all layers of the USB Host stack below the USBH layer, which is used as a real component
 
 Tests are written using [Catch2](https://github.com/catchorg/Catch2) test framework, use CMock, so you must install Ruby on your machine to run them.

--- a/host/usb/test/host_test/usbh_layer_test/main/CMakeLists.txt
+++ b/host/usb/test/host_test/usbh_layer_test/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(srcs)
 list(APPEND srcs "test_main.cpp"
                  "usbh_install_unit_test.cpp"
+                 "usbh_control_completion_test.cpp"
                  )
 
 idf_component_register(SRCS  ${srcs}

--- a/host/usb/test/host_test/usbh_layer_test/main/usbh_control_completion_test.cpp
+++ b/host/usb/test/host_test/usbh_layer_test/main/usbh_control_completion_test.cpp
@@ -1,0 +1,201 @@
+/*
+ * SPDX-FileCopyrightText: 2026 bigtreetech
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "usbh.h"
+
+extern "C" {
+#include "Mockhcd.h"
+}
+
+namespace {
+
+class ControlCompletionFixture {
+public:
+    ControlCompletionFixture()
+    {
+        active = this;
+        Mockhcd_Init();
+        hcd_pipe_alloc_Stub(pipe_alloc);
+        hcd_pipe_free_IgnoreAndReturn(ESP_OK);
+        hcd_pipe_get_mps_IgnoreAndReturn(64);
+        hcd_pipe_command_IgnoreAndReturn(ESP_OK);
+        hcd_urb_enqueue_Stub(enqueue);
+        hcd_urb_dequeue_Stub(dequeue);
+
+        usbh_config_t config = {};
+        config.proc_req_cb = [](usb_proc_req_source_t, bool, void *) {
+            return false;
+        };
+        config.event_cb = event_callback;
+        REQUIRE(ESP_OK == usbh_install(&config));
+
+        usbh_dev_params_t params = {};
+        params.uid = 1;
+        params.speed = USB_SPEED_FULL;
+        params.root_port_hdl = reinterpret_cast<hcd_port_handle_t>(this);
+        REQUIRE(ESP_OK == usbh_devs_add(&params));
+        REQUIRE(ESP_OK == usbh_devs_open_uid(params.uid, &device));
+
+        // The MSC caller can preempt the USB daemon as soon as completion is
+        // reported, including when GET_MAX_LUN leads directly to cleanup.
+        REQUIRE(pdPASS == xTaskCreate(close_device_task, "ep0_close", 4096, this,
+                                      uxTaskPriorityGet(nullptr) + 1, &close_task));
+    }
+
+    ~ControlCompletionFixture()
+    {
+        if (close_task) {
+            vTaskDelete(close_task);
+        }
+        if (device) {
+            CHECK(ESP_OK == usbh_dev_close(device));
+        }
+        CHECK(ESP_ERR_NOT_FINISHED == usbh_devs_mark_all_free());
+        CHECK(ESP_OK == usbh_process());
+        CHECK(ESP_OK == usbh_uninstall());
+        Mockhcd_Verify();
+        Mockhcd_Destroy();
+        active = nullptr;
+    }
+
+    void complete(hcd_pipe_event_t event)
+    {
+        REQUIRE(queued != nullptr);
+        queued->transfer.status = event == HCD_PIPE_EVENT_URB_DONE ? USB_TRANSFER_STATUS_COMPLETED :
+                                  event == HCD_PIPE_EVENT_ERROR_STALL ? USB_TRANSFER_STATUS_STALL : USB_TRANSFER_STATUS_ERROR;
+        completed = queued;
+        queued = nullptr;
+        REQUIRE_FALSE(pipe_callback(pipe, event, pipe_callback_arg, false));
+        REQUIRE(ESP_OK == usbh_process());
+    }
+
+    usb_device_handle_t device = nullptr;
+    unsigned completions = 0;
+    bool resubmit = false;
+    esp_err_t resubmit_result = ESP_FAIL;
+    esp_err_t close_result = ESP_FAIL;
+    bool closed_before_event_return = false;
+
+private:
+    static ControlCompletionFixture *active;
+    hcd_pipe_handle_t pipe = nullptr;
+    hcd_pipe_callback_t pipe_callback = nullptr;
+    void *pipe_callback_arg = nullptr;
+    TaskHandle_t close_task = nullptr;
+    urb_t *queued = nullptr;
+    urb_t *completed = nullptr;
+
+    static esp_err_t pipe_alloc(hcd_port_handle_t, const hcd_pipe_config_t *config,
+                                hcd_pipe_handle_t *handle, int)
+    {
+        active->pipe = reinterpret_cast<hcd_pipe_handle_t>(active);
+        active->pipe_callback = config->callback;
+        active->pipe_callback_arg = config->callback_arg;
+        *handle = active->pipe;
+        return ESP_OK;
+    }
+
+    static esp_err_t enqueue(hcd_pipe_handle_t, urb_t *urb, int)
+    {
+        REQUIRE(active->queued == nullptr);
+        active->queued = urb;
+        return ESP_OK;
+    }
+
+    static urb_t *dequeue(hcd_pipe_handle_t, int)
+    {
+        urb_t *urb = active->completed;
+        active->completed = nullptr;
+        return urb;
+    }
+
+    static void event_callback(usbh_event_data_t *event, void *)
+    {
+        if (event->event != USBH_EVENT_CTRL_XFER) {
+            return;
+        }
+        auto &fixture = *active;
+        ++fixture.completions;
+        if (fixture.resubmit && fixture.completions == 1) {
+            fixture.resubmit_result = usbh_dev_submit_ctrl_urb(fixture.device, event->ctrl_xfer_data.urb);
+        } else {
+            xTaskNotifyGive(fixture.close_task);
+            fixture.closed_before_event_return = fixture.close_result == ESP_OK;
+        }
+    }
+
+    static void close_device_task(void *arg)
+    {
+        auto &fixture = *static_cast<ControlCompletionFixture *>(arg);
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        fixture.close_result = usbh_dev_close(fixture.device);
+        if (fixture.close_result == ESP_OK) {
+            fixture.device = nullptr;
+        }
+        fixture.close_task = nullptr;
+        vTaskDelete(nullptr);
+    }
+};
+
+ControlCompletionFixture *ControlCompletionFixture::active = nullptr;
+
+} // namespace
+
+TEST_CASE_METHOD(ControlCompletionFixture, "USBH retires EP0 before a completion can close the device", "[usbh][control]")
+{
+    uint8_t data[USB_SETUP_PACKET_SIZE + 1] = {};
+    auto *setup = reinterpret_cast<usb_setup_packet_t *>(data);
+    setup->bmRequestType = 0xa1;
+    setup->bRequest = 0xfe; // GET_MAX_LUN
+    setup->wIndex = 3;
+    setup->wLength = 1;
+    urb_t urb = {
+        .tailq_entry = {},
+        .hcd_ptr = nullptr,
+        .hcd_var = 0,
+        .usb_host_client = nullptr,
+        .usb_host_inflight = false,
+        .transfer = {
+            .data_buffer = data,
+            .data_buffer_size = sizeof(data),
+            .num_bytes = sizeof(data),
+            .actual_num_bytes = 0,
+            .flags = 0,
+            .device_handle = device,
+            .bEndpointAddress = 0,
+            .status = USB_TRANSFER_STATUS_COMPLETED,
+            .timeout_ms = 0,
+            .callback = [](usb_transfer_t *) {},
+            .context = nullptr,
+            .num_isoc_packets = 0,
+        },
+    };
+    hcd_pipe_event_t event = HCD_PIPE_EVENT_URB_DONE;
+    SECTION("Successful control transfer") {}
+    SECTION("Control STALL") {
+        event = HCD_PIPE_EVENT_ERROR_STALL;
+    }
+    SECTION("Control transfer error") {
+        event = HCD_PIPE_EVENT_ERROR_XFER;
+    }
+    SECTION("Completion resubmits the same URB before closing") {
+        resubmit = true;
+    }
+
+    REQUIRE(ESP_OK == usbh_dev_submit_ctrl_urb(device, &urb));
+    complete(event);
+    if (resubmit) {
+        REQUIRE(ESP_OK == resubmit_result);
+        REQUIRE(device != nullptr);
+        complete(HCD_PIPE_EVENT_URB_DONE);
+    }
+    CHECK(completions == (resubmit ? 2 : 1));
+    CHECK(close_result == ESP_OK);
+    CHECK(closed_before_event_return);
+}

--- a/host/usb/test/mocks/usbh_layer_mock/usb/mock/mock_config.yaml
+++ b/host/usb/test/mocks/usbh_layer_mock/usb/mock/mock_config.yaml
@@ -5,3 +5,4 @@
     - return_thru_ptr
     - ignore
     - ignore_arg
+    - callback


### PR DESCRIPTION
## Description

Closing the last device handle immediately after a control transfer completes can trigger an assertion in `usbh_dev_close()`.

Previously, `handle_ep0_dequeue()` notified clients before decrementing the device's control-transfer count at the end of the dequeue loop. The notification could wake a higher-priority task that closes the device while the completed transfer is still counted as in flight.

Retire each dequeued control transfer before notifying its client. Keep the critical section limited to the counter update, with HCD operations and callbacks outside it.

Add a regression test covering successful completion, STALL, transfer errors, and same-URB resubmission. Document the fix under Unreleased without changing the component version.

## Related

Related to #570, whose MSC cleanup paths exposed this existing USBH race. This PR submits the underlying USBH fix independently.

## Testing

Linux host tests passed against ESP-IDF 6.2-dev (`c712a0dd`):

- USBH suite: 4 test cases, 72 assertions.
- The regression reproduces the `num_ctrl_xfers_inflight == 0` assertion with the original implementation and passes with this fix.
- It uses real USBH and FreeRTOS, mocked HCD operations, and a test event callback that wakes a higher-priority task. It verifies that device close succeeds before the completion event callback returns.
- `git diff --check` passed.

Hardware validation has not been performed. GitHub Actions results are pending.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches USB host device teardown timing on the control path; the change is small and targeted but affects concurrency-sensitive close logic.
> 
> **Overview**
> Fixes a **race in EP0 control-transfer completion** where `handle_ep0_dequeue()` fired the client completion callback before decrementing `num_ctrl_xfers_inflight`. A higher-priority task could call `usbh_dev_close()` from that callback while the transfer was still counted in flight, tripping the `num_ctrl_xfers_inflight == 0` assertion.
> 
> The change **retires each dequeued control transfer per iteration** (critical-section decrement, then notify) instead of batching decrements after the dequeue loop. Changelog documents the fix under Unreleased.
> 
> Adds a **Catch2/FreeRTOS host regression test** that completes EP0 (success, STALL, error, and resubmit-from-callback paths) and closes the device from a higher-priority task immediately on completion. CMock gains the `callback` plugin for the new test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be34012f55bcbfc9face7ed1983283486d8cbb01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->