### PR TITLE
release(esp_tinyusb): v2.3.0

### DIFF
--- a/device/esp_tinyusb/CHANGELOG.md
+++ b/device/esp_tinyusb/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.3.0
 
 - esp_tinyusb: MSC: Use `esp_vfs_fat_register` instead of the deprecated `esp_vfs_fat_register_cfg` for ESP-IDF v6.0 and higher
 - esp_tinyusb: Added support for exposing already-mounted VFS/FATFS paths through Media Transfer Protocol

--- a/device/esp_tinyusb/idf_component.yml
+++ b/device/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-usb/en/latest/esp32p4/usb_device.html"
-version: "2.2.1"
+version: "2.3.0"
 url: https://github.com/espressif/esp-usb/tree/master/device/esp_tinyusb
 repository: "https://github.com/espressif/esp-usb.git"
 repository_info:


### PR DESCRIPTION
## esp_tinyusb release v2.3.0


## Related

- #510 
- #535 
- #540 
- #531 
- #562 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump with no runtime code changes in the diff.
> 
> **Overview**
> **Bumps the `esp_tinyusb` IDF component release from 2.2.1 to 2.3.0** by updating `idf_component.yml` and retitling the former **Unreleased** section in `CHANGELOG.md` to **2.3.0**.
> 
> No source or API changes appear in this diff; it only publishes the version tag and freezes the already-documented 2.3.0 notes (MSC/VFS FAT registration on IDF v6+, exposing mounted VFS paths over MTP, power-management locks, and USB HS light-sleep wake-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1884051367ef5b37b4dc39f174a9f3b7725a3288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->